### PR TITLE
Fix issue with tzstr parsing on Python 2.x. lp:1331576, gh #51

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -1002,6 +1002,11 @@ class _tzparser(object):
             self.end = self._attr()
 
     def parse(self, tzstr):
+        # Python 2.x compatibility: tzstr should be converted to unicode before
+        # being passed to _timelex.
+        if isinstance(tzstr, binary_type):
+            tzstr = tzstr.decode()
+
         res = self._result()
         l = _timelex.split(tzstr)
         try:

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -3993,6 +3993,14 @@ END:VTIMEZONE
         self.assertEqual(datetime(2003, 10, 26, 1, 00,
                                   tzinfo=tzstr(s)).tzname(), "EST")
 
+    def testStrStr(self):
+        # Test that tzstr() won't throw an error if given a str instead
+        # of a unicode literal.
+        self.assertEqual(datetime(2003, 4, 6, 1, 59,
+                                  tzinfo=tzstr(str("EST5EDT"))).tzname(), "EST")
+        self.assertEqual(datetime(2003, 4, 6, 2, 00,
+                                  tzinfo=tzstr(str("EST5EDT"))).tzname(), "EDT")
+
     def testStrCmp1(self):
         self.assertEqual(tzstr("EST5EDT"),
                          tzstr("EST5EDT4,M4.1.0/02:00:00,M10-5-0/02:00"))


### PR DESCRIPTION
Fixes issue #51. I was a bit hesitant to wade into character encodings, which seem like they can be very complicated if not done right, but the same strategy is used successfully in `parser.parse()`, so I think it's fine.