### PR TITLE
Retry logic for travis and appveyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ python:
 install:
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
-  - python updatezinfo.py
+  - ./ci_tools/retry.sh python updatezinfo.py
 script:
   - python setup.py test
 sudo: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,13 @@ environment:
     - PYTHON: "C:/Python35"
     - PYTHON: "C:/Python35-x64"
 install:
-  - ps: Start-FileDownload 'https://raw.github.com/pypa/pip/master/contrib/get-pip.py'
+  - ps: Start-FileDownload 'https://bootstrap.pypa.io/get-pip.py'
   - "%PYTHON%/python.exe get-pip.py"
   - "%PYTHON%/Scripts/pip.exe install six"
   # use postgres' zic
   - set path=c:\Program Files\PostgreSQL\9.3\bin\;%PATH%
-  - "%PYTHON%/python.exe updatezinfo.py"
+  # This frequently fails with network errors, so we'll retry it up to 5 times
+  # with a 1 minute rate limit.
+  - "ci_tools/retry.bat %PYTHON%/python.exe updatezinfo.py"
 test_script:
   - "%PYTHON%/python.exe setup.py test"

--- a/ci_tools/retry.bat
+++ b/ci_tools/retry.bat
@@ -1,0 +1,18 @@
+@echo off
+REM This script takes a command and retries it a few times if it fails, with a
+REM timeout between each retry.
+
+setlocal EnableDelayedExpansion
+
+REM Loop at most n_retries times, waiting sleep_time times between
+set sleep_time=60
+set n_retries=5
+
+for /l %%x in (1, 1, %n_retries%) do (
+  call %*
+  if not ERRORLEVEL 1 EXIT /B 0
+  timeout /t %sleep_time% /nobreak > nul
+)
+
+REM If it failed all n_retries times, we can give up at last.
+EXIT /B 1

--- a/ci_tools/retry.sh
+++ b/ci_tools/retry.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+sleep_time=60
+n_retries=5
+
+for i in `seq 1 $n_retries`; do
+    "$@" && exit 0
+    sleep $sleep_time
+done
+
+exit 1


### PR DESCRIPTION
A partial mitigation of #176, adding retry logic to the `updatezinfo.py` script.

A next step (not necessarily to be done before the 2.5.0 release (#169) is to host our own mirror of all the tzdata files on HTTPS. I suspect part of the issue might be that we're downloading over ftp, which seems to be a bit finicky when I played with it using `ftplib`.