### PR TITLE
Loop fix

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -703,7 +703,7 @@ class rrule(rrulebase):
 
                 valid = False
                 rep_rate = (24*60)
-                for j in range(rep_rate / gcd(interval, rep_rate)):
+                for j in range(rep_rate // gcd(interval, rep_rate)):
                     if byminute:
                         nhours, minute = \
                             self.__mod_distance(value=minute,
@@ -735,7 +735,7 @@ class rrule(rrulebase):
 
                 rep_rate = (24*3600)
                 valid = False
-                for j in range(0, rep_rate / gcd(interval, rep_rate)):
+                for j in range(0, rep_rate // gcd(interval, rep_rate)):
                     if bysecond:
                         nminutes, second = \
                             self.__mod_distance(value=second,

--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -1009,50 +1009,50 @@ class _iterinfo(object):
         return list(range(self.yearlen)), 0, self.yearlen
 
     def mdayset(self, year, month, day):
-        set = [None]*self.yearlen
+        dset = [None]*self.yearlen
         start, end = self.mrange[month-1:month+1]
         for i in range(start, end):
-            set[i] = i
-        return set, start, end
+            dset[i] = i
+        return dset, start, end
 
     def wdayset(self, year, month, day):
         # We need to handle cross-year weeks here.
-        set = [None]*(self.yearlen+7)
+        dset = [None]*(self.yearlen+7)
         i = datetime.date(year, month, day).toordinal()-self.yearordinal
         start = i
         for j in range(7):
-            set[i] = i
+            dset[i] = i
             i += 1
             # if (not (0 <= i < self.yearlen) or
             #    self.wdaymask[i] == self.rrule._wkst):
             # This will cross the year boundary, if necessary.
             if self.wdaymask[i] == self.rrule._wkst:
                 break
-        return set, start, i
+        return dset, start, i
 
     def ddayset(self, year, month, day):
-        set = [None]*self.yearlen
+        dset = [None]*self.yearlen
         i = datetime.date(year, month, day).toordinal()-self.yearordinal
-        set[i] = i
-        return set, i, i+1
+        dset[i] = i
+        return dset, i, i+1
 
     def htimeset(self, hour, minute, second):
-        set = []
+        tset = []
         rr = self.rrule
         for minute in rr._byminute:
             for second in rr._bysecond:
-                set.append(datetime.time(hour, minute, second,
+                tset.append(datetime.time(hour, minute, second,
                                          tzinfo=rr._tzinfo))
-        set.sort()
-        return set
+        tset.sort()
+        return tset
 
     def mtimeset(self, hour, minute, second):
-        set = []
+        tset = []
         rr = self.rrule
         for second in rr._bysecond:
-            set.append(datetime.time(hour, minute, second, tzinfo=rr._tzinfo))
-        set.sort()
-        return set
+            tset.append(datetime.time(hour, minute, second, tzinfo=rr._tzinfo))
+        tset.sort()
+        return tset
 
     def stimeset(self, hour, minute, second):
         return (datetime.time(hour, minute, second,
@@ -1329,28 +1329,28 @@ class _rrulestr(object):
                     or exrulevals or exdatevals):
                 if not parser and (rdatevals or exdatevals):
                     from dateutil import parser
-                set = rruleset(cache=cache)
+                rset = rruleset(cache=cache)
                 for value in rrulevals:
-                    set.rrule(self._parse_rfc_rrule(value, dtstart=dtstart,
-                                                    ignoretz=ignoretz,
-                                                    tzinfos=tzinfos))
-                for value in rdatevals:
-                    for datestr in value.split(','):
-                        set.rdate(parser.parse(datestr,
-                                               ignoretz=ignoretz,
-                                               tzinfos=tzinfos))
-                for value in exrulevals:
-                    set.exrule(self._parse_rfc_rrule(value, dtstart=dtstart,
+                    rset.rrule(self._parse_rfc_rrule(value, dtstart=dtstart,
                                                      ignoretz=ignoretz,
                                                      tzinfos=tzinfos))
-                for value in exdatevals:
+                for value in rdatevals:
                     for datestr in value.split(','):
-                        set.exdate(parser.parse(datestr,
+                        rset.rdate(parser.parse(datestr,
                                                 ignoretz=ignoretz,
                                                 tzinfos=tzinfos))
+                for value in exrulevals:
+                    rset.exrule(self._parse_rfc_rrule(value, dtstart=dtstart,
+                                                      ignoretz=ignoretz,
+                                                      tzinfos=tzinfos))
+                for value in exdatevals:
+                    for datestr in value.split(','):
+                        rset.exdate(parser.parse(datestr,
+                                                 ignoretz=ignoretz,
+                                                 tzinfos=tzinfos))
                 if compatible and dtstart:
-                    set.rdate(dtstart)
-                return set
+                    rset.rdate(dtstart)
+                return rset
             else:
                 return self._parse_rfc_rrule(rrulevals[0],
                                              dtstart=dtstart,
@@ -1364,4 +1364,3 @@ class _rrulestr(object):
 rrulestr = _rrulestr()
 
 # vim:ts=4:sw=4:et
-    

--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -388,18 +388,20 @@ class rrule(rrulebase):
         # bymonth
         if bymonth is None:
             self._bymonth = None
-        elif isinstance(bymonth, integer_types):
-            self._bymonth = (bymonth,)
         else:
-            self._bymonth = tuple(bymonth)
+            if isinstance(bymonth, integer_types):
+                bymonth = (bymonth,)
+
+            self._bymonth = set(bymonth)
 
         # byyearday
         if byyearday is None:
             self._byyearday = None
-        elif isinstance(byyearday, integer_types):
-            self._byyearday = (byyearday,)
         else:
-            self._byyearday = tuple(byyearday)
+            if isinstance(byyearday, integer_types):
+                byyearday = (byyearday,)
+
+            self._byyearday = set(byyearday)
 
         # byeaster
         if byeaster is not None:
@@ -416,51 +418,42 @@ class rrule(rrulebase):
         if bymonthday is None:
             self._bymonthday = ()
             self._bynmonthday = ()
-        elif isinstance(bymonthday, integer_types):
-            if bymonthday < 0:
-                self._bynmonthday = (bymonthday,)
-                self._bymonthday = ()
-            else:
-                self._bymonthday = (bymonthday,)
-                self._bynmonthday = ()
         else:
-            self._bymonthday = tuple([x for x in bymonthday if x > 0])
-            self._bynmonthday = tuple([x for x in bymonthday if x < 0])
+            if isinstance(bymonthday, integer_types):
+                if bymonthday < 0:
+                    bymonthday = (bymonthday,)
+            self._bymonthday = set([x for x in bymonthday if x > 0])
+            self._bynmonthday = set([x for x in bymonthday if x < 0])
 
         # byweekno
         if byweekno is None:
             self._byweekno = None
-        elif isinstance(byweekno, integer_types):
-            self._byweekno = (byweekno,)
         else:
-            self._byweekno = tuple(byweekno)
+            if isinstance(byweekno, integer_types):
+                byweekno = (byweekno,)
+        
+            self._byweekno = set(byweekno)
 
         # byweekday / bynweekday
         if byweekday is None:
             self._byweekday = None
             self._bynweekday = None
-        elif isinstance(byweekday, integer_types):
-            self._byweekday = (byweekday,)
-            self._bynweekday = None
-        elif hasattr(byweekday, "n"):
-            if not byweekday.n or freq > MONTHLY:
-                self._byweekday = (byweekday.weekday,)
-                self._bynweekday = None
-            else:
-                self._bynweekday = ((byweekday.weekday, byweekday.n),)
-                self._byweekday = None
         else:
-            self._byweekday = []
-            self._bynweekday = []
+            if isinstance(byweekday, integer_types):
+                byweekday = (byweekday,)
+            elif hasattr(byweekday, "n"):
+                byweekday = (byweekday.weekday,)
+
+            self._byweekday = set()
+            self._bynweekday = set()
             for wday in byweekday:
                 if isinstance(wday, integer_types):
-                    self._byweekday.append(wday)
+                    self._byweekday.add(wday)
                 elif not wday.n or freq > MONTHLY:
-                    self._byweekday.append(wday.weekday)
+                    self._byweekday.add(wday.weekday)
                 else:
-                    self._bynweekday.append((wday.weekday, wday.n))
-            self._byweekday = tuple(self._byweekday)
-            self._bynweekday = tuple(self._bynweekday)
+                    self._bynweekday.add((wday.weekday, wday.n))
+
             if not self._byweekday:
                 self._byweekday = None
             elif not self._bynweekday:
@@ -474,31 +467,31 @@ class rrule(rrulebase):
                 self._byhour = None
         else:
             if isinstance(byhour, integer_types):
-                self._byhour = (byhour,)
-            else:
-                self._byhour = tuple(byhour)
+                byhour = (byhour,)
 
             if freq == HOURLY:
                 self._byhour = self.__construct_byset(start=dtstart.hour,
                                                       byxxx=self._byhour,
                                                       base=24)
+            else:
+                self.byhour = set(byhour)
 
         # byminute
         if byminute is None:
             if freq < MINUTELY:
-                self._byminute = (dtstart.minute,)
+                self._byminute = set(dtstart.minute,)
             else:
                 self._byminute = None
         else:
             if isinstance(byminute, integer_types):
-                self._byminute = (byminute,)
-            else:
-                self._byminute = tuple(byminute)
+                byminute = (byminute,)
 
             if freq == MINUTELY:
                 self._byminute = self.__construct_byset(start=dtstart.minute,
                                                         byxxx=self._byminute,
                                                         base=60)
+            else:
+                self._byminute = set(byminute)
 
         # bysecond
         if bysecond is None:
@@ -508,14 +501,16 @@ class rrule(rrulebase):
                 self._bysecond = None
         else:
             if isinstance(bysecond, integer_types):
-                self._bysecond = (bysecond,)
-            else:
-                self._bysecond = tuple(bysecond)
+                bysecond = (bysecond,)
+
+            self._bysecond = set(bysecond)
 
             if freq == SECONDLY:
                 self._bysecond = self.__construct_byset(start=dtstart.minute,
                                                         byxxx=self._byminute,
                                                         base=60)
+            else:
+                self._bysecond = set(bysecond)
 
         if self._freq >= HOURLY:
             self._timeset = None


### PR DESCRIPTION
Converted most of the `while True` loops to explicit `for` loops looping over a length after which the pattern repeats, then raise an error if the pattern hasn't broken by then. This should produce a desirable behavior that fixes #4 (though I think that there are certain endless-loop conditions which I'm currently only detecting in the iterator, not the constructor, because checking them in the constructor would involve a much more complicated logic because they involve interactions between the `byhour`, `byminute` and/or `bysecond` rules - either way I think they're likely exceedingly rare in practice).

I did a little refactoring in the looping logic, but not much since I think a lot of it won't end up being used in `rrule2` anyway. I'm a bit curious as to why we're explicitly handling the low-level operations of incrementing the day rather than incrementing a `datetime.datetime` object using `datetime.timedelta` objects - is this for the sake of performance or something? I can't imagine it would add much overhead, and it would be much easier to maintain.

I also converted the `by_` tuples to sets, because it doesn't seem that their order is ever used, but there are frequent calls to `in`, which will be considerably sped up by the use of sets. While I was doing that, I did some refactoring in the constructor which will make it easier to switch back if this change proves undesirable.