### PR TITLE
Add explicit error checking along with AM/PM flag.

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -585,7 +585,7 @@ class parser(object):
                         raise ValueError('No hour specified with AM or PM flag.')
 
                     # If AM/PM is found, it's a 12 hour clock, so raise an error for invalid range
-                    if not 1 <= res.hour <= 12:
+                    if not 0 <= res.hour <= 12:
                         raise ValueError('Invalid hour specified for 12-hour clock.')
 
                     if value == 1 and res.hour < 12:

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -580,6 +580,14 @@ class parser(object):
                 # Check am/pm
                 value = info.ampm(l[i])
                 if value is not None:
+                    # If AM/PM is found and hour is not, raise a ValueError
+                    if res.hour is None:
+                        raise ValueError('No hour specified with AM or PM flag.')
+
+                    # If AM/PM is found, it's a 12 hour clock, so raise an error for invalid range
+                    if not 1 <= res.hour <= 12:
+                        raise ValueError('Invalid hour specified for 12-hour clock.')
+
                     if value == 1 and res.hour < 12:
                         res.hour += 12
                     elif value == 0 and res.hour == 12:


### PR DESCRIPTION
Adds explicit error checking when AM or PM are specified. `dateutil.parser.parse()` will now raise a `ValueError` exception if either AM or PM is specified without specifying an hour, or when the hour specified is outside the range `1 <= hour <= 12`, since AM/PM indicates a 12-hour clock. This resolves issue #21.