### PR TITLE
Rearrange .tz module to fix import error

### DIFF
--- a/dateutil/tz/__init__.py
+++ b/dateutil/tz/__init__.py
@@ -1,20 +1,4 @@
 from .tz import *
-from six import PY3
 
 __all__ = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
            "tzstr", "tzical", "tzwin", "tzwinlocal", "gettz"]
-
-def tzname_in_python2(namefunc):
-    """Change unicode output into bytestrings in Python 2
-
-    tzname() API changed in Python 3. It used to return bytes, but was changed
-    to unicode strings
-    """
-    def adjust_encoding(*args, **kwargs):
-        name = namefunc(*args, **kwargs)
-        if name is not None and not PY3:
-            name = name.encode()
-
-        return name
-
-    return adjust_encoding

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -1,0 +1,18 @@
+from six import PY3
+
+__all__ = ['tzname_in_python2']
+
+def tzname_in_python2(namefunc):
+    """Change unicode output into bytestrings in Python 2
+
+    tzname() API changed in Python 3. It used to return bytes, but was changed
+    to unicode strings
+    """
+    def adjust_encoding(*args, **kwargs):
+        name = namefunc(*args, **kwargs)
+        if name is not None and not PY3:
+            name = name.encode()
+
+        return name
+
+    return adjust_encoding

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -14,7 +14,7 @@ import sys
 import os
 
 from six import string_types, PY3
-from .__init__ import tzname_in_python2
+from ._common import tzname_in_python2
 
 try:
     from .win import tzwin, tzwinlocal

--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -11,7 +11,7 @@ except ValueError:
     # ValueError is raised on non-Windows systems for some horrible reason.
     raise ImportError("Running tzwin on non-Windows system")
 
-from .__init__ import tzname_in_python2
+from ._common import tzname_in_python2
 
 __all__ = ["tzwin", "tzwinlocal", "tzres"]
 


### PR DESCRIPTION
This adjusts the import scheme for `tz` per the discussion in PR #202 (which solves pyinstaller/pyinstaller#1848). See the discussion there with @htgoebel.

This scheme is closer to the one originally implemented in @labrys's PR.