### PR TITLE
Run updatezinfo.py script with coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 install:
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
-  - ./ci_tools/retry.sh python updatezinfo.py
+  - ./ci_tools/retry.sh coverage run --omit=setup.py,dateutil/test/* updatezinfo.py
 script:
   - coverage run --omit=setup.py,dateutil/test/* setup.py test
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
 
   # This frequently fails with network errors, so we'll retry it up to 5 times
   # with a 1 minute rate limit.
-  - "ci_tools/retry.bat %PYTHON%/python.exe updatezinfo.py"
+  - "ci_tools/retry.bat coverage run --omit=setup.py,dateutil/test/* updatezinfo.py"
   # This environment variable tells the test suite it's OK to mess with the time zone.
   - set DATEUTIL_MAY_CHANGE_TZ=1
 test_script:


### PR DESCRIPTION
For now we can consider the fact that we're running updatezinfo to be part of testing the `rebuild` script for purposes of the code coverage. At some point we should probably write actual unit tests for it, though.