### PR TITLE
Add __pycache__ & py[co] exclusions to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,4 @@
 include LICENSE NEWS zonefile_metadata.json updatezinfo.py
-include dateutil/test/*.py
+recursive-include dateutils/test/ *
+global-exclude __pycache__
+global-exclude *.py[co]


### PR DESCRIPTION
Ensure binary, compiled files and cache directories are not included in generated source distributions (sdist)

While I'm here, tweak include directive for tests to ensure all test/ directory files are included in the future, no matter what extension they have

See https://github.com/dateutil/dateutil/commit/f6b45501f41f74bf9579606d5ff87587f48f9fe4 commit comments