### PR TITLE
Fail correctly when using with_fuzzy_tokens and incorrect strings

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -793,7 +793,7 @@ class parser(object):
                                     assert mstridx == -1
                                     mstridx = len(ymd)-1
                                 else:
-                                    return None
+                                    return None, None
 
                             i += 1
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -448,12 +448,7 @@ class parser(object):
         else:
             effective_dt = default
 
-        if kwargs.get('fuzzy_with_tokens', False):
-            res = self._parse(timestr, **kwargs)
-            if res is not None:
-                res, skipped_tokens = res
-        else:
-            res = self._parse(timestr, **kwargs)
+        res, skipped_tokens = self._parse(timestr, **kwargs)
 
         if res is None:
             raise ValueError("Unknown string format")
@@ -842,7 +837,7 @@ class parser(object):
                         i += 1
 
                     elif not fuzzy:
-                        return None
+                        return None, None
                     else:
                         i += 1
                     continue
@@ -971,7 +966,7 @@ class parser(object):
                         # -[0]3
                         res.tzoffset = int(l[i][:2])*3600
                     else:
-                        return None
+                        return None, None
                     i += 1
 
                     res.tzoffset *= signal
@@ -989,7 +984,7 @@ class parser(object):
 
                 # Check jumps
                 if not (info.jump(l[i]) or fuzzy):
-                    return None
+                    return None, None
 
                 if last_skipped_token_i == i - 1:
                     # recombine the tokens
@@ -1004,7 +999,7 @@ class parser(object):
             len_ymd = len(ymd)
             if len_ymd > 3:
                 # More than three members!?
-                return None
+                return None, None
             elif len_ymd == 1 or (mstridx != -1 and len_ymd == 2):
                 # One member, or two members with a month string
                 if mstridx != -1:
@@ -1068,15 +1063,15 @@ class parser(object):
                         res.month, res.day, res.year = ymd
 
         except (IndexError, ValueError, AssertionError):
-            return None
+            return None, None
 
         if not info.validate(res):
-            return None
+            return None, None
 
         if fuzzy_with_tokens:
             return res, tuple(skipped_tokens)
         else:
-            return res
+            return res, None
 
 DEFAULTPARSER = parser()
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -449,7 +449,9 @@ class parser(object):
             effective_dt = default
 
         if kwargs.get('fuzzy_with_tokens', False):
-            res, skipped_tokens = self._parse(timestr, **kwargs)
+            res = self._parse(timestr, **kwargs)
+            if res is not None:
+                res, skipped_tokens = res
         else:
             res = self._parse(timestr, **kwargs)
 

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -5499,6 +5499,11 @@ class ParserTest(unittest.TestCase):
         self.assertRaises(ValueError,
                           parse, 'shouldfail')
 
+    def testCorrectErrorOnFuzzyWithTokens(self):
+        self.assertRaises(ValueError, parse, '04/04/32/423', fuzzy_with_tokens=True)
+        self.assertRaises(ValueError, parse, '04/04/04 +32423', fuzzy_with_tokens=True)
+        self.assertRaises(ValueError, parse, '04/04/0d4', fuzzy_with_tokens=True)
+
     def testIncreasingCTime(self):
         # This test will check 200 different years, every month, every day,
         # every hour, every minute, every second, and every weekday, using

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -5500,9 +5500,9 @@ class ParserTest(unittest.TestCase):
                           parse, 'shouldfail')
 
     def testCorrectErrorOnFuzzyWithTokens(self):
-        self.assertRaises(ValueError, parse, '04/04/32/423', fuzzy_with_tokens=True)
-        self.assertRaises(ValueError, parse, '04/04/04 +32423', fuzzy_with_tokens=True)
-        self.assertRaises(ValueError, parse, '04/04/0d4', fuzzy_with_tokens=True)
+        self.assertRaisesRegexp(ValueError, 'Unknown string format', parse, '04/04/32/423', fuzzy_with_tokens=True)
+        self.assertRaisesRegexp(ValueError, 'Unknown string format', parse, '04/04/04 +32423', fuzzy_with_tokens=True)
+        self.assertRaisesRegexp(ValueError, 'Unknown string format', parse, '04/04/0d4', fuzzy_with_tokens=True)
 
     def testIncreasingCTime(self):
         # This test will check 200 different years, every month, every day,


### PR DESCRIPTION
For certain test cases, using `with_fuzzy_tokens=True` will cause parse to fail because a tuple is expected to be returned by _parse. This is then incorrectly unpacked which results in a confusing TypeError message. The standard way would be to allow a ValueError to be thrown. 

Example of issue:

    >> import dateutil.parser
    >> dateutil.parser.parse('04/04/0d4', fuzzy_with_tokens=True)

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "dateutil/parser.py", line 1139, in parse
         return DEFAULTPARSER.parse(timestr, **kwargs)
      File "dateutil/parser.py", line 452, in parse
        res, skipped_tokens = self._parse(timestr, **kwargs)
    TypeError: 'NoneType' object is not iterable
    

This pull request solves this issue for cases similiar to those specified in the test included (and any other errors that result in the internal _parse method failing).