### PR TITLE
Hotfix-133: Fix tzwin.py not importing when needed on Windows

### DIFF
--- a/dateutil/tz.py
+++ b/dateutil/tz.py
@@ -19,7 +19,6 @@ from dateutil.tzcommon import tzname_in_python2
 try:
     from dateutil.tzwin import tzwin, tzwinlocal
 except ImportError:
-    print 'import error'
     tzwin = tzwinlocal = None
 
 relativedelta = None

--- a/dateutil/tz.py
+++ b/dateutil/tz.py
@@ -14,10 +14,12 @@ import sys
 import os
 
 from six import string_types, PY3
+from dateutil.tzcommon import tzname_in_python2
 
 try:
     from dateutil.tzwin import tzwin, tzwinlocal
 except ImportError:
+    print 'import error'
     tzwin = tzwinlocal = None
 
 relativedelta = None
@@ -27,25 +29,8 @@ rrule = None
 __all__ = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
            "tzstr", "tzical", "tzwin", "tzwinlocal", "gettz"]
 
-
-def tzname_in_python2(namefunc):
-    """Change unicode output into bytestrings in Python 2
-
-    tzname() API changed in Python 3. It used to return bytes, but was changed
-    to unicode strings
-    """
-    def adjust_encoding(*args, **kwargs):
-        name = namefunc(*args, **kwargs)
-        if name is not None and not PY3:
-            name = name.encode()
-
-        return name
-
-    return adjust_encoding
-
 ZERO = datetime.timedelta(0)
 EPOCHORDINAL = datetime.datetime.utcfromtimestamp(0).toordinal()
-
 
 class tzutc(datetime.tzinfo):
 

--- a/dateutil/tzcommon.py
+++ b/dateutil/tzcommon.py
@@ -1,0 +1,16 @@
+from six import PY3
+
+def tzname_in_python2(namefunc):
+    """Change unicode output into bytestrings in Python 2
+
+    tzname() API changed in Python 3. It used to return bytes, but was changed
+    to unicode strings
+    """
+    def adjust_encoding(*args, **kwargs):
+        name = namefunc(*args, **kwargs)
+        if name is not None and not PY3:
+            name = name.encode()
+
+        return name
+
+    return adjust_encoding

--- a/dateutil/tzwin.py
+++ b/dateutil/tzwin.py
@@ -4,7 +4,7 @@ import struct
 
 from six.moves import winreg
 
-from .tz import tzname_in_python2
+from dateutil.tzcommon import tzname_in_python2
 
 __all__ = ["tzwin", "tzwinlocal"]
 


### PR DESCRIPTION
Exported `tzname_in_python2` into another file `tzcommon.py` and imported it in `tz.py` and `tzwin.py`