### PR TITLE
BLD: update versions of python supported

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ datetime module available in the Python standard library.
           'Programming Language :: Python :: 3.2',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
+          'Programming Language :: Python :: 3.5',
           'Topic :: Software Development :: Libraries',
       ],
       test_suite="dateutil.test"


### PR DESCRIPTION
@pganssle could only find the launchpad version before.  Merging this and tagging a new release should fix the pip problem

```
(/tmp/dummy)tcaswell@edill-810g:~$ pip install dateutil
Collecting dateutil
  Could not find a version that satisfies the requirement dateutil (from versions: )
No matching distribution found for dateutil
(/tmp/dummy)tcaswell@edill-810g:~$ python --version
Python 3.5.1 :: Continuum Analytics, Inc.

```