### PR TITLE
Fix issue with MANIFEST.in test inclusion.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include LICENSE NEWS zonefile_metadata.json updatezinfo.py
-recursive-include dateutils/test/ *
+recursive-include dateutil/test *
 global-exclude __pycache__
 global-exclude *.py[co]


### PR DESCRIPTION
Fix typo: `s/dateutils/dateutil/`, also trailing `/` was causing this to not work.