### PR TITLE
New rrule.replace method to create new rrule with modified attributes

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -751,6 +751,21 @@ class rrule(rrulebase):
         output.append(';'.join(parts))
         return '\n'.join(output)
 
+    def replace(self, **kwargs):
+        """Return new rrule with same attributes except for those attributes given new
+           values by whichever keyword arguments are specified."""
+        new_kwargs = {"interval": self._interval,
+                      "count": self._count,
+                      "dtstart": self._dtstart,
+                      "freq": self._freq,
+                      "until": self._until,
+                      "wkst": self._wkst,
+                      "cache": False if self._cache is None else True }
+        new_kwargs.update(self._original_rule)
+        new_kwargs.update(kwargs)
+        return rrule(**new_kwargs)
+
+
     def _iter(self):
         year, month, day, hour, minute, second, weekday, yearday, _ = \
             self._dtstart.timetuple()

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -4400,6 +4400,25 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                                   byweekno=long(2),
                                   dtstart=datetime(1997, 9, 2, 9, 0)))
 
+    def testReplaceIfSet(self):
+        rr = rrule(YEARLY,
+                   count=1,
+                   bymonthday=5,
+                   dtstart=datetime(1997, 1, 1))
+        newrr = rr.replace(bymonthday=6)
+        self.assertEqual(list(rr), [datetime(1997, 1, 5)])
+        self.assertEqual(list(newrr),
+                             [datetime(1997, 1, 6)])
+
+    def testReplaceIfNotSet(self):
+        rr = rrule(YEARLY,
+           count=1,
+           dtstart=datetime(1997, 1, 1))
+        newrr = rr.replace(bymonthday=6)
+        self.assertEqual(list(rr), [datetime(1997, 1, 1)])
+        self.assertEqual(list(newrr),
+                             [datetime(1997, 1, 6)])
+
 
 class RRuleSetTest(unittest.TestCase):
     def testSet(self):


### PR DESCRIPTION
Hi,
I've added replace method for creating new rrule with modified attributes. It is inspired by replace methods in python datetime library.