### PR TITLE
rrulebase.before always returning None.

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -188,12 +188,12 @@ class rrulebase(object):
             for i in gen:
                 if i > dt:
                     break
-                last = i
+            last = i
         else:
             for i in gen:
                 if i >= dt:
                     break
-                last = i
+            last = i
         return last
 
     def after(self, dt, inc=False):


### PR DESCRIPTION
assignment after break in for loop causes "last" assignment to never be executed
