### PR TITLE
Doc and test tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Features
   date and/or datetime objects;
 * Computing of dates based on very flexible recurrence rules,
   using a superset of the
-  [ftp://ftp.rfc-editor.org/in-notes/rfc2445.txt iCalendar]
+  `iCalendar <ftp://ftp.rfc-editor.org/in-notes/rfc2445.txt>`
   specification. Parsing of RFC strings is supported as well.
 * Generic parsing of dates in almost any string format;
 * Timezone (tzinfo) implementations for tzfile(5) format

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -198,7 +198,7 @@ class RRuleTest(unittest.TestCase):
     def testYearly(self):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1998, 9, 2, 9, 0),
                           datetime(1999, 9, 2, 9, 0)])
@@ -207,7 +207,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               interval=2,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1999, 9, 2, 9, 0),
                           datetime(2001, 9, 2, 9, 0)])
@@ -216,7 +216,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               interval=100,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(2097, 9, 2, 9, 0),
                           datetime(2197, 9, 2, 9, 0)])
@@ -225,7 +225,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               bymonth=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 2, 9, 0),
                           datetime(1998, 3, 2, 9, 0),
                           datetime(1999, 1, 2, 9, 0)])
@@ -234,7 +234,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               bymonthday=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 10, 1, 9, 0),
                           datetime(1997, 10, 3, 9, 0)])
@@ -244,7 +244,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               bymonthday=(5, 7),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 5, 9, 0),
                           datetime(1998, 1, 7, 9, 0),
                           datetime(1998, 3, 5, 9, 0)])
@@ -253,7 +253,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 9, 9, 0)])
@@ -262,7 +262,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 25, 9, 0),
                           datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 12, 31, 9, 0)])
@@ -271,7 +271,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byweekday=(TU(3), TH(-3)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 11, 9, 0),
                           datetime(1998, 1, 20, 9, 0),
                           datetime(1998, 12, 17, 9, 0)])
@@ -281,7 +281,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 8, 9, 0)])
@@ -291,7 +291,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 29, 9, 0),
                           datetime(1998, 3, 3, 9, 0)])
@@ -303,7 +303,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(3), TH(-3)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 15, 9, 0),
                           datetime(1998, 1, 20, 9, 0),
                           datetime(1998, 3, 12, 9, 0)])
@@ -313,7 +313,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 2, 3, 9, 0),
                           datetime(1998, 3, 3, 9, 0)])
@@ -324,7 +324,7 @@ class RRuleTest(unittest.TestCase):
                               bymonth=(1, 3),
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 3, 3, 9, 0),
                           datetime(2001, 3, 1, 9, 0)])
@@ -333,7 +333,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=4,
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -343,7 +343,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=4,
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -354,7 +354,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 4, 10, 9, 0),
@@ -365,7 +365,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 4, 10, 9, 0),
@@ -375,7 +375,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byweekno=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 5, 11, 9, 0),
                           datetime(1998, 5, 12, 9, 0),
                           datetime(1998, 5, 13, 9, 0)])
@@ -387,7 +387,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=1,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 29, 9, 0),
                           datetime(1999, 1, 4, 9, 0),
                           datetime(2000, 1, 3, 9, 0)])
@@ -399,7 +399,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=52,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1998, 12, 27, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -409,7 +409,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=-1,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1999, 1, 3, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -418,7 +418,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byeaster=0,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 12, 9, 0),
                           datetime(1999, 4, 4, 9, 0),
                           datetime(2000, 4, 23, 9, 0)])
@@ -427,7 +427,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byeaster=1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 13, 9, 0),
                           datetime(1999, 4, 5, 9, 0),
                           datetime(2000, 4, 24, 9, 0)])
@@ -436,7 +436,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byeaster=-1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 11, 9, 0),
                           datetime(1999, 4, 3, 9, 0),
                           datetime(2000, 4, 22, 9, 0)])
@@ -446,7 +446,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=53,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 12, 28, 9, 0),
                           datetime(2004, 12, 27, 9, 0),
                           datetime(2009, 12, 28, 9, 0)])
@@ -455,7 +455,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byhour=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0),
                           datetime(1998, 9, 2, 6, 0),
                           datetime(1998, 9, 2, 18, 0)])
@@ -464,7 +464,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6),
                           datetime(1997, 9, 2, 9, 18),
                           datetime(1998, 9, 2, 9, 6)])
@@ -473,7 +473,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 6),
                           datetime(1997, 9, 2, 9, 0, 18),
                           datetime(1998, 9, 2, 9, 0, 6)])
@@ -483,7 +483,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6),
                           datetime(1997, 9, 2, 18, 18),
                           datetime(1998, 9, 2, 6, 6)])
@@ -493,7 +493,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 6),
                           datetime(1997, 9, 2, 18, 0, 18),
                           datetime(1998, 9, 2, 6, 0, 6)])
@@ -503,7 +503,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 6),
                           datetime(1997, 9, 2, 9, 6, 18),
                           datetime(1997, 9, 2, 9, 18, 6)])
@@ -514,7 +514,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 6),
                           datetime(1997, 9, 2, 18, 6, 18),
                           datetime(1997, 9, 2, 18, 18, 6)])
@@ -525,7 +525,7 @@ class RRuleTest(unittest.TestCase):
                               bymonthday=15,
                               byhour=(6, 18),
                               bysetpos=(3, -3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 11, 15, 18, 0),
                           datetime(1998, 2, 15, 6, 0),
                           datetime(1998, 11, 15, 18, 0)])
@@ -533,7 +533,7 @@ class RRuleTest(unittest.TestCase):
     def testMonthly(self):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 10, 2, 9, 0),
                           datetime(1997, 11, 2, 9, 0)])
@@ -542,7 +542,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               interval=2,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 11, 2, 9, 0),
                           datetime(1998, 1, 2, 9, 0)])
@@ -551,7 +551,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               interval=18,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1999, 3, 2, 9, 0),
                           datetime(2000, 9, 2, 9, 0)])
@@ -560,7 +560,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               bymonth=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 2, 9, 0),
                           datetime(1998, 3, 2, 9, 0),
                           datetime(1999, 1, 2, 9, 0)])
@@ -569,7 +569,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               bymonthday=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 10, 1, 9, 0),
                           datetime(1997, 10, 3, 9, 0)])
@@ -579,7 +579,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               bymonthday=(5, 7),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 5, 9, 0),
                           datetime(1998, 1, 7, 9, 0),
                           datetime(1998, 3, 5, 9, 0)])
@@ -588,19 +588,10 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 9, 9, 0)])
-
-    def testMonthlyByNWeekDay(self):
-        self.assertEqual(list(rrule(MONTHLY,
-                              count=3,
-                              byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
-                         [datetime(1997, 9, 2, 9, 0),
-                          datetime(1997, 9, 25, 9, 0),
-                          datetime(1997, 10, 7, 9, 0)])
 
         # Third Monday of the month
         self.assertEqual(rrule(MONTHLY,
@@ -611,12 +602,20 @@ class RRuleTest(unittest.TestCase):
                           datetime(1997, 10, 20, 0, 0),
                           datetime(1997, 11, 17, 0, 0)])
 
+    def testMonthlyByNWeekDay(self):
+        self.assertEqual(list(rrule(MONTHLY,
+                              count=3,
+                              byweekday=(TU(1), TH(-1)),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
+                         [datetime(1997, 9, 2, 9, 0),
+                          datetime(1997, 9, 25, 9, 0),
+                          datetime(1997, 10, 7, 9, 0)])
 
     def testMonthlyByNWeekDayLarge(self):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byweekday=(TU(3), TH(-3)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 11, 9, 0),
                           datetime(1997, 9, 16, 9, 0),
                           datetime(1997, 10, 16, 9, 0)])
@@ -626,7 +625,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 8, 9, 0)])
@@ -636,7 +635,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 29, 9, 0),
                           datetime(1998, 3, 3, 9, 0)])
@@ -646,7 +645,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(3), TH(-3)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 15, 9, 0),
                           datetime(1998, 1, 20, 9, 0),
                           datetime(1998, 3, 12, 9, 0)])
@@ -656,7 +655,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 2, 3, 9, 0),
                           datetime(1998, 3, 3, 9, 0)])
@@ -667,7 +666,7 @@ class RRuleTest(unittest.TestCase):
                               bymonth=(1, 3),
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 3, 3, 9, 0),
                           datetime(2001, 3, 1, 9, 0)])
@@ -676,7 +675,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=4,
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -686,7 +685,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=4,
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -697,7 +696,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 4, 10, 9, 0),
@@ -708,7 +707,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 4, 10, 9, 0),
@@ -718,7 +717,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byweekno=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 5, 11, 9, 0),
                           datetime(1998, 5, 12, 9, 0),
                           datetime(1998, 5, 13, 9, 0)])
@@ -730,7 +729,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=1,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 29, 9, 0),
                           datetime(1999, 1, 4, 9, 0),
                           datetime(2000, 1, 3, 9, 0)])
@@ -742,7 +741,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=52,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1998, 12, 27, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -752,7 +751,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=-1,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1999, 1, 3, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -762,7 +761,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=53,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 12, 28, 9, 0),
                           datetime(2004, 12, 27, 9, 0),
                           datetime(2009, 12, 28, 9, 0)])
@@ -771,7 +770,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byeaster=0,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 12, 9, 0),
                           datetime(1999, 4, 4, 9, 0),
                           datetime(2000, 4, 23, 9, 0)])
@@ -780,7 +779,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byeaster=1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 13, 9, 0),
                           datetime(1999, 4, 5, 9, 0),
                           datetime(2000, 4, 24, 9, 0)])
@@ -789,7 +788,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byeaster=-1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 11, 9, 0),
                           datetime(1999, 4, 3, 9, 0),
                           datetime(2000, 4, 22, 9, 0)])
@@ -798,7 +797,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byhour=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0),
                           datetime(1997, 10, 2, 6, 0),
                           datetime(1997, 10, 2, 18, 0)])
@@ -807,7 +806,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6),
                           datetime(1997, 9, 2, 9, 18),
                           datetime(1997, 10, 2, 9, 6)])
@@ -816,7 +815,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MONTHLY,
                               count=3,
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 6),
                           datetime(1997, 9, 2, 9, 0, 18),
                           datetime(1997, 10, 2, 9, 0, 6)])
@@ -826,7 +825,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6),
                           datetime(1997, 9, 2, 18, 18),
                           datetime(1997, 10, 2, 6, 6)])
@@ -836,7 +835,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 6),
                           datetime(1997, 9, 2, 18, 0, 18),
                           datetime(1997, 10, 2, 6, 0, 6)])
@@ -846,7 +845,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 6),
                           datetime(1997, 9, 2, 9, 6, 18),
                           datetime(1997, 9, 2, 9, 18, 6)])
@@ -857,7 +856,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 6),
                           datetime(1997, 9, 2, 18, 6, 18),
                           datetime(1997, 9, 2, 18, 18, 6)])
@@ -868,7 +867,7 @@ class RRuleTest(unittest.TestCase):
                               bymonthday=(13, 17),
                               byhour=(6, 18),
                               bysetpos=(3, -3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 13, 18, 0),
                           datetime(1997, 9, 17, 6, 0),
                           datetime(1997, 10, 13, 18, 0)])
@@ -876,7 +875,7 @@ class RRuleTest(unittest.TestCase):
     def testWeekly(self):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 9, 9, 0),
                           datetime(1997, 9, 16, 9, 0)])
@@ -885,7 +884,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               interval=2,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 16, 9, 0),
                           datetime(1997, 9, 30, 9, 0)])
@@ -894,7 +893,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               interval=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1998, 1, 20, 9, 0),
                           datetime(1998, 6, 9, 9, 0)])
@@ -903,7 +902,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               bymonth=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 13, 9, 0),
                           datetime(1998, 1, 20, 9, 0)])
@@ -912,7 +911,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               bymonthday=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 10, 1, 9, 0),
                           datetime(1997, 10, 3, 9, 0)])
@@ -922,7 +921,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               bymonthday=(5, 7),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 5, 9, 0),
                           datetime(1998, 1, 7, 9, 0),
                           datetime(1998, 3, 5, 9, 0)])
@@ -931,7 +930,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 9, 9, 0)])
@@ -940,7 +939,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 9, 9, 0)])
@@ -953,7 +952,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 8, 9, 0)])
@@ -963,7 +962,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 8, 9, 0)])
@@ -973,7 +972,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 2, 3, 9, 0),
                           datetime(1998, 3, 3, 9, 0)])
@@ -984,7 +983,7 @@ class RRuleTest(unittest.TestCase):
                               bymonth=(1, 3),
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 3, 3, 9, 0),
                           datetime(2001, 3, 1, 9, 0)])
@@ -993,7 +992,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=4,
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -1003,7 +1002,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=4,
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -1014,7 +1013,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(1, 7),
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 1, 1, 9, 0),
@@ -1025,7 +1024,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(1, 7),
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 1, 1, 9, 0),
@@ -1035,7 +1034,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byweekno=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 5, 11, 9, 0),
                           datetime(1998, 5, 12, 9, 0),
                           datetime(1998, 5, 13, 9, 0)])
@@ -1047,7 +1046,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=1,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 29, 9, 0),
                           datetime(1999, 1, 4, 9, 0),
                           datetime(2000, 1, 3, 9, 0)])
@@ -1059,7 +1058,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=52,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1998, 12, 27, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -1069,7 +1068,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=-1,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1999, 1, 3, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -1079,7 +1078,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=53,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 12, 28, 9, 0),
                           datetime(2004, 12, 27, 9, 0),
                           datetime(2009, 12, 28, 9, 0)])
@@ -1088,7 +1087,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byeaster=0,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 12, 9, 0),
                           datetime(1999, 4, 4, 9, 0),
                           datetime(2000, 4, 23, 9, 0)])
@@ -1097,7 +1096,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byeaster=1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 13, 9, 0),
                           datetime(1999, 4, 5, 9, 0),
                           datetime(2000, 4, 24, 9, 0)])
@@ -1106,7 +1105,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byeaster=-1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 11, 9, 0),
                           datetime(1999, 4, 3, 9, 0),
                           datetime(2000, 4, 22, 9, 0)])
@@ -1115,7 +1114,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byhour=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0),
                           datetime(1997, 9, 9, 6, 0),
                           datetime(1997, 9, 9, 18, 0)])
@@ -1124,7 +1123,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6),
                           datetime(1997, 9, 2, 9, 18),
                           datetime(1997, 9, 9, 9, 6)])
@@ -1133,7 +1132,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(WEEKLY,
                               count=3,
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 6),
                           datetime(1997, 9, 2, 9, 0, 18),
                           datetime(1997, 9, 9, 9, 0, 6)])
@@ -1143,7 +1142,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6),
                           datetime(1997, 9, 2, 18, 18),
                           datetime(1997, 9, 9, 6, 6)])
@@ -1153,7 +1152,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 6),
                           datetime(1997, 9, 2, 18, 0, 18),
                           datetime(1997, 9, 9, 6, 0, 6)])
@@ -1163,7 +1162,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 6),
                           datetime(1997, 9, 2, 9, 6, 18),
                           datetime(1997, 9, 2, 9, 18, 6)])
@@ -1174,7 +1173,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 6),
                           datetime(1997, 9, 2, 18, 6, 18),
                           datetime(1997, 9, 2, 18, 18, 6)])
@@ -1185,7 +1184,7 @@ class RRuleTest(unittest.TestCase):
                               byweekday=(TU, TH),
                               byhour=(6, 18),
                               bysetpos=(3, -3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0),
                           datetime(1997, 9, 4, 6, 0),
                           datetime(1997, 9, 9, 18, 0)])
@@ -1193,7 +1192,7 @@ class RRuleTest(unittest.TestCase):
     def testDaily(self):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 9, 4, 9, 0)])
@@ -1202,7 +1201,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               interval=2,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 6, 9, 0)])
@@ -1211,7 +1210,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               interval=92,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 12, 3, 9, 0),
                           datetime(1998, 3, 5, 9, 0)])
@@ -1220,7 +1219,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               bymonth=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 1, 2, 9, 0),
                           datetime(1998, 1, 3, 9, 0)])
@@ -1229,7 +1228,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               bymonthday=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 10, 1, 9, 0),
                           datetime(1997, 10, 3, 9, 0)])
@@ -1239,7 +1238,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               bymonthday=(5, 7),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 5, 9, 0),
                           datetime(1998, 1, 7, 9, 0),
                           datetime(1998, 3, 5, 9, 0)])
@@ -1248,7 +1247,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 9, 9, 0)])
@@ -1257,7 +1256,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 9, 9, 0)])
@@ -1267,7 +1266,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 8, 9, 0)])
@@ -1277,7 +1276,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 1, 6, 9, 0),
                           datetime(1998, 1, 8, 9, 0)])
@@ -1287,7 +1286,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 2, 3, 9, 0),
                           datetime(1998, 3, 3, 9, 0)])
@@ -1298,7 +1297,7 @@ class RRuleTest(unittest.TestCase):
                               bymonth=(1, 3),
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 3, 3, 9, 0),
                           datetime(2001, 3, 1, 9, 0)])
@@ -1307,7 +1306,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=4,
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -1317,7 +1316,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=4,
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 9, 0),
                           datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 4, 10, 9, 0),
@@ -1328,7 +1327,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(1, 7),
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 1, 1, 9, 0),
@@ -1339,7 +1338,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(1, 7),
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 7, 19, 9, 0),
                           datetime(1999, 1, 1, 9, 0),
@@ -1349,7 +1348,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byweekno=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 5, 11, 9, 0),
                           datetime(1998, 5, 12, 9, 0),
                           datetime(1998, 5, 13, 9, 0)])
@@ -1361,7 +1360,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=1,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 29, 9, 0),
                           datetime(1999, 1, 4, 9, 0),
                           datetime(2000, 1, 3, 9, 0)])
@@ -1373,7 +1372,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=52,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1998, 12, 27, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -1383,7 +1382,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=-1,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 9, 0),
                           datetime(1999, 1, 3, 9, 0),
                           datetime(2000, 1, 2, 9, 0)])
@@ -1393,7 +1392,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=53,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 12, 28, 9, 0),
                           datetime(2004, 12, 27, 9, 0),
                           datetime(2009, 12, 28, 9, 0)])
@@ -1402,7 +1401,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byeaster=0,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 12, 9, 0),
                           datetime(1999, 4, 4, 9, 0),
                           datetime(2000, 4, 23, 9, 0)])
@@ -1411,7 +1410,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byeaster=1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 13, 9, 0),
                           datetime(1999, 4, 5, 9, 0),
                           datetime(2000, 4, 24, 9, 0)])
@@ -1420,7 +1419,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byeaster=-1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 11, 9, 0),
                           datetime(1999, 4, 3, 9, 0),
                           datetime(2000, 4, 22, 9, 0)])
@@ -1429,7 +1428,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byhour=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0),
                           datetime(1997, 9, 3, 6, 0),
                           datetime(1997, 9, 3, 18, 0)])
@@ -1438,7 +1437,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6),
                           datetime(1997, 9, 2, 9, 18),
                           datetime(1997, 9, 3, 9, 6)])
@@ -1447,7 +1446,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 6),
                           datetime(1997, 9, 2, 9, 0, 18),
                           datetime(1997, 9, 3, 9, 0, 6)])
@@ -1457,7 +1456,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6),
                           datetime(1997, 9, 2, 18, 18),
                           datetime(1997, 9, 3, 6, 6)])
@@ -1467,7 +1466,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 6),
                           datetime(1997, 9, 2, 18, 0, 18),
                           datetime(1997, 9, 3, 6, 0, 6)])
@@ -1477,7 +1476,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 6),
                           datetime(1997, 9, 2, 9, 6, 18),
                           datetime(1997, 9, 2, 9, 18, 6)])
@@ -1488,7 +1487,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 6),
                           datetime(1997, 9, 2, 18, 6, 18),
                           datetime(1997, 9, 2, 18, 18, 6)])
@@ -1499,7 +1498,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(15, 45),
                               bysetpos=(3, -3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 15),
                           datetime(1997, 9, 3, 6, 45),
                           datetime(1997, 9, 3, 18, 15)])
@@ -1507,7 +1506,7 @@ class RRuleTest(unittest.TestCase):
     def testHourly(self):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 10, 0),
                           datetime(1997, 9, 2, 11, 0)])
@@ -1516,7 +1515,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               interval=2,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 11, 0),
                           datetime(1997, 9, 2, 13, 0)])
@@ -1525,7 +1524,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               interval=769,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 10, 4, 10, 0),
                           datetime(1997, 11, 5, 11, 0)])
@@ -1534,7 +1533,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               bymonth=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 1, 0),
                           datetime(1998, 1, 1, 2, 0)])
@@ -1543,7 +1542,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               bymonthday=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 0, 0),
                           datetime(1997, 9, 3, 1, 0),
                           datetime(1997, 9, 3, 2, 0)])
@@ -1553,7 +1552,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               bymonthday=(5, 7),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 5, 0, 0),
                           datetime(1998, 1, 5, 1, 0),
                           datetime(1998, 1, 5, 2, 0)])
@@ -1562,7 +1561,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 10, 0),
                           datetime(1997, 9, 2, 11, 0)])
@@ -1571,7 +1570,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 10, 0),
                           datetime(1997, 9, 2, 11, 0)])
@@ -1581,7 +1580,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 1, 0),
                           datetime(1998, 1, 1, 2, 0)])
@@ -1591,7 +1590,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 1, 0),
                           datetime(1998, 1, 1, 2, 0)])
@@ -1601,7 +1600,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 1, 0),
                           datetime(1998, 1, 1, 2, 0)])
@@ -1612,7 +1611,7 @@ class RRuleTest(unittest.TestCase):
                               bymonth=(1, 3),
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 1, 0),
                           datetime(1998, 1, 1, 2, 0)])
@@ -1621,7 +1620,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=4,
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 0, 0),
                           datetime(1997, 12, 31, 1, 0),
                           datetime(1997, 12, 31, 2, 0),
@@ -1631,7 +1630,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=4,
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 0, 0),
                           datetime(1997, 12, 31, 1, 0),
                           datetime(1997, 12, 31, 2, 0),
@@ -1642,7 +1641,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 0, 0),
                           datetime(1998, 4, 10, 1, 0),
                           datetime(1998, 4, 10, 2, 0),
@@ -1653,7 +1652,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 0, 0),
                           datetime(1998, 4, 10, 1, 0),
                           datetime(1998, 4, 10, 2, 0),
@@ -1663,7 +1662,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byweekno=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 5, 11, 0, 0),
                           datetime(1998, 5, 11, 1, 0),
                           datetime(1998, 5, 11, 2, 0)])
@@ -1673,7 +1672,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=1,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 29, 0, 0),
                           datetime(1997, 12, 29, 1, 0),
                           datetime(1997, 12, 29, 2, 0)])
@@ -1683,7 +1682,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=52,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 0, 0),
                           datetime(1997, 12, 28, 1, 0),
                           datetime(1997, 12, 28, 2, 0)])
@@ -1693,7 +1692,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=-1,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 0, 0),
                           datetime(1997, 12, 28, 1, 0),
                           datetime(1997, 12, 28, 2, 0)])
@@ -1703,7 +1702,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=53,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 12, 28, 0, 0),
                           datetime(1998, 12, 28, 1, 0),
                           datetime(1998, 12, 28, 2, 0)])
@@ -1712,7 +1711,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byeaster=0,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 12, 0, 0),
                           datetime(1998, 4, 12, 1, 0),
                           datetime(1998, 4, 12, 2, 0)])
@@ -1721,7 +1720,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byeaster=1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 13, 0, 0),
                           datetime(1998, 4, 13, 1, 0),
                           datetime(1998, 4, 13, 2, 0)])
@@ -1730,7 +1729,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byeaster=-1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 11, 0, 0),
                           datetime(1998, 4, 11, 1, 0),
                           datetime(1998, 4, 11, 2, 0)])
@@ -1739,7 +1738,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byhour=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0),
                           datetime(1997, 9, 3, 6, 0),
                           datetime(1997, 9, 3, 18, 0)])
@@ -1748,7 +1747,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6),
                           datetime(1997, 9, 2, 9, 18),
                           datetime(1997, 9, 2, 10, 6)])
@@ -1757,7 +1756,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(HOURLY,
                               count=3,
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 6),
                           datetime(1997, 9, 2, 9, 0, 18),
                           datetime(1997, 9, 2, 10, 0, 6)])
@@ -1767,7 +1766,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6),
                           datetime(1997, 9, 2, 18, 18),
                           datetime(1997, 9, 3, 6, 6)])
@@ -1777,7 +1776,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 6),
                           datetime(1997, 9, 2, 18, 0, 18),
                           datetime(1997, 9, 3, 6, 0, 6)])
@@ -1787,7 +1786,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 6),
                           datetime(1997, 9, 2, 9, 6, 18),
                           datetime(1997, 9, 2, 9, 18, 6)])
@@ -1798,7 +1797,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 6),
                           datetime(1997, 9, 2, 18, 6, 18),
                           datetime(1997, 9, 2, 18, 18, 6)])
@@ -1809,7 +1808,7 @@ class RRuleTest(unittest.TestCase):
                               byminute=(15, 45),
                               bysecond=(15, 45),
                               bysetpos=(3, -3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 15, 45),
                           datetime(1997, 9, 2, 9, 45, 15),
                           datetime(1997, 9, 2, 10, 15, 45)])
@@ -1817,7 +1816,7 @@ class RRuleTest(unittest.TestCase):
     def testMinutely(self):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 9, 1),
                           datetime(1997, 9, 2, 9, 2)])
@@ -1826,7 +1825,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               interval=2,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 9, 2),
                           datetime(1997, 9, 2, 9, 4)])
@@ -1835,7 +1834,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               interval=1501,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 10, 1),
                           datetime(1997, 9, 4, 11, 2)])
@@ -1844,7 +1843,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               bymonth=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 0, 1),
                           datetime(1998, 1, 1, 0, 2)])
@@ -1853,7 +1852,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               bymonthday=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 0, 0),
                           datetime(1997, 9, 3, 0, 1),
                           datetime(1997, 9, 3, 0, 2)])
@@ -1863,7 +1862,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               bymonthday=(5, 7),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 5, 0, 0),
                           datetime(1998, 1, 5, 0, 1),
                           datetime(1998, 1, 5, 0, 2)])
@@ -1872,7 +1871,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 9, 1),
                           datetime(1997, 9, 2, 9, 2)])
@@ -1881,7 +1880,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 2, 9, 1),
                           datetime(1997, 9, 2, 9, 2)])
@@ -1891,7 +1890,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 0, 1),
                           datetime(1998, 1, 1, 0, 2)])
@@ -1901,7 +1900,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 0, 1),
                           datetime(1998, 1, 1, 0, 2)])
@@ -1911,7 +1910,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 0, 1),
                           datetime(1998, 1, 1, 0, 2)])
@@ -1922,7 +1921,7 @@ class RRuleTest(unittest.TestCase):
                               bymonth=(1, 3),
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0),
                           datetime(1998, 1, 1, 0, 1),
                           datetime(1998, 1, 1, 0, 2)])
@@ -1931,7 +1930,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=4,
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 0, 0),
                           datetime(1997, 12, 31, 0, 1),
                           datetime(1997, 12, 31, 0, 2),
@@ -1941,7 +1940,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=4,
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 0, 0),
                           datetime(1997, 12, 31, 0, 1),
                           datetime(1997, 12, 31, 0, 2),
@@ -1952,7 +1951,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 0, 0),
                           datetime(1998, 4, 10, 0, 1),
                           datetime(1998, 4, 10, 0, 2),
@@ -1963,7 +1962,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 0, 0),
                           datetime(1998, 4, 10, 0, 1),
                           datetime(1998, 4, 10, 0, 2),
@@ -1973,7 +1972,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byweekno=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 5, 11, 0, 0),
                           datetime(1998, 5, 11, 0, 1),
                           datetime(1998, 5, 11, 0, 2)])
@@ -1983,7 +1982,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=1,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 29, 0, 0),
                           datetime(1997, 12, 29, 0, 1),
                           datetime(1997, 12, 29, 0, 2)])
@@ -1993,7 +1992,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=52,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 0, 0),
                           datetime(1997, 12, 28, 0, 1),
                           datetime(1997, 12, 28, 0, 2)])
@@ -2003,7 +2002,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=-1,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 0, 0),
                           datetime(1997, 12, 28, 0, 1),
                           datetime(1997, 12, 28, 0, 2)])
@@ -2013,7 +2012,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=53,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 12, 28, 0, 0),
                           datetime(1998, 12, 28, 0, 1),
                           datetime(1998, 12, 28, 0, 2)])
@@ -2022,7 +2021,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byeaster=0,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 12, 0, 0),
                           datetime(1998, 4, 12, 0, 1),
                           datetime(1998, 4, 12, 0, 2)])
@@ -2031,7 +2030,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byeaster=1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 13, 0, 0),
                           datetime(1998, 4, 13, 0, 1),
                           datetime(1998, 4, 13, 0, 2)])
@@ -2040,7 +2039,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byeaster=-1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 11, 0, 0),
                           datetime(1998, 4, 11, 0, 1),
                           datetime(1998, 4, 11, 0, 2)])
@@ -2049,7 +2048,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byhour=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0),
                           datetime(1997, 9, 2, 18, 1),
                           datetime(1997, 9, 2, 18, 2)])
@@ -2058,7 +2057,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6),
                           datetime(1997, 9, 2, 9, 18),
                           datetime(1997, 9, 2, 10, 6)])
@@ -2067,7 +2066,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(MINUTELY,
                               count=3,
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 6),
                           datetime(1997, 9, 2, 9, 0, 18),
                           datetime(1997, 9, 2, 9, 1, 6)])
@@ -2077,7 +2076,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6),
                           datetime(1997, 9, 2, 18, 18),
                           datetime(1997, 9, 3, 6, 6)])
@@ -2087,7 +2086,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 6),
                           datetime(1997, 9, 2, 18, 0, 18),
                           datetime(1997, 9, 2, 18, 1, 6)])
@@ -2097,7 +2096,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 6),
                           datetime(1997, 9, 2, 9, 6, 18),
                           datetime(1997, 9, 2, 9, 18, 6)])
@@ -2108,7 +2107,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 6),
                           datetime(1997, 9, 2, 18, 6, 18),
                           datetime(1997, 9, 2, 18, 18, 6)])
@@ -2118,7 +2117,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bysecond=(15, 30, 45),
                               bysetpos=(3, -3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 15),
                           datetime(1997, 9, 2, 9, 0, 45),
                           datetime(1997, 9, 2, 9, 1, 15)])
@@ -2126,7 +2125,7 @@ class RRuleTest(unittest.TestCase):
     def testSecondly(self):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 0),
                           datetime(1997, 9, 2, 9, 0, 1),
                           datetime(1997, 9, 2, 9, 0, 2)])
@@ -2135,7 +2134,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               interval=2,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 0),
                           datetime(1997, 9, 2, 9, 0, 2),
                           datetime(1997, 9, 2, 9, 0, 4)])
@@ -2144,7 +2143,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               interval=90061,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 0),
                           datetime(1997, 9, 3, 10, 1, 1),
                           datetime(1997, 9, 4, 11, 2, 2)])
@@ -2153,7 +2152,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               bymonth=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0, 0),
                           datetime(1998, 1, 1, 0, 0, 1),
                           datetime(1998, 1, 1, 0, 0, 2)])
@@ -2162,7 +2161,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               bymonthday=(1, 3),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 0, 0, 0),
                           datetime(1997, 9, 3, 0, 0, 1),
                           datetime(1997, 9, 3, 0, 0, 2)])
@@ -2172,7 +2171,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               bymonthday=(5, 7),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 5, 0, 0, 0),
                           datetime(1998, 1, 5, 0, 0, 1),
                           datetime(1998, 1, 5, 0, 0, 2)])
@@ -2181,7 +2180,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 0),
                           datetime(1997, 9, 2, 9, 0, 1),
                           datetime(1997, 9, 2, 9, 0, 2)])
@@ -2190,7 +2189,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 0),
                           datetime(1997, 9, 2, 9, 0, 1),
                           datetime(1997, 9, 2, 9, 0, 2)])
@@ -2200,7 +2199,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0, 0),
                           datetime(1998, 1, 1, 0, 0, 1),
                           datetime(1998, 1, 1, 0, 0, 2)])
@@ -2210,7 +2209,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=(1, 3),
                               byweekday=(TU(1), TH(-1)),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0, 0),
                           datetime(1998, 1, 1, 0, 0, 1),
                           datetime(1998, 1, 1, 0, 0, 2)])
@@ -2220,7 +2219,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0, 0),
                           datetime(1998, 1, 1, 0, 0, 1),
                           datetime(1998, 1, 1, 0, 0, 2)])
@@ -2231,7 +2230,7 @@ class RRuleTest(unittest.TestCase):
                               bymonth=(1, 3),
                               bymonthday=(1, 3),
                               byweekday=(TU, TH),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 1, 1, 0, 0, 0),
                           datetime(1998, 1, 1, 0, 0, 1),
                           datetime(1998, 1, 1, 0, 0, 2)])
@@ -2240,7 +2239,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=4,
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 0, 0, 0),
                           datetime(1997, 12, 31, 0, 0, 1),
                           datetime(1997, 12, 31, 0, 0, 2),
@@ -2250,7 +2249,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=4,
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 31, 0, 0, 0),
                           datetime(1997, 12, 31, 0, 0, 1),
                           datetime(1997, 12, 31, 0, 0, 2),
@@ -2261,7 +2260,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(1, 100, 200, 365),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 0, 0, 0),
                           datetime(1998, 4, 10, 0, 0, 1),
                           datetime(1998, 4, 10, 0, 0, 2),
@@ -2272,7 +2271,7 @@ class RRuleTest(unittest.TestCase):
                               count=4,
                               bymonth=(4, 7),
                               byyearday=(-365, -266, -166, -1),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 10, 0, 0, 0),
                           datetime(1998, 4, 10, 0, 0, 1),
                           datetime(1998, 4, 10, 0, 0, 2),
@@ -2282,7 +2281,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byweekno=20,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 5, 11, 0, 0, 0),
                           datetime(1998, 5, 11, 0, 0, 1),
                           datetime(1998, 5, 11, 0, 0, 2)])
@@ -2292,7 +2291,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=1,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 29, 0, 0, 0),
                           datetime(1997, 12, 29, 0, 0, 1),
                           datetime(1997, 12, 29, 0, 0, 2)])
@@ -2302,7 +2301,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=52,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 0, 0, 0),
                           datetime(1997, 12, 28, 0, 0, 1),
                           datetime(1997, 12, 28, 0, 0, 2)])
@@ -2312,7 +2311,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=-1,
                               byweekday=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 12, 28, 0, 0, 0),
                           datetime(1997, 12, 28, 0, 0, 1),
                           datetime(1997, 12, 28, 0, 0, 2)])
@@ -2322,7 +2321,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byweekno=53,
                               byweekday=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 12, 28, 0, 0, 0),
                           datetime(1998, 12, 28, 0, 0, 1),
                           datetime(1998, 12, 28, 0, 0, 2)])
@@ -2331,7 +2330,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byeaster=0,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 12, 0, 0, 0),
                           datetime(1998, 4, 12, 0, 0, 1),
                           datetime(1998, 4, 12, 0, 0, 2)])
@@ -2340,7 +2339,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byeaster=1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 13, 0, 0, 0),
                           datetime(1998, 4, 13, 0, 0, 1),
                           datetime(1998, 4, 13, 0, 0, 2)])
@@ -2349,7 +2348,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byeaster=-1,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1998, 4, 11, 0, 0, 0),
                           datetime(1998, 4, 11, 0, 0, 1),
                           datetime(1998, 4, 11, 0, 0, 2)])
@@ -2358,7 +2357,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byhour=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 0),
                           datetime(1997, 9, 2, 18, 0, 1),
                           datetime(1997, 9, 2, 18, 0, 2)])
@@ -2367,7 +2366,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 0),
                           datetime(1997, 9, 2, 9, 6, 1),
                           datetime(1997, 9, 2, 9, 6, 2)])
@@ -2376,7 +2375,7 @@ class RRuleTest(unittest.TestCase):
         self.assertEqual(list(rrule(SECONDLY,
                               count=3,
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0, 6),
                           datetime(1997, 9, 2, 9, 0, 18),
                           datetime(1997, 9, 2, 9, 1, 6)])
@@ -2386,7 +2385,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               byminute=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 0),
                           datetime(1997, 9, 2, 18, 6, 1),
                           datetime(1997, 9, 2, 18, 6, 2)])
@@ -2396,7 +2395,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byhour=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 0, 6),
                           datetime(1997, 9, 2, 18, 0, 18),
                           datetime(1997, 9, 2, 18, 1, 6)])
@@ -2406,7 +2405,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 6, 6),
                           datetime(1997, 9, 2, 9, 6, 18),
                           datetime(1997, 9, 2, 9, 18, 6)])
@@ -2417,7 +2416,7 @@ class RRuleTest(unittest.TestCase):
                               byhour=(6, 18),
                               byminute=(6, 18),
                               bysecond=(6, 18),
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 18, 6, 6),
                           datetime(1997, 9, 2, 18, 6, 18),
                           datetime(1997, 9, 2, 18, 18, 6)])
@@ -2428,7 +2427,7 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bysecond=(0,),
                               byminute=(1,),
-                              dtstart=parse("20100322120100"))),
+                              dtstart=datetime(2010, 3, 22, 12, 1))),
                          [datetime(2010, 3, 22, 12, 1),
                           datetime(2010, 3, 22, 13, 1),
                           datetime(2010, 3, 22, 14, 1)])
@@ -2443,14 +2442,14 @@ class RRuleTest(unittest.TestCase):
                                   byhour=long(6),
                                   byminute=long(6),
                                   bysecond=long(6),
-                                  dtstart=parse("19970902T090000"))),
+                                  dtstart=datetime(1997, 9, 2, 9, 0))),
                              [datetime(1998, 2, 5, 6, 6, 6),
                               datetime(1998, 2, 12, 6, 6, 6)])
             self.assertEqual(list(rrule(YEARLY,
                                   count=long(2),
                                   bymonthday=long(5),
                                   byweekno=long(2),
-                                  dtstart=parse("19970902T090000"))),
+                                  dtstart=datetime(1997, 9, 2, 9, 0))),
                              [datetime(1998, 1, 5, 9, 0),
                               datetime(2004, 1, 5, 9, 0)])
 
@@ -2465,7 +2464,7 @@ class RRuleTest(unittest.TestCase):
 
         self.assertRaises(ValueError, rrule, HOURLY,
                           **dict(interval=4, byhour=(7, 11, 15, 19),
-                                 dtstart=parse("19970902T090000")))
+                                 dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testMinutelyBadRRule(self):
         """
@@ -2474,7 +2473,7 @@ class RRuleTest(unittest.TestCase):
 
         self.assertRaises(ValueError, rrule, MINUTELY,
                           **dict(interval=12, byminute=(10, 11, 25, 39, 50),
-                                 dtstart=parse("19970902T090000")))
+                                 dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testSecondlyBadRRule(self):
         """
@@ -2483,7 +2482,7 @@ class RRuleTest(unittest.TestCase):
 
         self.assertRaises(ValueError, rrule, SECONDLY,
                           **dict(interval=10, bysecond=(2, 15, 37, 42, 59),
-                                 dtstart=parse("19970902T090000")))
+                                 dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testMinutelyBadComboRRule(self):
         """
@@ -2496,7 +2495,7 @@ class RRuleTest(unittest.TestCase):
         # In Python 2.7 you can use a context manager for this.
         def make_bad_rrule():
             list(rrule(MINUTELY, interval=120, byhour=(10, 12, 14, 16),
-                 count=2, dtstart=parse("19970902T090000")))
+                 count=2, dtstart=datetime(1997, 9, 2, 9, 0)))
 
         self.assertRaises(ValueError, make_bad_rrule)
 
@@ -2508,11 +2507,11 @@ class RRuleTest(unittest.TestCase):
         # In Python 2.7 you can use a context manager for this.
         def make_bad_minute_rrule():
             list(rrule(SECONDLY, interval=360, byminute=(10, 28, 49),
-                 count=4, dtstart=parse("19970902T090000")))
+                 count=4, dtstart=datetime(1997, 9, 2, 9, 0)))
 
         def make_bad_hour_rrule():
             list(rrule(SECONDLY, interval=43200, byhour=(2, 10, 18, 23),
-                 count=4, dtstart=parse("19970902T090000")))
+                 count=4, dtstart=datetime(1997, 9, 2, 9, 0)))
 
         self.assertRaises(ValueError, make_bad_minute_rrule)
         self.assertRaises(ValueError, make_bad_hour_rrule)
@@ -2520,8 +2519,8 @@ class RRuleTest(unittest.TestCase):
     def testUntilNotMatching(self):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
-                              dtstart=parse("19970902T090000"),
-                              until=parse("19970905T080000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0),
+                              until=datetime(1997, 9, 5, 8, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 9, 4, 9, 0)])
@@ -2529,8 +2528,8 @@ class RRuleTest(unittest.TestCase):
     def testUntilMatching(self):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
-                              dtstart=parse("19970902T090000"),
-                              until=parse("19970904T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0),
+                              until=datetime(1997, 9, 4, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 9, 4, 9, 0)])
@@ -2538,21 +2537,21 @@ class RRuleTest(unittest.TestCase):
     def testUntilSingle(self):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
-                              dtstart=parse("19970902T090000"),
-                              until=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0),
+                              until=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0)])
 
     def testUntilEmpty(self):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
-                              dtstart=parse("19970902T090000"),
-                              until=parse("19970901T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0),
+                              until=datetime(1997, 9, 1, 9, 0))),
                          [])
 
     def testUntilWithDate(self):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
-                              dtstart=parse("19970902T090000"),
+                              dtstart=datetime(1997, 9, 2, 9, 0),
                               until=date(1997, 9, 5))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
@@ -2564,7 +2563,7 @@ class RRuleTest(unittest.TestCase):
                               interval=2,
                               byweekday=(TU, SU),
                               wkst=MO,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 7, 9, 0),
                           datetime(1997, 9, 16, 9, 0)])
@@ -2575,7 +2574,7 @@ class RRuleTest(unittest.TestCase):
                               interval=2,
                               byweekday=(TU, SU),
                               wkst=SU,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 14, 9, 0),
                           datetime(1997, 9, 16, 9, 0)])
@@ -2591,7 +2590,7 @@ class RRuleTest(unittest.TestCase):
     def testDTStartWithMicroseconds(self):
         self.assertEqual(list(rrule(DAILY,
                               count=3,
-                              dtstart=parse("19970902T090000.5"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0, 0, 500000))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 9, 4, 9, 0)])
@@ -2601,31 +2600,31 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               bymonth=2,
                               bymonthday=31,
-                              dtstart=parse("99970902T090000"))),
+                              dtstart=datetime(9997, 9, 2, 9, 0, 0))),
                          [])
 
     def testGetItem(self):
         self.assertEqual(rrule(DAILY,
                                count=3,
-                               dtstart=parse("19970902T090000"))[0],
+                               dtstart=datetime(1997, 9, 2, 9, 0))[0],
                          datetime(1997, 9, 2, 9, 0))
 
     def testGetItemNeg(self):
         self.assertEqual(rrule(DAILY,
                                count=3,
-                               dtstart=parse("19970902T090000"))[-1],
+                               dtstart=datetime(1997, 9, 2, 9, 0))[-1],
                          datetime(1997, 9, 4, 9, 0))
 
     def testGetItemSlice(self):
         self.assertEqual(rrule(DAILY,
                                # count=3,
-                               dtstart=parse("19970902T090000"))[1:2],
+                               dtstart=datetime(1997, 9, 2, 9, 0))[1:2],
                          [datetime(1997, 9, 3, 9, 0)])
 
     def testGetItemSliceEmpty(self):
         self.assertEqual(rrule(DAILY,
                                count=3,
-                               dtstart=parse("19970902T090000"))[:],
+                               dtstart=datetime(1997, 9, 2, 9, 0))[:],
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 9, 4, 9, 0)])
@@ -2633,56 +2632,56 @@ class RRuleTest(unittest.TestCase):
     def testGetItemSliceStep(self):
         self.assertEqual(rrule(DAILY,
                                count=3,
-                               dtstart=parse("19970902T090000"))[::-2],
+                               dtstart=datetime(1997, 9, 2, 9, 0))[::-2],
                          [datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 2, 9, 0)])
 
     def testCount(self):
         self.assertEqual(rrule(DAILY,
                                count=3,
-                               dtstart=parse("19970902T090000")).count(),
+                               dtstart=datetime(1997, 9, 2, 9, 0)).count(),
                          3)
 
     def testContains(self):
-        rr = rrule(DAILY, count=3, dtstart=parse("19970902T090000"))
+        rr = rrule(DAILY, count=3, dtstart=datetime(1997, 9, 2, 9, 0))
         self.assertEqual(datetime(1997, 9, 3, 9, 0) in rr, True)
 
     def testContainsNot(self):
-        rr = rrule(DAILY, count=3, dtstart=parse("19970902T090000"))
+        rr = rrule(DAILY, count=3, dtstart=datetime(1997, 9, 2, 9, 0))
         self.assertEqual(datetime(1997, 9, 3, 9, 0) not in rr, False)
 
     def testBefore(self):
         self.assertEqual(rrule(DAILY,  # count=5
-            dtstart=parse("19970902T090000")).before(parse("19970905T090000")),
+            dtstart=datetime(1997, 9, 2, 9, 0)).before(datetime(1997, 9, 5, 9, 0)),
                          datetime(1997, 9, 4, 9, 0))
 
     def testBeforeInc(self):
         self.assertEqual(rrule(DAILY,
                                #count=5,
-                               dtstart=parse("19970902T090000"))
-                               .before(parse("19970905T090000"), inc=True),
+                               dtstart=datetime(1997, 9, 2, 9, 0))
+                               .before(datetime(1997, 9, 5, 9, 0), inc=True),
                          datetime(1997, 9, 5, 9, 0))
 
     def testAfter(self):
         self.assertEqual(rrule(DAILY,
                                #count=5,
-                               dtstart=parse("19970902T090000"))
-                               .after(parse("19970904T090000")),
+                               dtstart=datetime(1997, 9, 2, 9, 0))
+                               .after(datetime(1997, 9, 4, 9, 0)),
                          datetime(1997, 9, 5, 9, 0))
 
     def testAfterInc(self):
         self.assertEqual(rrule(DAILY,
                                #count=5,
-                               dtstart=parse("19970902T090000"))
-                               .after(parse("19970904T090000"), inc=True),
+                               dtstart=datetime(1997, 9, 2, 9, 0))
+                               .after(datetime(1997, 9, 4, 9, 0), inc=True),
                          datetime(1997, 9, 4, 9, 0))
 
     def testBetween(self):
         self.assertEqual(rrule(DAILY,
                                #count=5,
-                               dtstart=parse("19970902T090000"))
-                               .between(parse("19970902T090000"),
-                                        parse("19970906T090000")),
+                               dtstart=datetime(1997, 9, 2, 9, 0))
+                               .between(datetime(1997, 9, 2, 9, 0),
+                                        datetime(1997, 9, 6, 9, 0)),
                          [datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
                           datetime(1997, 9, 5, 9, 0)])
@@ -2690,9 +2689,9 @@ class RRuleTest(unittest.TestCase):
     def testBetweenInc(self):
         self.assertEqual(rrule(DAILY,
                                #count=5,
-                               dtstart=parse("19970902T090000"))
-                               .between(parse("19970902T090000"),
-                                        parse("19970906T090000"), inc=True),
+                               dtstart=datetime(1997, 9, 2, 9, 0))
+                               .between(datetime(1997, 9, 2, 9, 0),
+                                        datetime(1997, 9, 6, 9, 0), inc=True),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
@@ -2701,7 +2700,7 @@ class RRuleTest(unittest.TestCase):
 
     def testCachePre(self):
         rr = rrule(DAILY, count=15, cache=True,
-                   dtstart=parse("19970902T090000"))
+                   dtstart=datetime(1997, 9, 2, 9, 0))
         self.assertEqual(list(rr),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 3, 9, 0),
@@ -2721,7 +2720,7 @@ class RRuleTest(unittest.TestCase):
 
     def testCachePost(self):
         rr = rrule(DAILY, count=15, cache=True,
-                   dtstart=parse("19970902T090000"))
+                   dtstart=datetime(1997, 9, 2, 9, 0))
         for x in rr: pass
         self.assertEqual(list(rr),
                          [datetime(1997, 9, 2, 9, 0),
@@ -2742,7 +2741,7 @@ class RRuleTest(unittest.TestCase):
 
     def testCachePostInternal(self):
         rr = rrule(DAILY, count=15, cache=True,
-                   dtstart=parse("19970902T090000"))
+                   dtstart=datetime(1997, 9, 2, 9, 0))
         for x in rr: pass
         self.assertEqual(rr._cache,
                          [datetime(1997, 9, 2, 9, 0),
@@ -2763,21 +2762,21 @@ class RRuleTest(unittest.TestCase):
 
     def testCachePreContains(self):
         rr = rrule(DAILY, count=3, cache=True,
-                   dtstart=parse("19970902T090000"))
+                   dtstart=datetime(1997, 9, 2, 9, 0))
         self.assertEqual(datetime(1997, 9, 3, 9, 0) in rr, True)
 
     def testCachePostContains(self):
         rr = rrule(DAILY, count=3, cache=True,
-                   dtstart=parse("19970902T090000"))
+                   dtstart=datetime(1997, 9, 2, 9, 0))
         for x in rr: pass
         self.assertEqual(datetime(1997, 9, 3, 9, 0) in rr, True)
 
     def testSet(self):
         set = rruleset()
         set.rrule(rrule(YEARLY, count=2, byweekday=TU,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.rrule(rrule(YEARLY, count=1, byweekday=TH,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         self.assertEqual(list(set),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
@@ -2786,7 +2785,7 @@ class RRuleTest(unittest.TestCase):
     def testSetDate(self):
         set = rruleset()
         set.rrule(rrule(YEARLY, count=1, byweekday=TU,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.rdate(datetime(1997, 9, 4, 9))
         set.rdate(datetime(1997, 9, 9, 9))
         self.assertEqual(list(set),
@@ -2797,9 +2796,9 @@ class RRuleTest(unittest.TestCase):
     def testSetExRule(self):
         set = rruleset()
         set.rrule(rrule(YEARLY, count=6, byweekday=(TU, TH),
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.exrule(rrule(YEARLY, count=3, byweekday=TH,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         self.assertEqual(list(set),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 9, 9, 0),
@@ -2808,7 +2807,7 @@ class RRuleTest(unittest.TestCase):
     def testSetExDate(self):
         set = rruleset()
         set.rrule(rrule(YEARLY, count=6, byweekday=(TU, TH),
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.exdate(datetime(1997, 9, 4, 9))
         set.exdate(datetime(1997, 9, 11, 9))
         set.exdate(datetime(1997, 9, 18, 9))
@@ -2820,7 +2819,7 @@ class RRuleTest(unittest.TestCase):
     def testSetExDateRevOrder(self):
         set = rruleset()
         set.rrule(rrule(MONTHLY, count=5, bymonthday=10,
-                        dtstart=parse("20040101T090000")))
+                        dtstart=datetime(2004, 1, 1, 9, 0)))
         set.exdate(datetime(2004, 4, 10, 9, 0))
         set.exdate(datetime(2004, 2, 10, 9, 0))
         self.assertEqual(list(set),
@@ -2853,7 +2852,7 @@ class RRuleTest(unittest.TestCase):
         set.rdate(datetime(1997, 9, 16, 9))
         set.rdate(datetime(1997, 9, 18, 9))
         set.exrule(rrule(YEARLY, count=3, byweekday=TH,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         self.assertEqual(list(set),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 9, 9, 0),
@@ -2862,17 +2861,17 @@ class RRuleTest(unittest.TestCase):
     def testSetCount(self):
         set = rruleset()
         set.rrule(rrule(YEARLY, count=6, byweekday=(TU, TH),
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.exrule(rrule(YEARLY, count=3, byweekday=TH,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         self.assertEqual(set.count(), 3)
 
     def testSetCachePre(self):
         set = rruleset()
         set.rrule(rrule(YEARLY, count=2, byweekday=TU,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.rrule(rrule(YEARLY, count=1, byweekday=TH,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         self.assertEqual(list(set),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1997, 9, 4, 9, 0),
@@ -2881,9 +2880,9 @@ class RRuleTest(unittest.TestCase):
     def testSetCachePost(self):
         set = rruleset(cache=True)
         set.rrule(rrule(YEARLY, count=2, byweekday=TU,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.rrule(rrule(YEARLY, count=1, byweekday=TH,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         for x in set: pass
         self.assertEqual(list(set),
                          [datetime(1997, 9, 2, 9, 0),
@@ -2893,9 +2892,9 @@ class RRuleTest(unittest.TestCase):
     def testSetCachePostInternal(self):
         set = rruleset(cache=True)
         set.rrule(rrule(YEARLY, count=2, byweekday=TU,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         set.rrule(rrule(YEARLY, count=1, byweekday=TH,
-                        dtstart=parse("19970902T090000")))
+                        dtstart=datetime(1997, 9, 2, 9, 0)))
         for x in set: pass
         self.assertEqual(list(set._cache),
                          [datetime(1997, 9, 2, 9, 0),
@@ -2961,7 +2960,7 @@ class RRuleTest(unittest.TestCase):
     def testStrNoDTStart(self):
         self.assertEqual(list(rrulestr(
                               "RRULE:FREQ=YEARLY;COUNT=3\n"
-                              , dtstart=parse("19970902T090000"))),
+                              , dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1998, 9, 2, 9, 0),
                           datetime(1999, 9, 2, 9, 0)])
@@ -2969,7 +2968,7 @@ class RRuleTest(unittest.TestCase):
     def testStrValueOnly(self):
         self.assertEqual(list(rrulestr(
                               "FREQ=YEARLY;COUNT=3\n"
-                              , dtstart=parse("19970902T090000"))),
+                              , dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1998, 9, 2, 9, 0),
                           datetime(1999, 9, 2, 9, 0)])
@@ -2977,7 +2976,7 @@ class RRuleTest(unittest.TestCase):
     def testStrUnfold(self):
         self.assertEqual(list(rrulestr(
                               "FREQ=YEA\n RLY;COUNT=3\n", unfold=True,
-                              dtstart=parse("19970902T090000"))),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1998, 9, 2, 9, 0),
                           datetime(1999, 9, 2, 9, 0)])
@@ -3082,14 +3081,14 @@ class RRuleTest(unittest.TestCase):
                           rrule, MONTHLY,
                                  count=1,
                                  bysetpos=0,
-                                 dtstart=parse("19970902T090000"))
+                                 dtstart=datetime(1997, 9, 2, 9, 0))
 
     def testBadBySetPosMany(self):
         self.assertRaises(ValueError,
                           rrule, MONTHLY,
                                  count=1,
                                  bysetpos=(-1, 0, 1),
-                                 dtstart=parse("19970902T090000"))
+                                 dtstart=datetime(1997, 9, 2, 9, 0))
 
 
 class ParserTest(unittest.TestCase):


### PR DESCRIPTION
Documentation currently uses `parse()` for almost all the rrule tests, and a bunch of others. I think it's better to explicitly specify `datetime` objects, since any problems with the parser will start causing the rrule tests to fail as well, causing the tests to be less well-separated. It also probably speeds up the test process a bit.