### PR TITLE
Format wkst properly in rrule.__str__

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -707,7 +707,7 @@ class rrule(rrulebase):
             parts.append('INTERVAL=' + str(self._interval))
 
         if self._wkst:
-            parts.append('WKST=' + str(self._wkst))
+            parts.append('WKST=' + repr(weekday(self._wkst))[0:2])
 
         if self._count:
             parts.append('COUNT=' + str(self._count))

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -4382,6 +4382,12 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                               byminute=(1,),
                               dtstart=datetime(2010, 3, 22, 12, 1)))
 
+    def testToStrWithWkSt(self):
+        self._rrulestr_reverse_test(rrule(WEEKLY,
+                              count=3,
+                              wkst=SU,
+                              dtstart=datetime(1997, 9, 2, 9, 0)))
+
     def testToStrLongIntegers(self):
         if not PY3:  # There is no longs in python3
             self._rrulestr_reverse_test(rrule(MINUTELY,


### PR DESCRIPTION
This fixes #262 by converting `wkst` to a weekday string when stringifying an rrule.