### PR TITLE
Add tzinfo compatibility with non-datetime times

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from datetime import datetime, timedelta
+from datetime import time as dt_time
 from six import BytesIO, StringIO
 
 import os
@@ -280,7 +281,6 @@ class TZTest(unittest.TestCase):
         self.assertIs(datetime(2003, 10, 26, 0, 0, tzinfo=gmt5).tzname(),
                       None)
 
-
     def testICalStart1(self):
         tz = tzical(StringIO(TZICAL_EST5EDT)).get()
         self.assertEqual(datetime(2003, 4, 6, 1, 59, tzinfo=tz).tzname(), "EST")
@@ -329,6 +329,34 @@ class TZTest(unittest.TestCase):
         self.assertEqual(dt.astimezone(tz=gettz("UTC-2")),
                           datetime(2007, 8, 6, 2, 10, tzinfo=tzstr("UTC-2")))
 
+    def testTimeOnlyUTC(self):
+        # https://github.com/dateutil/dateutil/issues/132
+        # tzutc doesn't care
+        tz_utc = tzutc()
+        self.assertEqual(dt_time(13, 20, tzinfo=tz_utc).utcoffset(),
+                         timedelta(0))
+
+    def testTimeOnlyOffset(self):
+        # tzoffset doesn't care
+        tz_offset = tzoffset('+3', 3600)
+        self.assertEqual(dt_time(13, 20, tzinfo=tz_offset).utcoffset(),
+                         timedelta(seconds=3600))
+
+    def testTimeOnlyLocal(self):
+        # tzlocal returns None
+        tz_local = tzlocal()
+        self.assertIs(dt_time(13, 20, tzinfo=tz_local).utcoffset(), None)
+
+    def testTimeOnlyRange(self):
+        # tzrange returns None
+        tz_range = tzrange('dflt')
+        self.assertIs(dt_time(13, 20, tzinfo=tz_range).utcoffset(), None)
+
+    def testTimeOnlyGettz(self):
+        # gettz returns None
+        tz_get = gettz('Europe/Minsk')
+        self.assertIs(dt_time(13, 20, tzinfo=tz_get).utcoffset(), None)
+
     @unittest.skipIf(IS_WIN, "requires Unix")
     def testTZSetDoesntCorrupt(self):
         # if we start in non-UTC then tzset UTC make sure parse doesn't get
@@ -374,5 +402,4 @@ class TzWinTest(unittest.TestCase):
         datetime.now(tzwin.tzwinlocal())
 
         datetime(2014, 3, 11, tzinfo=tzwin.tzwinlocal()).utcoffset()
-
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -93,6 +93,9 @@ class tzlocal(datetime.tzinfo):
             self._dst_offset = self._std_offset
 
     def utcoffset(self, dt):
+        if dt is None:
+            return dt
+
         if self._isdst(dt):
             return self._dst_offset
         else:
@@ -439,6 +442,9 @@ class tzfile(datetime.tzinfo):
             return self._trans_idx[idx-1]
 
     def utcoffset(self, dt):
+        if dt is None:
+            return None
+
         if not self._ttinfo_std:
             return ZERO
         return self._find_ttinfo(dt).delta
@@ -518,6 +524,9 @@ class tzrange(datetime.tzinfo):
             self._end_delta = end
 
     def utcoffset(self, dt):
+        if dt is None:
+            return None
+
         if self._isdst(dt):
             return self._dst_offset
         else:
@@ -699,6 +708,9 @@ class _tzicalvtz(datetime.tzinfo):
         return lastcomp
 
     def utcoffset(self, dt):
+        if dt is None:
+            return None
+
         return self._find_comp(dt).tzoffsetto
 
     def dst(self, dt):


### PR DESCRIPTION
Fixes #132. I don't think the tests here are compatible with the #180 stack because I changed how `dateutil.tz` is imported, so when those are merged, I'll rebase and clean up. 