### PR TITLE
Add iso8601 formatter

### DIFF
--- a/dateutil/formatter.py
+++ b/dateutil/formatter.py
@@ -1,0 +1,10 @@
+def isoformat(dt, utc_zulu=True):
+    """
+    Formats the datetime using datetime.isoformat()
+
+    If `utc_zulu` is `True` and `dt` has UTC timezone then the suffix will be
+    `'Z'` instead of `'+00:00'`. Otherwise the output is unchanged.
+    """
+    if dt.tzinfo is not None and dt.tzinfo.tzname(dt) == 'UTC' and utc_zulu:
+        return dt.replace(tzinfo=None).isoformat() + 'Z'
+    return dt.isoformat()

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -20,6 +20,7 @@ MISSING_TARBALL = ("This test fails if you don't have the dateutil "
 from datetime import *
 
 from dateutil.relativedelta import *
+from dateutil.formatter import *
 from dateutil.parser import *
 from dateutil.easter import *
 from dateutil.rrule import *
@@ -3725,6 +3726,38 @@ class ParserTest(unittest.TestCase):
         myparser = parser(myparserinfo())
         dt = myparser.parse("01/Foo/2007")
         self.assertEqual(dt, datetime(2007, 1, 1))
+
+
+class FormatterTest(unittest.TestCase):
+    def setUp(self):
+        self.brsttz = tzoffset("BRST", -10800)
+        self.default = datetime(2003, 9, 25)
+
+    def testISOFormatZulu(self):
+        self.assertEqual(
+            isoformat(parse("2003-09-17T20:54:47.282310Z")),
+            "2003-09-17T20:54:47.282310Z"
+        )
+
+    def testISOFormatNoZulu(self):
+        self.assertEqual(
+            isoformat(parse("2003-09-17T20:54:47.282310Z"), utc_zulu=False),
+            "2003-09-17T20:54:47.282310+00:00"
+        )
+
+    def testISOFormatNoTimezone(self):
+        self.assertEqual(
+            isoformat(
+                parse("2003-09-17T20:54:47.282310Z").replace(tzinfo=None)
+            ),
+            "2003-09-17T20:54:47.282310"
+        )
+
+    def testISOFormatEETTimezone(self):
+        self.assertEqual(
+            isoformat(parse("2003-09-17T20:54:47.282310+02:00")),
+            "2003-09-17T20:54:47.282310+02:00"
+        )
 
 
 class EasterTest(unittest.TestCase):

--- a/dateutil/tz.py
+++ b/dateutil/tz.py
@@ -37,8 +37,12 @@ def tzname_in_python2(myfunc):
     def inner_func(*args, **kwargs):
         if PY3:
             return myfunc(*args, **kwargs)
-        else:
-            return myfunc(*args, **kwargs).encode()
+
+        ret = myfunc(*args, **kwargs)
+        if ret is not None:
+            return ret.encode()
+
+        return ret
     return inner_func
 
 ZERO = datetime.timedelta(0)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -206,6 +206,51 @@ We can use the non-leap year day to ignore this:
     >>> date(2000, 1, 1)+relativedelta(nlyearday=260)
     datetime.date(2000, 9, 17)
 
+formatter examples
+------------------
+
+.. testsetup:: formatter
+
+    from dateutil.formatter import *
+    from dateutil.tzinfo import *
+    from datetime import *
+    import pprint
+    import sys
+    sys.displayhook = pprint.pprint
+
+UTC formatting (zulu).
+
+.. doctest:: formatter
+
+    >>> now = datetime(2003, 9, 17, 20, 54, 47, 282310, tzutc())
+    >>> isoformat(now)
+    '2003-09-17T20:54:47.282310Z'
+
+UTC formatting (no zulu).
+
+.. doctest:: formatter
+
+    >>> now = datetime(2003, 9, 17, 20, 54, 47, 282310, tzutc())
+    >>> isoformat(now, utc_zulu=False)
+    '2003-09-17T20:54:47.282310+00:00'
+
+No timezone.
+
+.. doctest:: formatter
+
+    >>> now = datetime(2003, 9, 17, 20, 54, 47, 282310)
+    >>> isoformat(now)
+    '2003-09-17T20:54:47.282310'
+
+Non-UTC timezone.
+
+.. doctest:: formatter
+
+    >>> now = datetime(2003, 9, 17, 20, 54, 47, 282310, tzoffset("EET", 60*60*2))
+    >>> isoformat(now)
+    '2003-09-17T20:54:47.282310+02:00'
+
+
 rrule examples
 --------------
 These examples were converted from the RFC.

--- a/docs/formatter.rst
+++ b/docs/formatter.rst
@@ -1,0 +1,6 @@
+=========
+formatter
+=========
+.. automodule:: dateutil.formatter
+   :members:
+   :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ Contents:
    rrule
    tz
    zoneinfo
+   formatter
    examples
 
 Indices and tables


### PR DESCRIPTION
Added an `isoformat` function to allow formatting dates with a zulu extension rather than `+00:00` for UTC datetimes.
