### PR TITLE
Prepare 2.5.2 release.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Version 2.5.2
+-------------
+- Updated zoneinfo to 2016c
+- Fixed parser bug where yearfirst and dayfirst parameters were not being
+  respected when no separator was present. (gh issue #81 and #217, pr #229)
+
 Version 2.5.1
 -------------
 - Updated zoneinfo to 2016b

--- a/dateutil/__init__.py
+++ b/dateutil/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = "2.5.1"
+__version__ = "2.5.2"


### PR DESCRIPTION
Prepare the 2.5.2 version release (mostly coinciding with the `tzdata2016c` release).