### PR TITLE
Use NotImplemented in defined classes.

### DIFF
--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -348,7 +348,7 @@ class relativedelta(object):
                                  microsecond=(other.microsecond or
                                               self.microsecond))
         if not isinstance(other, datetime.date):
-            raise TypeError("unsupported type for add operation")
+            return NotImplemented
         elif self._has_time and not isinstance(other, datetime.datetime):
             other = datetime.datetime.fromordinal(other.toordinal())
         year = (self.year or other.year)+self.years
@@ -397,7 +397,7 @@ class relativedelta(object):
 
     def __sub__(self, other):
         if not isinstance(other, relativedelta):
-            raise TypeError("unsupported type for sub operation")
+            return NotImplemented   # In case the other object defines __rsub__
         return self.__class__(years=self.years - other.years,
                              months=self.months - other.months,
                              days=self.days - other.days,
@@ -454,7 +454,11 @@ class relativedelta(object):
     __nonzero__ = __bool__
 
     def __mul__(self, other):
-        f = float(other)
+        try:
+            f = float(other)
+        except TypeError:
+            return NotImplemented
+
         return self.__class__(years=int(self.years * f),
                              months=int(self.months * f),
                              days=int(self.days * f),
@@ -476,7 +480,7 @@ class relativedelta(object):
 
     def __eq__(self, other):
         if not isinstance(other, relativedelta):
-            return False
+            return NotImplemented
         if self.weekday or other.weekday:
             if not self.weekday or not other.weekday:
                 return False
@@ -505,7 +509,12 @@ class relativedelta(object):
         return not self.__eq__(other)
 
     def __div__(self, other):
-        return self.__mul__(1/float(other))
+        try:
+            reciprocal = 1 / float(other)
+        except TypeError:
+            return NotImplemented
+
+        return self.__mul__(reciprocal)
 
     __truediv__ = __div__
 

--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -138,3 +138,31 @@ class TZWinContext(object):
         if p.returncode:
             raise OSError('Failed to set current time zone: ' +
                           (err or 'Unknown error.'))
+
+###
+# Utility classes
+class NotAValueClass(object):
+    """
+    A class analogous to NaN that has operations defined for any type.
+    """
+    def _op(self, other):
+        return self             # Operation with NotAValue returns NotAValue
+
+    def _cmp(self, other):
+        return False
+
+    __add__ = __radd__ = _op
+    __sub__ = __rsub__ = _op
+    __mul__ = __rmul__ = _op
+    __div__ = __rdiv__ = _op
+    __truediv__ = __rtruediv__ = _op
+    __floordiv__ = __rfloordiv__ = _op
+
+    __lt__ = __rlt__ = _op
+    __gt__ = __rgt__ = _op
+    __eq__ = __req__ = _op
+    __le__ = __rle__ = _op
+    __ge__ = __rge__ = _op
+
+NotAValue = NotAValueClass()
+

--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -166,3 +166,36 @@ class NotAValueClass(object):
 
 NotAValue = NotAValueClass()
 
+
+class ComparesEqualClass(object):
+    """
+    A class that is always equal to whatever you compare it to.
+    """
+
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+    def __le__(self, other):
+        return True
+
+    def __ge__(self, other):
+        return True
+
+    def __lt__(self, other):
+        return False
+
+    def __gt__(self, other):
+        return False
+
+    __req__ = __eq__
+    __rne__ = __ne__
+    __rle__ = __le__
+    __rge__ = __ge__
+    __rlt__ = __lt__
+    __rgt__ = __gt__
+
+ComparesEqual = ComparesEqualClass()
+

--- a/dateutil/test/test_relativedelta.py
+++ b/dateutil/test/test_relativedelta.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from ._common import unittest, WarningTestMixin
+from ._common import unittest, WarningTestMixin, NotAValue
 
 import calendar
 from datetime import datetime, date
 
 from dateutil.relativedelta import *
+
 
 class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
     now = datetime(2003, 9, 17, 20, 54, 47, 282310)
@@ -191,6 +192,10 @@ class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
         with self.assertRaises(TypeError):
             relativedelta(days=3) + 9
 
+    def testAdditionUnsupportedType(self):
+        # For unsupported types that define their own comparators, etc.
+        self.assertIs(relativedelta(days=1) + NotAValue, NotAValue)
+
     def testSubtraction(self):
         self.assertEqual(relativedelta(days=10) -
                          relativedelta(years=1, months=2, days=3, hours=4,
@@ -210,15 +215,24 @@ class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
         with self.assertRaises(TypeError):
             relativedelta(hours=12) - 14
 
+    def testSubtractionUnsupportedType(self):
+        self.assertIs(relativedelta(days=1) + NotAValue, NotAValue)
+
     def testMultiplication(self):
         self.assertEqual(datetime(2000, 1, 1) + relativedelta(days=1) * 28,
                          datetime(2000, 1, 29))
         self.assertEqual(datetime(2000, 1, 1) + 28 * relativedelta(days=1),
                          datetime(2000, 1, 29))
 
+    def testMultiplicationUnsupportedType(self):
+        self.assertIs(relativedelta(days=1) * NotAValue, NotAValue)
+
     def testDivision(self):
         self.assertEqual(datetime(2000, 1, 1) + relativedelta(days=28) / 28,
                          datetime(2000, 1, 2))
+
+    def testDivisionUnsupportedType(self):
+        self.assertIs(relativedelta(days=1) / NotAValue, NotAValue)
 
     def testBoolean(self):
         self.assertFalse(relativedelta(days=0))
@@ -238,6 +252,9 @@ class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
     def testInequalityTypeMismatch(self):
         # Different type
         self.assertFalse(relativedelta(year=1) == 19)
+
+    def testInequalityUnsupportedType(self):
+        self.assertIs(relativedelta(hours=3) == NotAValue, NotAValue)
 
     def testInequalityWeekdays(self):
         # Different weekdays

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -965,6 +965,26 @@ class TzWinTest(unittest.TestCase, TzWinFoldMixin):
 
             self.assertNotEqual(tw1, tw2)
 
+    def testTzWinEqualityInvalid(self):
+        # Compare to objects that do not implement comparison with this
+        # (should default to False)
+        UTC = tz.tzutc()
+        EST = tz.tzwin('Eastern Standard Time')
+        
+        self.assertFalse(EST == UTC)
+        self.assertFalse(EST == 1)
+        self.assertFalse(UTC == EST)
+
+        self.assertTrue(EST != UTC)
+        self.assertTrue(EST != 1)
+
+    def testTzWinInequalityUnsupported(self):
+        # Compare it to an object that is promiscuous about equality, but for
+        # which tzwin does not implement an equality operator. 
+        EST = tz.tzwin('Eastern Standard Time')
+        self.assertTrue(EST == ComparesEqual)
+        self.assertFalse(EST != ComparesEqual)
+
     def testTzwinTimeOnlyDST(self):
         # For zones with DST, .dst() should return None
         tw_est = tz.tzwin('Eastern Standard Time')

--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -116,8 +116,10 @@ class tzwinbase(_tzinfo):
     """tzinfo class based on win32's timezones available in the registry."""
     def __eq__(self, other):
         # Compare on all relevant dimensions, including name.
-        return (isinstance(other, tzwinbase) and
-                (self._stdoffset == other._stdoffset and
+        if not isinstance(other, tzwinbase):
+            return NotImplemented
+
+        return  (self._stdoffset == other._stdoffset and
                  self._dstoffset == other._dstoffset and
                  self._stddayofweek == other._stddayofweek and
                  self._dstdayofweek == other._dstdayofweek and
@@ -128,10 +130,10 @@ class tzwinbase(_tzinfo):
                  self._stdminute == other._stdminute and
                  self._dstminute == other._dstminute and
                  self._stdname == other._stdname and
-                 self._dstname == other._dstname))
+                 self._dstname == other._dstname)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not (self == other)
 
     def utcoffset(self, dt):
         isdst = self._isdst(dt)


### PR DESCRIPTION
The [Python documentation](https://docs.python.org/3.5/library/constants.html) indicates that `NotImplemented` should be returned for rich comparison and arithmetic operations on defined classes. Up until now, we've been raising `TypeError` or returning `False` automatically, which prevents less picky classes from properly implementing operations with respect to our classes.

I think this covers all the operators we define.