### PR TITLE
Markdown -> RST.

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -4,11 +4,15 @@ This module offers a generic date/time string parser which is able to parse
 most known formats to represent a date and/or time.
 
 Additional resources about date/time string formats can be found below:
-- [A summary of the international standard date and time notation](http://www.cl.cam.ac.uk/~mgk25/iso-time.html)
-- [W3C Date and Time Formats](http://www.w3.org/TR/NOTE-datetime)
-- [Time Formats (Planetary Rings Node)](http://pds-rings.seti.org/tools/time_formats.html)
-- [CPAN ParseDate module](http://search.cpan.org/~muir/Time-modules-2013.0912/lib/Time/ParseDate.pm)
-- [Java SimpleDateFormat Class](https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html)
+
+- `A summary of the international standard date and time notation
+  <http://www.cl.cam.ac.uk/~mgk25/iso-time.html>`_
+- `W3C Date and Time Formats <http://www.w3.org/TR/NOTE-datetime>`_
+- `Time Formats (Planetary Rings Node) <http://pds-rings.seti.org/tools/time_formats.html>`_
+- `CPAN ParseDate module
+  <http://search.cpan.org/~muir/Time-modules-2013.0912/lib/Time/ParseDate.pm>`_
+- `Java SimpleDateFormat Class
+  <https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html>`_
 """
 from __future__ import unicode_literals
 


### PR DESCRIPTION
Looking at how this was parsed from ReadTheDocs, I guess it's using restructuredText not markdown, my mistake. This fixes the part that was actually parsed. The documentation that didn't make it into readthedocs can be a later update.