### PR TITLE
Explicitly throw error in rrulestr on empty BYDAY

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -1418,7 +1418,7 @@ class _rrulestr(object):
                 splt = wday.split('(')
                 w = splt[0]
                 n = int(splt[1][:-1])
-            else:
+            elif len(wday):
                 # If it's of the form +1MO
                 for i in range(len(wday)):
                     if wday[i] not in '+-0123456789':
@@ -1427,6 +1427,9 @@ class _rrulestr(object):
                 w = wday[i:]
                 if n:
                     n = int(n)
+            else:
+                raise ValueError("Invalid (empty) BYDAY specification.")
+
             l.append(weekdays[self._weekday_map[w]](n))
         rrkwargs["byweekday"] = l
 

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -2826,6 +2826,19 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                           "RRULE:FREQ=YEARLY;"
                           "UNTIL=TheCowsComeHome;BYDAY=1TU,-1TH\n"))
 
+    def testStrEmptyByDay(self):
+        with self.assertRaises(ValueError):
+            list(rrulestr("DTSTART:19970902T090000\n"
+                          "FREQ=WEEKLY;"
+                          "BYDAY=;"         # This part is invalid
+                          "WKST=SU"))
+
+    def testStrInvalidByDay(self):
+        with self.assertRaises(ValueError):
+            list(rrulestr("DTSTART:19970902T090000\n"
+                          "FREQ=WEEKLY;"
+                          "BYDAY=-1OK;"         # This part is invalid
+                          "WKST=SU"))
 
     def testBadBySetPos(self):
         self.assertRaises(ValueError,


### PR DESCRIPTION
Fixes #162.

If `BYDAY` is not specified in an `rrulestr`, a `VaueError` is explicitly thrown (rather than the `UnboundLocalError` or whatever that was happening before.