### PR TITLE
removed redundant description in rrule description

### DIFF
--- a/docs/rrule.rst
+++ b/docs/rrule.rst
@@ -1,7 +1,6 @@
 =====
 rrule
 =====
-The rrule module offers a small, complete, and very fast, implementation of the recurrence rules documented in the iCalendar RFC, including support for caching of results. 
 
 .. automodule:: dateutil.rrule
    :members:


### PR DESCRIPTION
The [source docstring](https://dateutil.readthedocs.org/en/latest/_modules/dateutil/rrule.html#rrule) already has the description and due to this there is a redundancy in the [docs](https://dateutil.readthedocs.org/en/latest/rrule.html#rrule). I dint want to mess with source code, hence i thought about removing the extra line from the docs. 

>This is my first contribution to open source, do let me know if I am doing anything wrong in here.