### PR TITLE
Refactor relativedelta a bit, improve test coverage.

### DIFF
--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -176,16 +176,10 @@ class relativedelta(object):
                 compare = operator.lt
                 increment = -1
 
-            ii = 0
             while compare(dt1, dtm):
                 months += increment
                 self._set_months(months)
                 dtm = self.__radd__(dt2)
-                ii += 1
-                if ii > 1:
-                    print('ii == {}'.format(ii))
-                    print(dt1)
-                    print(dt2)
 
             # Get the timedelta between the "months-adjusted" date and dt1
             delta = dt1 - dtm

--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -2,6 +2,9 @@
 import datetime
 import calendar
 
+import operator
+from math import copysign
+
 from six import integer_types
 from warnings import warn
 
@@ -157,19 +160,34 @@ class relativedelta(object):
             self.microsecond = None
             self._has_time = 0
 
-            months = (dt1.year * 12 + dt1.month) - (dt2.year * 12 + dt2.month)
+            # Get year / month delta between the two
+            months = (dt1.year - dt2.year) * 12 + (dt1.month - dt2.month)
             self._set_months(months)
+
+            # Remove the year/month delta so the timedelta is just well-defined
+            # time units (seconds, days and microseconds)
             dtm = self.__radd__(dt2)
+
+            # If we've overshot our target, make an adjustment
             if dt1 < dt2:
-                while dt1 > dtm:
-                    months += 1
-                    self._set_months(months)
-                    dtm = self.__radd__(dt2)
+                compare = operator.gt
+                increment = 1
             else:
-                while dt1 < dtm:
-                    months -= 1
-                    self._set_months(months)
-                    dtm = self.__radd__(dt2)
+                compare = operator.lt
+                increment = -1
+
+            ii = 0
+            while compare(dt1, dtm):
+                months += increment
+                self._set_months(months)
+                dtm = self.__radd__(dt2)
+                ii += 1
+                if ii > 1:
+                    print('ii == {}'.format(ii))
+                    print(dt1)
+                    print(dt2)
+
+            # Get the timedelta between the "months-adjusted" date and dt1
             delta = dt1 - dtm
             self.seconds = delta.seconds + delta.days * 86400
             self.microseconds = delta.microseconds
@@ -193,7 +211,6 @@ class relativedelta(object):
             self.second = second
             self.microsecond = microsecond
 
-                        # Absolute information
             if any(x is not None and int(x) != x
                    for x in (year, month, day, hour,
                              minute, second, microsecond)):
@@ -233,27 +250,27 @@ class relativedelta(object):
 
     def _fix(self):
         if abs(self.microseconds) > 999999:
-            s = self.microseconds // abs(self.microseconds)
+            s = _sign(self.microseconds)
             div, mod = divmod(self.microseconds * s, 1000000)
             self.microseconds = mod * s
             self.seconds += div * s
         if abs(self.seconds) > 59:
-            s = self.seconds // abs(self.seconds)
+            s = _sign(self.seconds)
             div, mod = divmod(self.seconds * s, 60)
             self.seconds = mod * s
             self.minutes += div * s
         if abs(self.minutes) > 59:
-            s = self.minutes//abs(self.minutes)
+            s = _sign(self.minutes)
             div, mod = divmod(self.minutes * s, 60)
             self.minutes = mod * s
             self.hours += div * s
         if abs(self.hours) > 23:
-            s = self.hours//abs(self.hours)
+            s = _sign(self.hours)
             div, mod = divmod(self.hours * s, 24)
             self.hours = mod * s
             self.days += div * s
         if abs(self.months) > 11:
-            s = self.months // abs(self.months)
+            s = _sign(self.months)
             div, mod = divmod(self.months * s, 12)
             self.months = mod * s
             self.years += div * s
@@ -274,10 +291,10 @@ class relativedelta(object):
     def _set_months(self, months):
         self.months = months
         if abs(self.months) > 11:
-            s = self.months//abs(self.months)
-            div, mod = divmod(self.months*s, 12)
-            self.months = mod*s
-            self.years = div*s
+            s = _sign(self.months)
+            div, mod = divmod(self.months * s, 12)
+            self.months = mod * s
+            self.years = div * s
         else:
             self.years = 0
 
@@ -512,5 +529,8 @@ class relativedelta(object):
                 l.append("{attr}={value}".format(attr=attr, value=repr(value)))
         return "{classname}({attrs})".format(classname=self.__class__.__name__,
                                              attrs=", ".join(l))
+
+def _sign(x):
+    return int(copysign(1, x))
 
 # vim:ts=4:sw=4:et


### PR DESCRIPTION
I've improved the test coverage on the `relativedelta` module, and while I was in there I did some refactoring to make the code a bit more readable.

I should note that I did not add any tests for the `weekday` objects, because that already has good test coverage in the `rrule` module, and will eventually be moved into a common file to prevent code duplication.

I also deliberately didn't add a test for [this `TypeError`](https://github.com/dateutil/dateutil/blob/master/dateutil/relativedelta.py#L131) - I think it is considered an antipattern to explicitly check inheritance like that (rather than duck-typing), so I didn't want to "endorse" this behavior that may go away.