### PR TITLE
Boolean evaluation of relativedeltas on python 2.7

### DIFF
--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -375,6 +375,8 @@ Here is the behavior of operations with relativedelta:
                     self.minute is None and
                     self.second is None and
                     self.microsecond is None)
+    # Compatibility with Python 2.x
+    __nonzero__ = __bool__
 
     def __mul__(self, other):
         f = float(other)

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -193,6 +193,10 @@ class RelativeDeltaTest(unittest.TestCase):
         self.assertEqual(datetime(2000, 1, 1) + relativedelta(days=28) / 28,
                          datetime(2000, 1, 2))
 
+    def testBoolean(self):
+        self.assertFalse(relativedelta(days=0))
+        self.assertTrue(relativedelta(days=1))
+
 
 class RRuleTest(unittest.TestCase):
     def testYearly(self):


### PR DESCRIPTION
Python 3 implements truth-testing by, among other things, calling the [`__bool__`][1] method of a class instance, whereas Python 2 calls the [`__nonzero__`][2] method. dateutil.relativedelta only implements `__bool__`, which means that for example:

``` python
>>> bool(relativedelta(days=0))
True
```
There's already an open [issue][3] for this on launchpad, with a fix.

This pull-request introduces a failing test.

[1]: https://docs.python.org/3/library/stdtypes.html#truth
[2]: https://docs.python.org/2/library/stdtypes.html#truth
[3]: https://bugs.launchpad.net/dateutil/+bug/1035038