### PR TITLE
Add ambiguous time support to tzlocal()

### DIFF
--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -5,6 +5,7 @@ except ImportError:
     import unittest
 
 import os
+import time
 import subprocess
 import warnings
 import tempfile
@@ -95,30 +96,97 @@ class PicklableMixin(object):
         self.assertEqual(obj, nobj)
 
 
-class TZWinContext(object):
-    """ Context manager for changing local time zone on Windows """
+class TZContextBase(object):
+    """
+    Base class for a context manager which allows changing of time zones.
+
+    Subclasses may define a guard variable to either block or or allow time
+    zone changes by redefining ``_guard_var_name`` and ``_guard_allows_change``.
+    The default is that the guard variable must be affirmatively set.
+
+    Subclasses must define ``get_current_tz`` and ``set_current_tz``.
+    """
+    _guard_var_name = "DATEUTIL_MAY_CHANGE_TZ"
+    _guard_allows_change = True
+
+    def __init__(self, tzval):
+        self.tzval = tzval
+        self._old_tz = None
+
     @classmethod
     def tz_change_allowed(cls):
-        # Allowing dateutil to change the local TZ is set as a local environment
-        # flag.
-        return bool(os.environ.get('DATEUTIL_MAY_CHANGE_TZ', False))
+        """
+        Class method used to query whether or not this class allows time zone
+        changes.
+        """
+        guard = bool(os.environ.get(cls._guard_var_name, False))
 
-    def __init__(self, tzname):
-        self.tzname = tzname
-        self._old_tz = None
+        # _guard_allows_change gives the "default" behavior - if True, the
+        # guard is overcoming a block. If false, the guard is causing a block.
+        # Whether tz_change is allowed is therefore the XNOR of the two.
+        return guard == cls._guard_allows_change
+
+    @classmethod
+    def tz_change_disallowed_message(cls):
+        """ Generate instructions on how to allow tz changes """
+        msg = ('Changing time zone not allowed. Set {envar} to {gval} '
+               'if you would like to allow this behavior')
+
+        return msg.format(envar=cls._guard_var_name,
+                          gval=cls._guard_allows_change)
 
     def __enter__(self):
         if not self.tz_change_allowed():
-            raise ValueError('Environment variable DATEUTIL_MAY_CHANGE_TZ ' + 
-                             'must be true.')
+            raise ValueError(self.tz_change_disallowed_message())
 
         self._old_tz = self.get_current_tz()
-        self.set_current_tz(self.tzname)
+        self.set_current_tz(self.tzval)
 
     def __exit__(self, type, value, traceback):
         if self._old_tz is not None:
             self.set_current_tz(self._old_tz)
 
+        self._old_tz = None
+
+    def get_current_tz(self):
+        raise NotImplementedError
+
+    def set_current_tz(self):
+        raise NotImplementedError
+
+
+class TZEnvContext(TZContextBase):
+    """
+    Context manager that temporarily sets the `TZ` variable (for use on
+    *nix-like systems). Because the effect is local to the shell anyway, this
+    will apply *unless* a guard is set.
+
+    If you do not want the TZ environment variable set, you may set the
+    ``DATEUTIL_MAY_NOT_CHANGE_TZ_VAR`` variable to a truthy value.
+    """
+    _guard_var_name = "DATEUTIL_MAY_NOT_CHANGE_TZ_VAR"
+    _guard_allows_change = False
+
+    def get_current_tz(self):
+        return os.environ.get('TZ', UnsetTz)
+
+    def set_current_tz(self, tzval):
+        if tzval is UnsetTz and 'TZ' in os.environ:
+            del os.environ['TZ']
+        else:
+            os.environ['TZ'] = tzval
+
+        time.tzset()
+
+
+class TZWinContext(TZContextBase):
+    """
+    Context manager for changing local time zone on Windows.
+
+    Because the effect of this is system-wide and global, it may have
+    unintended side effect. Set the ``DATEUTIL_MAY_CHANGE_TZ`` environment
+    variable to a truthy value before using this context manager.
+    """
     def get_current_tz(self):
         p = subprocess.Popen(['tzutil', '/g'], stdout=subprocess.PIPE)
 
@@ -198,4 +266,10 @@ class ComparesEqualClass(object):
     __rgt__ = __gt__
 
 ComparesEqual = ComparesEqualClass()
+
+class UnsetTzClass(object):
+    """ Sentinel class for unset time zone variable """
+    pass
+
+UnsetTz = UnsetTzClass()
 

--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -5,6 +5,7 @@ except ImportError:
     import unittest
 
 import os
+import datetime
 import time
 import subprocess
 import warnings
@@ -206,6 +207,18 @@ class TZWinContext(TZContextBase):
         if p.returncode:
             raise OSError('Failed to set current time zone: ' +
                           (err or 'Unknown error.'))
+
+
+###
+# Compatibility functions
+
+def _total_seconds(td):
+    # Python 2.6 doesn't have a total_seconds() method on timedelta objects
+    return ((td.seconds + td.days * 86400) * 1000000 +
+            td.microseconds) // 1000000
+
+total_seconds = getattr(datetime.timedelta, 'total_seconds', _total_seconds)
+
 
 ###
 # Utility classes

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -321,7 +321,6 @@ class TzLocalNixTest(unittest.TestCase):
     def testDSTUTC(self):
         self._testDST(self.UTC, timedelta(0))
 
-    @unittest.skip('Known failure')
     def testTimeOnlyOffsetLocalUTC(self):
         with TZEnvContext(self.UTC):
             self.assertEqual(dt_time(13, 20, tzinfo=tz.tzlocal()).utcoffset(),
@@ -332,13 +331,11 @@ class TzLocalNixTest(unittest.TestCase):
             self.assertIs(dt_time(13, 20, tzinfo=tz.tzlocal()).utcoffset(),
                           None)
 
-    @unittest.skip('Known failure')
     def testTimeOnlyDSTLocalUTC(self):
         with TZEnvContext(self.UTC):
             self.assertEqual(dt_time(13, 20, tzinfo=tz.tzlocal()).dst(),
                              timedelta(0))
 
-    @unittest.skip('Known failure')
     def testTimeOnlyDSTLocalDST(self):
         with TZEnvContext(self.TZ_EST):
             self.assertIs(dt_time(13, 20, tzinfo=tz.tzlocal()).dst(),

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -634,7 +634,7 @@ class TzLocalTest(unittest.TestCase):
 @unittest.skipIf(IS_WIN, "requires Unix")
 @unittest.skipUnless(TZEnvContext.tz_change_allowed(),
                          TZEnvContext.tz_change_disallowed_message())
-class TzLocalNixTest(unittest.TestCase):
+class TzLocalNixTest(unittest.TestCase, TzFoldMixin):
     # This is a set of tests for `tzlocal()` on *nix systems
 
     # POSIX string indicating change to summer time on the 2nd Sunday in March
@@ -642,10 +642,21 @@ class TzLocalNixTest(unittest.TestCase):
     TZ_EST = 'EST+5EDT,M3.2.0/2,M11.1.0/2'
 
     # POSIX string for AEST/AEDT (valid >= 2008)
-    TZ_AEST = 'AEST-10AEDT-11,M4.1.0/2,M10.1.0/2'
+    TZ_AEST = 'AEST-10AEDT,M10.1.0/2,M4.1.0/3'
 
     # POSIX string for UTC
     UTC = 'UTC'
+
+    def gettz(self, tzname):
+        # Actual time zone changes are handled by the _gettz_context function
+        return tz.tzlocal()
+
+    def _gettz_context(self, tzname):
+        tzname_map = {'Australia/Sydney': self.TZ_AEST,
+                      'America/Toronto': self.TZ_EST,
+                      'America/New_York': self.TZ_EST}
+
+        return TZEnvContext(tzname_map.get(tzname, tzname))
 
     def _testTzFunc(self, tzval, func, std_val, dst_val):
         """

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -13,6 +13,7 @@ import sys
 import time as _time
 import base64
 import copy
+import itertools
 
 from functools import partial
 
@@ -216,6 +217,51 @@ class TzOffsetTest(unittest.TestCase):
         self.assertTrue(tzo == ComparesEqual)
         self.assertFalse(tzo != ComparesEqual)
         self.assertEqual(tzo, ComparesEqual)
+
+
+class TzLocalTest(unittest.TestCase):
+    def testTimeOnlyLocal(self):
+        # tzlocal returns None
+        tz_local = tz.tzlocal()
+        self.assertIs(dt_time(13, 20, tzinfo=tz_local).utcoffset(), None)
+
+    def testEquality(self):
+        tz1 = tz.tzlocal()
+        tz2 = tz.tzlocal()
+
+        # Explicitly calling == and != here to ensure the operators work
+        self.assertTrue(tz1 == tz2)
+        self.assertFalse(tz1 != tz2)
+
+    def testInequalityFixedOffset(self):
+        tzl = tz.tzlocal()
+        tzos = tz.tzoffset('LST', tzl._std_offset.total_seconds())
+        tzod = tz.tzoffset('LDT', tzl._std_offset.total_seconds())
+
+        self.assertFalse(tzl == tzos)
+        self.assertFalse(tzl == tzod)
+        self.assertTrue(tzl != tzos)
+        self.assertTrue(tzl != tzod)
+
+    def testInequalityInvalid(self):
+        tzl = tz.tzlocal()
+        UTC = tz.tzutc()
+
+        self.assertTrue(tzl != 1)
+        self.assertTrue(tzl != tz.tzutc())
+        self.assertFalse(tzl == 1)
+        self.assertFalse(tzl == UTC)
+
+    def testInequalityUnsupported(self):
+        tzl = tz.tzlocal()
+
+        self.assertTrue(tzl == ComparesEqual)
+        self.assertFalse(tzl != ComparesEqual)
+
+    def testRepr(self):
+        tzl = tz.tzlocal()
+
+        self.assertEqual(repr(tzl), 'tzlocal()')
 
 
 class TzFoldMixin(object):
@@ -623,11 +669,6 @@ class TZTest(unittest.TestCase, TzFoldMixin):
                           datetime(2007, 8, 6, 6, 10, tzinfo=tz.tzstr("GMT+2")))
         self.assertEqual(dt.astimezone(tz=tz.gettz("UTC-2")),
                           datetime(2007, 8, 6, 2, 10, tzinfo=tz.tzstr("UTC-2")))
-
-    def testTimeOnlyLocal(self):
-        # tzlocal returns None
-        tz_local = tz.tzlocal()
-        self.assertIs(dt_time(13, 20, tzinfo=tz_local).utcoffset(), None)
 
     def testTimeOnlyRange(self):
         # tzrange returns None

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from ._common import unittest, PicklableMixin
+from ._common import total_seconds
 from ._common import TZEnvContext, TZWinContext
 from ._common import ComparesEqual
 
@@ -602,8 +603,8 @@ class TzLocalTest(unittest.TestCase):
 
     def testInequalityFixedOffset(self):
         tzl = tz.tzlocal()
-        tzos = tz.tzoffset('LST', tzl._std_offset.total_seconds())
-        tzod = tz.tzoffset('LDT', tzl._std_offset.total_seconds())
+        tzos = tz.tzoffset('LST', total_seconds(tzl._std_offset))
+        tzod = tz.tzoffset('LDT', total_seconds(tzl._std_offset))
 
         self.assertFalse(tzl == tzos)
         self.assertFalse(tzl == tzod)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -99,8 +99,8 @@ class tzlocal(datetime.tzinfo):
             self._dst_offset = self._std_offset
 
     def utcoffset(self, dt):
-        if dt is None:
-            return dt
+        if dt is None and self._hasdst():
+            return None
 
         if self._isdst(dt):
             return self._dst_offset
@@ -108,8 +108,11 @@ class tzlocal(datetime.tzinfo):
             return self._std_offset
 
     def dst(self, dt):
+        if dt is None and self._hasdst():
+            return None
+
         if self._isdst(dt):
-            return self._dst_offset-self._std_offset
+            return self._dst_offset - self._std_offset
         else:
             return ZERO
 
@@ -142,8 +145,14 @@ class tzlocal(datetime.tzinfo):
         #
         # Here is a more stable implementation:
         #
+        if not self._hasdst():
+            return False
+
         timestamp = _datetime_to_timestamp(dt)
-        return time.localtime(timestamp+time.timezone).tm_isdst
+        return time.localtime(timestamp + time.timezone).tm_isdst
+
+    def _hasdst(self):
+        return self._dst_offset != self._std_offset
 
     def __eq__(self, other):
         if not isinstance(other, tzlocal):

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -90,16 +90,21 @@ class tzoffset(datetime.tzinfo):
     __reduce__ = object.__reduce__
 
 
-class tzlocal(datetime.tzinfo):
+class tzlocal(_tzinfo):
     def __init__(self):
+        super(tzlocal, self).__init__()
+
         self._std_offset = datetime.timedelta(seconds=-time.timezone)
         if time.daylight:
             self._dst_offset = datetime.timedelta(seconds=-time.altzone)
         else:
             self._dst_offset = self._std_offset
 
+        self._dst_saved = self._dst_offset - self._std_offset
+        self._hasdst = bool(self._dst_saved)
+
     def utcoffset(self, dt):
-        if dt is None and self._hasdst():
+        if dt is None and self._hasdst:
             return None
 
         if self._isdst(dt):
@@ -108,7 +113,7 @@ class tzlocal(datetime.tzinfo):
             return self._std_offset
 
     def dst(self, dt):
-        if dt is None and self._hasdst():
+        if dt is None and self._hasdst:
             return None
 
         if self._isdst(dt):
@@ -145,14 +150,23 @@ class tzlocal(datetime.tzinfo):
         #
         # Here is a more stable implementation:
         #
-        if not self._hasdst():
+        if not self._hasdst:
             return False
 
+        dstval = self._naive_is_dst(dt)
+
+        # Check for ambiguous times:
+        if not dstval and self._fold is not None:
+            dst_fold_offset = self._naive_is_dst(dt - self._dst_saved)
+
+            if dst_fold_offset:
+                return self._fold
+
+        return dstval
+
+    def _naive_is_dst(self, dt):
         timestamp = _datetime_to_timestamp(dt)
         return time.localtime(timestamp + time.timezone).tm_isdst
-
-    def _hasdst(self):
-        return self._dst_offset != self._std_offset
 
     def __eq__(self, other):
         if not isinstance(other, tzlocal):


### PR DESCRIPTION
Among other improvements, this adds fold support to `tz.tzlocal()`. I have not tested this behavior on Windows because I don't think windows supports the POSIX-style assignment of the `TZ` variable.

There is also a behavior change with regard to bare `time` objects - `tzlocal()` can now be used to create timezone-aware `time()` objects if your local time zone has a fixed offset.

Since a date is required to resolve the ambiguity in non-fixed-offset times, that still returns `None`.

Finally, I also did some refactoring on the tests. Slowly but steadily, I'm managing to break up the monolithic `TzTest` object.