### PR TITLE
Remove 'setcachsize' from zoneinfo __all__ list

### DIFF
--- a/dateutil/zoneinfo/__init__.py
+++ b/dateutil/zoneinfo/__init__.py
@@ -12,7 +12,7 @@ from contextlib import closing
 
 from dateutil.tz import tzfile
 
-__all__ = ["setcachesize", "gettz", "rebuild"]
+__all__ = ["gettz", "rebuild"]
 
 _ZONEFILENAME = "dateutil-zoneinfo.tar.gz"
 


### PR DESCRIPTION
This function was removed from the zoneinfo module in version 2.3 and
causes an error when doing a wildcard import from the zoneinfo module.

```python
>>> from dateutil.zoneinfo import *
Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      AttributeError: 'module' object has no attribute 'setcachesize'
```