### PR TITLE
Parse python logger timestamps

### DIFF
--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -4873,6 +4873,10 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("20030925"),
                          datetime(2003, 9, 25))
 
+    def testPythonLoggerFormat(self):
+        self.assertEqual(parse("2003-09-25 10:49:41,502"),
+                         datetime(2003, 9, 25, 10, 49, 41, 502000))
+
     def testNoSeparator1(self):
         self.assertEqual(parse("199709020908"),
                          datetime(1997, 9, 2, 9, 8))


### PR DESCRIPTION
By default, the Python logging module uses a format that includes `%(asctime)s`. The Python docs define this variable as:

Human-readable time when the LogRecord was created. By default this is of the form ‘2003-07-08 16:49:45,896’ (the numbers after the comma are millisecond portion of the time).

Example: `2003-09-25 10:49:41,502`

Currently, dateutil fails to parse a string like this:
```python
>>> from dateutil.parser import parse
>>> parse("2003-09-25 10:49:41,502")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/dateutil/parser.py", line 1008, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/dateutil/parser.py", line 395, in parse
    raise ValueError("Unknown string format")
ValueError: Unknown string format
```

This patch enables dateutil to parse these timestamps which are extremely common in Python log files.

```python
>>> from dateutil.parser import parse
>>> parse("2003-09-25 10:49:41,502")
datetime.datetime(2003, 9, 25, 10, 49, 41, 502000)
```