### PR TITLE
Rolled back smart_defaults and fallback_on_invalid_dates modifications to parser

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -13,22 +13,8 @@ of a date/time stamp is omitted, the following rules are applied:
 
 If any other elements are missing, they are taken from the
 :class:`datetime.datetime` object passed to the parameter ``default``. If this
-results in a day number exceeding the valid number of days per month, one can
-fall back to the last day of the month by setting ``fallback_on_invalid_day``
-parameter to ``True``.
-
-Also provided is the ``smart_defaults`` option, which attempts to fill in the
-missing elements from context. If specified, the logic is:
-- If the omitted element is smaller than the largest specified element, select
-  the *earliest* time matching the specified conditions; so ``"June 2010"`` is
-  interpreted as ``June 1, 2010 0:00:00``) and the (somewhat strange)
-  ``"Feb 1997 3:15 PM"`` is interpreted as ``February 1, 1997 15:15:00``.
-- If the element is larger than the largest specified element, select the
-  *most recent* time matching the specified conditions (e.g parsing ``"May"``
-  in June 2015 returns the date May 1st, 2015, whereas parsing it in April 2015
-  returns May 1st 2014). If using the ``date_in_future`` flag, this logic is
-  inverted, and instead the *next* time matching the specified conditions is
-  returned.
+results in a day number exceeding the valid number of days per month, the
+value falls back to the end of the month.
 
 Additional resources about date/time string formats can be found below:
 
@@ -290,7 +276,7 @@ class parserinfo(object):
     PERTAIN = ["of"]
     TZOFFSET = {}
 
-    def __init__(self, dayfirst=False, yearfirst=False, smart_defaults=False):
+    def __init__(self, dayfirst=False, yearfirst=False):
         self._jump = self._convert(self.JUMP)
         self._weekdays = self._convert(self.WEEKDAYS)
         self._months = self._convert(self.MONTHS)
@@ -301,7 +287,6 @@ class parserinfo(object):
 
         self.dayfirst = dayfirst
         self.yearfirst = yearfirst
-        self.smart_defaults = smart_defaults
 
         self._year = time.localtime().tm_year
         self._century = self._year // 100 * 100
@@ -494,9 +479,7 @@ class parser(object):
     def __init__(self, info=None):
         self.info = info or parserinfo()
 
-    def parse(self, timestr, default=None, ignoretz=False, tzinfos=None,
-              smart_defaults=None, date_in_future=False, 
-              fallback_on_invalid_day=None, **kwargs):
+    def parse(self, timestr, default=None, ignoretz=False, tzinfos=None, **kwargs):
         """
         Parse the date/time string into a :class:`datetime.datetime` object.
 
@@ -506,36 +489,7 @@ class parser(object):
         :param default:
             The default datetime object, if this is a datetime object and not
             ``None``, elements specified in ``timestr`` replace elements in the
-            default object, unless ``smart_defaults`` is set to ``True``, in
-            which case to the extent necessary, timestamps are calculated
-            relative to this date.
-
-        :param smart_defaults:
-            If using smart defaults, the ``default`` parameter is treated as
-            the effective parsing date/time, and the context of the datetime
-            string is determined relative to ``default``. If ``None``, this
-            parameter is inherited from the :class:`parserinfo` object.
-
-        :param date_in_future:
-            If ``smart_defaults`` is ``True``, the parser assumes by default
-            that the timestamp refers to a date in the past, and will return
-            the beginning of the most recent timespan which matches the time
-            string (e.g. if ``default`` is March 3rd, 2013,  "Feb" parses to
-            "Feb 1, 2013" and "May 3" parses to May 3rd, 2012). Setting this
-            parameter to ``True`` inverts this assumption, and returns the
-            beginning of the *next* matching timespan.
-
-        :param fallback_on_invalid_day:
-            If specified ``True``, an otherwise invalid date such as "Feb 30"
-            or "June 32" falls back to the last day of the month. If specified
-            as "False", the parser is strict about parsing otherwise valid
-            dates that would turn up as invalid because of the fallback rules
-            (e.g. "Feb 2010" run with a default of January 30, 2010 and
-            ``smartparser`` set to ``False`` would would throw an error, rather
-            than falling back to the end of February). If ``None`` or
-            unspecified, the date falls back to the most recent valid date only
-            if the invalid date is created as a result of an unspecified day in
-            the time string.
+            default object.
 
         :param ignoretz:
             If set ``True``, time zones in parsed strings are ignored and a
@@ -585,9 +539,6 @@ class parser(object):
             your system.
         """
 
-        if smart_defaults is None:
-            smart_defaults = self.info.smart_defaults
-
         if default is None:
             effective_dt = datetime.datetime.now()
             default = datetime.datetime.now().replace(hour=0, minute=0,
@@ -610,72 +561,7 @@ class parser(object):
             if value is not None:
                 repl[attr] = value
 
-        # Choose the correct fallback position if requested by the
-        # ``smart_defaults`` parameter.
-        if smart_defaults:
-            # Determine if it refers to this year, last year or next year
-            if res.year is None:
-                if res.month is not None:
-                    # Explicitly deal with leap year problems
-                    if res.month == 2 and (res.day is not None and
-                                           res.day == 29):
-
-                        ly_offset = 4 if date_in_future else -4
-                        next_year = 4 * (default.year // 4)
-
-                        if date_in_future:
-                            next_year += ly_offset
-
-                        if not isleap(next_year):
-                            next_year += ly_offset
-
-                        if not isleap(default.year):
-                            default = default.replace(year=next_year)
-                    elif date_in_future:
-                        next_year = default.year + 1
-                    else:
-                        next_year = default.year - 1
-
-                    if ((res.month == default.month and res.day is not None and
-                         ((res.day < default.day and date_in_future) or
-                          (res.day > default.day and not date_in_future))) or
-                        ((res.month < default.month and date_in_future) or
-                         (res.month > default.month and not date_in_future))):
-
-                        default = default.replace(year=next_year)
-
-            # Select a proper month
-            if res.month is None:
-                if res.year is not None:
-                    default = default.replace(month=1)
-
-                # I'm not sure if this is even possible.
-                if res.day is not None:
-                    if res.day < default.day and date_in_future:
-                        default += datetime.timedelta(months=1)
-                    elif res.day > default.day and not date_in_future:
-                        default -= datetime.timedelta(months=1)
-
-            if res.day is None:
-                # Determine if it's today, tomorrow or yesterday.
-                if res.year is None and res.month is None:
-                    t_repl = {}
-                    for key, val in repl.iteritems():
-                        if key in ('hour', 'minute', 'second', 'microsecond'):
-                            t_repl[key] = val
-
-                    stime = effective_dt.replace(**t_repl)
-
-                    if stime < effective_dt and date_in_future:
-                        default += datetime.timedelta(days=1)
-                    elif stime > effective_dt and not date_in_future:
-                        default -= datetime.timedelta(days=1)
-                else:
-                    # Otherwise it's the beginning of the month
-                    default = default.replace(day=1)
-
-        if fallback_on_invalid_day or (fallback_on_invalid_day is None and
-                                       'day' not in repl):
+        if 'day' not in repl:
             # If the default day exceeds the last day of the month, fall back to
             # the end of the month.
             cyear = default.year if res.year is None else res.year

--- a/dateutil/test/test.py
+++ b/dateutil/test/test.py
@@ -5354,6 +5354,13 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("10 h 36", default=self.default),
                          datetime(2003, 9, 25, 10, 36))
 
+    def testAMPMNoHour(self):
+        with self.assertRaises(ValueError):
+            parse("AM")
+
+        with self.assertRaises(ValueError):
+            parse("Jan 20, 2015 PM")
+
     def testHourAmPm1(self):
         self.assertEqual(parse("10h am", default=self.default),
                          datetime(2003, 9, 25, 10))
@@ -5401,6 +5408,13 @@ class ParserTest(unittest.TestCase):
     def testHourAmPm12(self):
         self.assertEqual(parse("10:00p.m.", default=self.default),
                          datetime(2003, 9, 25, 22))
+
+    def testAMPMRange(self):
+        with self.assertRaises(ValueError):
+            parse("13:44 AM")
+
+        with self.assertRaises(ValueError):
+            parse("January 25, 1921 23:13 PM")
 
     def testPertain(self):
         self.assertEqual(parse("Sep 03", default=self.default),
@@ -5454,6 +5468,11 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse(s2, fuzzy=True), datetime(2020, 6, 8))
         self.assertEqual(parse(s3, fuzzy=True), datetime(2003, 12, 3, 3))
         self.assertEqual(parse(s4, fuzzy=True), datetime(2003, 12, 3, 3))
+
+    def testFuzzyIgnoreAMPM(self):
+        s1 = "Jan 29, 1945 14:45 AM I going to see you there?"
+
+        self.assertEqual(parse(s1, fuzzy=True), datetime(1945, 1, 29, 14, 45))
 
     def testExtraSpace(self):
         self.assertEqual(parse("  July   4 ,  1976   12:01:02   am  "),
@@ -5605,162 +5624,20 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse('0031-01-01T00:00:00'),
                          datetime(31, 1, 1, 0, 0))
 
-    # Test that if a year is omitted, we use the most recent matching value
-    def testSmartDefaultsNoYearMonthEarlier(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 5, 1),
-                               smart_defaults=True), 
-                         datetime(2013, 8, 3))
+    def testInvalidDay(self):
+        with self.assertRaises(ValueError):
+            parse("Feb 30, 2007")
 
-    def testSmartDefaultsNoYearDayEarlier(self):        
-        self.assertEqual(parse("August 3", default=datetime(2014, 8, 1),
-                               smart_defaults=True), 
-                         datetime(2013, 8, 3))
-
-    def testSmartDefaultsNoYearSameDay(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 8, 3),
-                               smart_defaults=True), 
-                         datetime(2014, 8, 3))
-
-    def testSmartDefaultsNoYearDayLater(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 8, 4),
-                               smart_defaults=True), 
-                         datetime(2014, 8, 3))
-    
-    def testSmartDefaultsNoYearMonthLater(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 12, 19),
-                               smart_defaults=True), 
-                         datetime(2014, 8, 3))
-
-    def testSmartDefaultsNoYearFeb29(self):
-        self.assertEqual(parse("February 29", default=datetime(2014, 12, 19),
-                               date_in_future=False, smart_defaults=True),
-                         datetime(2012, 2, 29))
-
-    def testSmartDefaultsNoYearFeb29Y2100(self):
-        # Year 2000 was not a leap year.
-        self.assertEqual(parse("February 29", default=datetime(2100, 12, 19),
-                               smart_defaults=True),
-                         datetime(2096, 2, 29))
-
-    # Test that if a year is omitted, we use the most next matching value
-    def testSmartDefaultsNoYearFutureDayEarlier(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 5, 1),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2014, 8, 3))
-
-    def testSmartDefaultsNoYearFutureMonthEarlier(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 8, 1),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2014, 8, 3))
-
-    def testSmartDefaultsNoYearFutureSameDay(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 8, 3),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2014, 8, 3))
-
-    def testSmartDefaultsNoYearFutureDayLater(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 8, 4),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2015, 8, 3))
-    
-    def testSmartDefaultsNoYearFutureMonthLater(self):
-        self.assertEqual(parse("August 3", default=datetime(2014, 12, 19),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2015, 8, 3))
-
-    def testSmartDefaultsNoYearFutureFeb29Y2100(self):
-        self.assertEqual(parse("February 29", default=datetime(2098, 12, 19),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2104, 2, 29))
-
-    # Test that if only a month is provided, we select the beginning of the most recent
-    # occurrence of the specified month
-    def testSmartDefaultsMonthOnlyMonthEarlier(self):
-        self.assertEqual(parse("September", default=datetime(2014, 5, 1),
-                               smart_defaults=True),
-                         datetime(2013, 9, 1))
-
-    def testSmartDefaultsMonthOnlySameMonthFirstDay(self):
-        self.assertEqual(parse("September", default=datetime(2014, 9, 1),
-                               smart_defaults=True),
-                         datetime(2014, 9, 1))
-
-    def testSmartDefaultsMonthOnlySameMonthLastDay(self):
-        self.assertEqual(parse("September", default=datetime(2014, 9, 30),
-                               smart_defaults=True),
-                         datetime(2014, 9, 1))
-
-    def testSmartDefaultMonthOnlyMonthLater(self):
-        self.assertEqual(parse("September", default=datetime(2014, 11, 1),
-                               smart_defaults=True),
-                         datetime(2014, 9, 1))
-
-    # Test that if only a month is provided, we select the beginning of the most recent
-    # occurrence of the specified month
-    def testSmartDefaultsMonthOnlyFutureMonthEarlier(self):
-        self.assertEqual(parse("September", default=datetime(2014, 5, 1),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2014, 9, 1))
-
-    def testSmartDefaultsMonthOnlyFutureSameMonthFirstDay(self):
-        self.assertEqual(parse("September", default=datetime(2014, 9, 1),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2014, 9, 1))
-
-    def testSmartDefaultsMonthOnlyFutureSameMonthLastDay(self):
-        self.assertEqual(parse("September", default=datetime(2014, 9, 30),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2014, 9, 1))
-    
-    def testSmartDefaultsMonthOnlyFutureMonthLater(self):
-        self.assertEqual(parse("September", default=datetime(2014, 11, 1),
-                               date_in_future=True, smart_defaults=True),
-                         datetime(2015, 9, 1))
-
-    # Test to ensure that if a year is specified, January 1st of that year is
-    # returned.
-    def testSmartDefaultsYearOnly(self):
-        self.assertEqual(parse("2009", smart_defaults=True),
-                         datetime(2009, 1, 1))
-
-    def testSmartDefaultsYearOnlyFuture(self):
-        self.assertEqual(parse("2009", smart_defaults=True,
-                               date_in_future=True),
-                         datetime(2009, 1, 1))
-
-    # Tests that invalid days fall back to the end of the month if that's
-    # the desired behavior.
-    def testInvalidDayNoFallback(self):
-        self.assertRaises(ValueError, parse, "Feb 30, 2007",
-                          **{'fallback_on_invalid_day':False})
-
-    def testInvalidDayFallbackFebNoLeapYear(self):
-        self.assertEqual(parse("Feb 31, 2007", fallback_on_invalid_day=True),
-                         datetime(2007, 2, 28))
-
-    def testInvalidDayFallbackFebLeapYear(self):
-        self.assertEqual(parse("Feb 31, 2008", fallback_on_invalid_day=True),
-                         datetime(2008, 2, 29))
-
-    def testUnspecifiedDayNoFallback(self):
-        self.assertRaises(ValueError, parse, "April 2009",
-                          **{'fallback_on_invalid_day':False,
-                             'default':datetime(2010, 1, 31)})
-
-    def testUnspecifiedDayUnspecifiedFallback(self):
+    def testUnspecifiedDayFallback(self):
+        # Test that for an unspecified day, the fallback behavior is correct.
         self.assertEqual(parse("April 2009", default=datetime(2010, 1, 31)),
                          datetime(2009, 4, 30))
 
-    def testUnspecifiedDayUnspecifiedFallback(self):
-        self.assertEqual(parse("April 2009", fallback_on_invalid_day=True,
-                               default=datetime(2010, 1, 31)),
-                         datetime(2009, 4, 30))
-
-    def testUnspecifiedDayUnspecifiedFallbackFebNoLeapYear(self):        
+    def testUnspecifiedDayFallbackFebNoLeapYear(self):        
         self.assertEqual(parse("Feb 2007", default=datetime(2010, 1, 31)),
                          datetime(2007, 2, 28))
 
-    def testUnspecifiedDayUnspecifiedFallbackFebLeapYear(self):        
+    def testUnspecifiedDayFallbackFebLeapYear(self):        
         self.assertEqual(parse("Feb 2008", default=datetime(2010, 1, 31)),
                          datetime(2008, 2, 29))
 


### PR DESCRIPTION
Rolling back `smart_defaults` and `fallback_on_invalid_date` introduced in PR #30, My explanation for this is found in Issue #169:

> In the time since adding this, I've been thinking we may want to implement this differently, and I don't want to get stuck maintaining API compatibility. (This should automatically fix #126 for the release, but that should also be updated on the feature branch). I think this should be re-implemented with a combination of #125 and breaking up `parse` into smaller, customizable functions.

Since these features have not been included in a public release yet, hopefully it will not break anyone's dependencies here.