### PR TITLE
Extract tz rebuild into separate file

### DIFF
--- a/dateutil/zoneinfo/rebuild.py
+++ b/dateutil/zoneinfo/rebuild.py
@@ -1,0 +1,43 @@
+import logging
+import os
+import tempfile
+import shutil
+import json
+from subprocess import check_call
+
+from dateutil.zoneinfo import tar_open, METADATA_FN, ZONEFILENAME
+
+
+def rebuild(filename, tag=None, format="gz", zonegroups=[], metadata=None):
+    """Rebuild the internal timezone info in dateutil/zoneinfo/zoneinfo*tar*
+
+    filename is the timezone tarball from ftp.iana.org/tz.
+
+    """
+    tmpdir = tempfile.mkdtemp()
+    zonedir = os.path.join(tmpdir, "zoneinfo")
+    moduledir = os.path.dirname(__file__)
+    try:
+        with tar_open(filename) as tf:
+            for name in zonegroups:
+                tf.extract(name, tmpdir)
+            filepaths = [os.path.join(tmpdir, n) for n in zonegroups]
+            try:
+                check_call(["zic", "-d", zonedir] + filepaths)
+            except OSError as e:
+                if e.errno == 2:
+                    logging.error(
+                        "Could not find zic. Perhaps you need to install "
+                        "libc-bin or some other package that provides it, "
+                        "or it's not in your PATH?")
+                    raise
+        # write metadata file
+        with open(os.path.join(zonedir, METADATA_FN), 'w') as f:
+            json.dump(metadata, f, indent=4, sort_keys=True)
+        target = os.path.join(moduledir, ZONEFILENAME)
+        with tar_open(target, "w:%s" % format) as tf:
+            for entry in os.listdir(zonedir):
+                entrypath = os.path.join(zonedir, entry)
+                tf.add(entrypath, entry)
+    finally:
+        shutil.rmtree(tmpdir)

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -26,7 +26,7 @@ def main():
         sha_512_file = sha_hasher.hexdigest()
         assert metadata['tzdata_file_sha512'] == sha_512_file, "SHA failed for"
     print("Updating timezone information...")
-    rebuild(metadata['tzdata_file'], zonegroups=metadata['zonegroups'],
+    rebuild.rebuild(metadata['tzdata_file'], zonegroups=metadata['zonegroups'],
             metadata=metadata)
     print("Done.")
 


### PR DESCRIPTION
bugfix #97 
Fix for an issue that happens inside GAE sandbox, where `subprocess.check_call` is not available. 