### PR TITLE
When possible dont convert years when the year has been specified past two digits

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -342,30 +342,19 @@ class parserinfo(object):
 
         return self.TZOFFSET.get(name)
 
-    @staticmethod
-    def _find_potential_year_tokens(year, tokens):
-        result = []
-        for t in tokens:
-            try:
-                if int(t) == year:
-                    result.append(t)
-            except ValueError:
-                pass
-        return result
-
     def convertyear(self, year, tokens=None):
-        potential_year_tokens = self._find_potential_year_tokens(year, tokens) if tokens else []
+        potential_year_tokens = _find_potential_year_tokens(year, tokens) if tokens else []
         year_token_unambiguous = len(potential_year_tokens) == 1
-        if (year_token_unambiguous and len(potential_year_tokens[0]) > 2) or year >= 100:
-            return year
-        else:
+        year_at_least_three_digits = (year_token_unambiguous and
+                                      len(potential_year_tokens[0]) > 2) or year >= 100
+        if not year_at_least_three_digits:
             year += self._century
             if abs(year-self._year) >= 50:
                 if year < self._year:
                     year += 100
                 else:
                     year -= 100
-            return year
+        return year
 
     def validate(self, res, tokens):
         # move to info
@@ -1066,8 +1055,8 @@ class parser(object):
                         res.year, res.day, res.month = ymd
 
                 else:
-                    if ymd[0] > 31 or \
-                       (yearfirst and ymd[1] <= 12 and ymd[2] <= 31):
+                    if _find_probable_year_index(ymd, l) == 0 or (ymd[0] > 31 or
+                       (yearfirst and ymd[1] <= 12 and ymd[2] <= 31)):
                         # 99-01-01
                         res.year, res.month, res.day = ymd
                     elif ymd[0] > 12 or (dayfirst and ymd[1] <= 12):
@@ -1339,5 +1328,26 @@ def _parsems(value):
         i, f = value.split(".")
         return int(i), int(f.ljust(6, "0")[:6])
 
+
+def _token_could_be_year(token, year):
+    try:
+        return int(token) == year
+    except ValueError:
+        return False
+
+
+def _find_potential_year_tokens(year, tokens):
+    return [token for token in tokens if _token_could_be_year(token, year)]
+
+
+def _find_probable_year_index(ymd, tokens):
+    """
+    attempt to deduce if a pre 100 year was lost
+     due to padded zeros being taken off
+    """
+    for index, token in enumerate(ymd):
+        potential_year_tokens = _find_potential_year_tokens(token, tokens)
+        if len(potential_year_tokens) == 1 and len(potential_year_tokens[0]) > 2:
+            return index
 
 # vim:ts=4:sw=4:et

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -5558,6 +5558,12 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse('0099-01-01T00:00:00'),
                          datetime(99, 1, 1, 0, 0))
 
+    def test_31_ad(self):
+        self.assertEqual(
+            parse('0031-01-01T00:00:00'),
+            datetime(31, 1, 1, 0, 0)
+        )
+
     def testParseStr(self):
         self.assertEqual(parse(self.str_str),
                          parse(self.uni_str))

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -5554,6 +5554,10 @@ class ParserTest(unittest.TestCase):
         dt = myparser.parse("01/Foo/2007")
         self.assertEqual(dt, datetime(2007, 1, 1))
 
+    def test_99_ad(self):
+        self.assertEqual(parse('0099-01-01T00:00:00'),
+                         datetime(99, 1, 1, 0, 0))
+
     def testParseStr(self):
         self.assertEqual(parse(self.str_str),
                          parse(self.uni_str))


### PR DESCRIPTION
Howdy!

While playing around with dateutil parsing I found what I think is a bug

```
datetime(99, 1, 1, 0, 0).isoformat()
'0099-01-01T00:00:00'

dateutil.parse('0099-01-01T00:00:00')
datetime.datetime(1999, 1, 1, 0, 0)
```

This PR tries to address this. When the library can identify a single possible year token, if that year is greater than 3 digits it will assume the year is correct rather than coercing it.

I also noticed problems with years like 0039. So I tried to address that as well

A better solution would be to detect padding zeros and handle those tokens differently... but I was struggling with that so I took the post processing approach instead. 

