### PR TITLE
Switch to explicit checking against None in constructor.

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -368,10 +368,10 @@ class rrule(rrulebase):
                 if pos == 0 or not (-366 <= pos <= 366):
                     raise ValueError("bysetpos must be between 1 and 366, "
                                      "or between -366 and -1")
-        if not (byweekno or byyearday or bymonthday or
-                byweekday is not None or byeaster is not None):
+        if (byweekno is None and byyearday is None and bymonthday is None and
+                byweekday is None and byeaster is None):
             if freq == YEARLY:
-                if not bymonth:
+                if bymonth is None:
                     bymonth = dtstart.month
                 bymonthday = dtstart.day
             elif freq == MONTHLY:


### PR DESCRIPTION
In [rrule.py:371](https://github.com/dateutil/dateutil/blob/master/dateutil/rrule.py#L371), it seems to me that the existence of the `byweekno`, `byyearday` and `bymonthday` parameters are being checked just by their boolean truth values, rather than checking them against `None` (the default value for each of them).

I'm not sure if there's some reason it is done this way, but it can cause a problem when the sequence you want to pass is a numpy array rather than one of the standard sequence types, because the truth value of numpy arrays is not well-defined, causing an error to be thrown.
