### PR TITLE
Add REPR and comparison functionality to tzwinlocal

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -489,3 +489,19 @@ class TzWinTest(unittest.TestCase):
             for t_date, expected in transition_dates:
                 self.assertEqual(t_date.replace(tzinfo=tw).tzname(), expected)
 
+    @unittest.skipUnless(TZWinContext.tz_change_allowed(),
+        'Skipping unless tz changes are allowed.')
+    def testTzwinLocalRepr(self):
+        # https://github.com/dateutil/dateutil/issues/143
+        with TZWinContext('Eastern Standard Time'):
+            tw = tz.tzwinlocal()
+
+            self.assertEqual(repr(tw), 'tzwinlocal(Eastern Standard Time)')
+
+        with TZWinContext('Pacific Standard Time'):
+            tw = tz.tzwinlocal()
+
+            self.assertEqual(repr(tw), 'tzwinlocal(Pacific Standard Time)')
+
+
+

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -143,11 +143,9 @@ class tzlocal(datetime.tzinfo):
         return time.localtime(timestamp+time.timezone).tm_isdst
 
     def __eq__(self, other):
-        if not isinstance(other, tzlocal):
-            return False
-        return (self._std_offset == other._std_offset and
-                self._dst_offset == other._dst_offset)
-        return True
+        return (isinstance(other, tzlocal) and
+                (self._std_offset == other._std_offset and
+                 self._dst_offset == other._dst_offset))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -112,6 +112,25 @@ class tzres(object):
 
 class tzwinbase(datetime.tzinfo):
     """tzinfo class based on win32's timezones available in the registry."""
+    def __eq__(self, other):
+        # Compare on all relevant dimensions, including name.
+        return (isinstance(other, tzwinbase) and
+                (self._stdoffset == other._stdoffset and
+                 self._dstoffset == other._dstoffset and
+                 self._stddayofweek == other._stddayofweek and
+                 self._dstdayofweek == other._dstdayofweek and
+                 self._stdweeknumber == other._stdweeknumber and
+                 self._dstweeknumber == other._dstweeknumber and
+                 self._stdhour == other._stdhour and
+                 self._dsthour == other._dsthour and
+                 self._stdminute == other._stdminute and
+                 self._dstminute == other._dstminute and
+                 self._stdname == other._stdname and
+                 self._dstname == other._dstname))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def utcoffset(self, dt):
         if self._isdst(dt):
             return datetime.timedelta(minutes=self._dstoffset)

--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -245,7 +245,11 @@ class tzwinlocal(tzwinbase):
          self._dstminute) = tup[1:5]
 
         self._dstdayofweek = tup[7]
-        
+
+    def __repr__(self):
+        # Repr will return the standard name, not the daylight name.
+        return "tzwinlocal({twl_name})".format(twl_name=self._stdname)
+
     def __reduce__(self):
         return (self.__class__, ())
 


### PR DESCRIPTION
This is a combination of PRs #179 and #180 because of some funkiness with the rebase that was muddying up the git history. It fixes Issues #148 and #151.

#### PR #179 - Add REPR functionality to tzwinlocal
Built off #178 for convenience, this adds `__repr__` functionality to `tzwinlocal()`. The 'StandardName' will be used for all repr (this does not affect tzname()).

Fixes #148.

#### PR #180 - Add comparison functionality to tzwin objects
I will note that even if the tzwin objects are identical on all relevant characteristics (i.e. they represent the exact same offset at all times), they will compare unequal if their names are different. Not sure how I feel about this, but it seems like the best way to go in terms of least surprise.

Fixes #151.