### PR TITLE
Tox: install unittest2 under Python 2.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,4 +3,6 @@ envlist = py26, py27, py32, py33, py34
 
 [testenv]
 commands = python setup.py test -q
-deps = six
+deps =
+    py26: unittest2
+    six


### PR DESCRIPTION
This fixes testing under Tox and matches the behaviour of Travis