### PR TITLE
Bump metadata version to 2.0, add support for tzdata mirrors.

### DIFF
--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -5,6 +5,7 @@ import json
 import io
 
 from six.moves.urllib import request
+from six.moves.urllib import error as urllib_error
 
 from dateutil.zoneinfo import rebuild
 
@@ -15,11 +16,30 @@ def main():
     with io.open(METADATA_FILE, 'r') as f:
         metadata = json.load(f)
 
+    releases_urls = metadata['releases_url']
+    if metadata['metadata_version'] < 2.0:
+        # In later versions the releases URL is a mirror URL
+        releases_urls = [releases_urls]
+
     if not os.path.isfile(metadata['tzdata_file']):
-        print("Downloading tz file from iana")
-        request.urlretrieve(os.path.join(metadata['releases_url'],
-                                         metadata['tzdata_file']),
-                            metadata['tzdata_file'])
+
+        for ii, releases_url in enumerate(releases_urls):
+            print("Downloading tz file from mirror {ii}".format(ii=ii))
+            try:
+                request.urlretrieve(os.path.join(releases_url,
+                                                 metadata['tzdata_file']),
+                                    metadata['tzdata_file'])
+            except urllib_error.URLError as e:
+                print("Download failed, trying next mirror.")
+                last_error = e
+                continue
+
+            last_error = None
+            break
+
+        if last_error is not None:
+            raise last_error
+
     with open(metadata['tzdata_file'], 'rb') as tzfile:
         sha_hasher = hashlib.sha512()
         sha_hasher.update(tzfile.read())

--- a/zonefile_metadata.json
+++ b/zonefile_metadata.json
@@ -1,10 +1,13 @@
 {
-    "metadata_version" : 1.0,
-    "releases_url" : "ftp://ftp.iana.org/tz/releases/",
-    "tzversion": "2015d",
-    "tzdata_file" : "tzdata2015d.tar.gz",
-    "tzdata_file_sha512" : "37b5aa3c5e0d601c8b20fac08d7267c398a836e4190ef85625d5e86a806ba1baceb2315ba81a9a6c854eae4fce40e9c8f90cf5adade3f48ad443f77c221d8983",
-    "zonegroups" : [
+    "metadata_version": 2.0,
+    "releases_url": [
+        "https://dateutil.github.io/tzdata/tzdata/",
+        "ftp://ftp.iana.org/tz/releases/"
+    ],
+    "tzdata_file": "tzdata2016a.tar.gz",
+    "tzdata_file_sha512": "9aa5f61a73afa5070dfb1d1982945d268ea8215663d0cd594216500aff14797ea5591ccfd488dc2280902fa1820bf782623624912b669873728431258fe10ec1",
+    "tzversion": "2016a",
+    "zonegroups": [
         "africa",
         "antarctica",
         "asia",
@@ -17,6 +20,6 @@
         "systemv",
         "factory",
         "backzone",
-        "backward"]
+        "backward"
+    ]
 }
-


### PR DESCRIPTION
I've created a mirror of the IANA database on a [github pages repository](https://dateutil.github.io/tzdata/). This is the first step in having a separate update channel between the code and the tzdata files. For now, having an HTTPS mirror of the tzdata tarball should help to further alleviate the CI failure issues.