### PR TITLE
Cache tznames with _dst_offset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ python:
   - "3.4"
   - "pypy"
   - "pypy3"
+env:
+  - TZ="US/Central"
+  - TZ="UTC"
 install:
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -559,7 +559,7 @@ class parser(object):
                     raise ValueError("Offset must be tzinfo subclass, "
                                      "tz string, or int offset.")
                 ret = ret.replace(tzinfo=tzinfo)
-            elif res.tzname and res.tzname in time.tzname:
+            elif res.tzname and res.tzname in tz.tzlocal._tzname:
                 ret = ret.replace(tzinfo=tz.tzlocal())
             elif res.tzoffset == 0:
                 ret = ret.replace(tzinfo=tz.tzutc())

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -5946,6 +5946,7 @@ END:VTIMEZONE
         dt = parse("2013-03-06 19:08:15")
         self.assertFalse(tz._isdst(dt))
 
+    @unittest.skipIf(sys.platform.startswith("win"), "requires Unix")
     def testTZSetDoesntCorrupt(self):
         # if we start in non-UTC then tzset UTC make sure parse doesn't get
         # confused

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import calendar
 import base64
 import sys
+import os
+import time as _time
 
 from six import StringIO, BytesIO, PY3
 
@@ -5943,5 +5945,14 @@ END:VTIMEZONE
         tz = tzwin.tzwin("UTC")
         dt = parse("2013-03-06 19:08:15")
         self.assertFalse(tz._isdst(dt))
+
+    def testTZSetDoesntCorrupt(self):
+        # if we start in non-UTC then tzset UTC make sure parse doesn't get
+        # confused
+        os.environ['TZ'] = 'UTC'
+        _time.tzset()
+        # this should parse to UTC timezone not the original timezone
+        dt = parse('2014-07-20T12:34:56+00:00')
+        self.assertEqual(str(dt), '2014-07-20 12:34:56+00:00')
 
 # vim:ts=4:sw=4

--- a/dateutil/tz.py
+++ b/dateutil/tz.py
@@ -110,6 +110,7 @@ class tzlocal(datetime.tzinfo):
         _dst_offset = datetime.timedelta(seconds=-time.altzone)
     else:
         _dst_offset = _std_offset
+    _tzname = tuple(time.tzname)
 
     def utcoffset(self, dt):
         if self._isdst(dt):
@@ -125,7 +126,7 @@ class tzlocal(datetime.tzinfo):
 
     @tzname_in_python2
     def tzname(self, dt):
-        return time.tzname[self._isdst(dt)]
+        return self._tzname[self._isdst(dt)]
 
     def _isdst(self, dt):
         # We can't use mktime here. It is unstable when deciding if


### PR DESCRIPTION
This should add caching (and checking) of the tzlocal._tznames attribute to make sure that, even if the timezone is changed after loading, it does not return an incorrect value.

I've added an `env` section to the build script to test the code in two timezones since this bug only exhibits itself when the system starts in non-UTC then is changed to UTC at runtime.

Ref: https://github.com/dateutil/dateutil/issues/100