### PR TITLE
Significantly improve rrule performance on Python 2.x

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -16,7 +16,7 @@ except ImportError:
     from fractions import gcd
 
 from six import advance_iterator, integer_types
-from six.moves import _thread
+from six.moves import _thread, range
 import heapq
 
 # For warning about deprecation of until and count


### PR DESCRIPTION
I noticed that on Python 2.x, the test performance was abysmal for whatever reason, taking MUCH longer than the Python 3.x tests.  Using [nose-timer](https://github.com/mahmoudimus/nose-timer), I determined that the issue was the `rrule` tests:

```
[master@dateutil]$ python2 `which nosetests` --with-timer --timer-top-n 10
... [clipped] SSSS
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByWeekNoAndWeekDay53: 0.9731s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByWeekNo: 0.5110s
dateutil.test.test_rrule.RRuleTest.testSecondlyByWeekNoAndWeekDay53: 0.4850s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByMonthAndYearDayNeg: 0.4731s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByEasterPos: 0.4554s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByEaster: 0.4549s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByEasterNeg: 0.4479s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByMonthAndYearDay: 0.4470s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByMonthAndMonthDay: 0.2652s
dateutil.test.test_rrule.RRuleTest.testSecondlyByWeekNo: 0.2577s
----------------------------------------------------------------------
Ran 904 tests in 11.393s
```

After using [`line_profiler`](https://github.com/rkern/line_profiler) I found that the culprit was one of a few calls to `range()`, which makes sense, since in Python 2.x it creates a list, not an iterator. Importing `range` from `six` makes all the tests faster:

```
[improve_rrule_performance@dateutil]$ python2 `which nosetests` --with-timer --timer-top-n 10
........ [clipped] SSSSS
dateutil.test.test_tz.TZTest.testBrokenIsDstHandling: 0.1452s
dateutil.test.test_rrule.RRuleTest.testToStrDailyByWeekNoAndWeekDay53: 0.0411s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByHourAndMinute: 0.0379s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByHour: 0.0375s
dateutil.test.test_parser.ParserTest.testIncreasingCTime: 0.0344s
dateutil.test.test_rrule.RRuleTest.testToStrLongIntegers: 0.0310s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByHourAndMinuteAndSecond: 0.0280s
dateutil.test.test_rrule.RRuleTest.testToStrSecondlyByHourAndSecond: 0.0269s
dateutil.test.test_parser.ParserTest.testIncreasingISOFormat: 0.0267s
dateutil.test.test_rrule.RRuleTest.testDailyByWeekNoAndWeekDay53: 0.0213s
----------------------------------------------------------------------
Ran 904 tests in 1.453s
```

The `testBrokenIsDstHandling` test is slow I think because I think it's the first `gettz()` call that hits some caching branch (maybe that's the first time the zoneinfofile is built).
