### PR TITLE
Fixed typo in NEWS

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,7 +5,7 @@ Version 2.4.2
   if not a unicode type. gh #51 (lp:1331576), gh pr #55.
 - Fix a parser issue where AM and PM tokens were showing up in fuzzy date
   stamps, triggering inappropriate errors. gh #56 (lp: 1428895), gh pr #63.
-- Missing function "setcachsize" removed from zoneinfo __all__ list by @ryanss,
+- Missing function "setcachesize" removed from zoneinfo __all__ list by @ryanss,
   fixing an issue with wildcard imports of dateutil.zoneinfo. (gh pr #66).
 - (PyPi only) Fix an issue with source distributions not including the test
   suite.


### PR DESCRIPTION
I know that the typo is in the commit message as well, but I figure that this is a description of the changes made.