### PR TITLE
Full ambiguous timezone support.

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -306,7 +306,6 @@ class TzFoldMixin(object):
             self.assertEqual(t0.utcoffset(), timedelta(hours=-5.0))
             self.assertEqual(t1.utcoffset(), timedelta(hours=-4.0))
 
-
     def testFoldIndependence(self):
         tzname = self._get_tzname('America/New_York')
 
@@ -1154,17 +1153,17 @@ class TZICalTest(unittest.TestCase, TzFoldMixin):
             'BEGIN:VTIMEZONE',
             'TZID:Australia-Sydney',
             'BEGIN:STANDARD',
-            'DTSTART:19980301T020000',
+            'DTSTART:19980301T030000',
             'RRULE:FREQ=YEARLY;BYDAY=+1SU;BYMONTH=04',
-            'TZOFFSETFROM:+1000',
-            'TZOFFSETTO:+1100',
+            'TZOFFSETFROM:+1100',
+            'TZOFFSETTO:+1000',
             'TZNAME:AEST',
             'END:STANDARD',
             'BEGIN:DAYLIGHT',
-            'DTSTART:19971029T030000',
+            'DTSTART:19971029T020000',
             'RRULE:FREQ=YEARLY;BYDAY=+1SU;BYMONTH=10',
-            'TZOFFSETFROM:+1100',
-            'TZOFFSETTO:+1000',
+            'TZOFFSETFROM:+1000',
+            'TZOFFSETTO:+1100',
             'TZNAME:AEDT',
             'END:DAYLIGHT',
             'END:VTIMEZONE'
@@ -1178,12 +1177,27 @@ class TZICalTest(unittest.TestCase, TzFoldMixin):
 
         return tzc
 
+    # Fold known fails
+    @unittest.skip('Known failure: Fold not implemented')
+    def testFoldNegativeUTCOffset(self):
+        pass
+
+    @unittest.skip('Known failure: Fold not implemented')
+    def testFoldPositiveUTCOffset(self):
+        pass
+
+    @unittest.skip('Known failure: Fold not implemented')
+    def testFoldIndependence(self):
+        pass
+
+
     def testRepr(self):
         instr = StringIO(TZICAL_PST8PDT)
         instr.name = 'StringIO(PST8PDT)'
         tzc = tz.tzical(instr)
 
         self.assertEqual(repr(tzc), "tzical(" + repr(instr.name) + ")")
+
 
     # Test performance
     def _test_us_zone(self, tzc, func, values, start):
@@ -1202,8 +1216,6 @@ class TZICalTest(unittest.TestCase, TzFoldMixin):
     def _test_multi_zones(self, tzstrs, tzids, func, values, start):
         tzic = tz.tzical(StringIO(''.join(tzstrs)))
         for tzid, vals in zip(tzids, values):
-            print(tzid)
-            print(vals)
             tzc = tzic.get(tzid)
 
             self._test_us_zone(tzc, func, vals, start)

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -806,7 +806,30 @@ class ZoneInfoGettzTest(GettzTest):
         self.assertEqual(CHI, CHI_COPY)
 
 
-class TZRangeTest(unittest.TestCase):
+class TZRangeTest(unittest.TestCase, TzFoldMixin):
+    TZ_EST = tz.tzrange('EST', timedelta(hours=-5),
+                        'EDT', timedelta(hours=-4),
+                        start=relativedelta(month=3, day=1, hour=2,
+                                            weekday=SU(+2)),
+                        end=relativedelta(month=11, day=1, hour=1,
+                                          weekday=SU(+1)))
+
+    TZ_AEST = tz.tzrange('AEST', timedelta(hours=10),
+                         'AEDT', timedelta(hours=11),
+                         start=relativedelta(month=10, day=1, hour=2,
+                                             weekday=SU(+1)),
+                         end=relativedelta(month=4, day=1, hour=2,
+                                           weekday=SU(+1)))
+    # POSIX string for UTC
+    UTC = 'UTC'
+
+    def gettz(self, tzname):
+        tzname_map = {'Australia/Sydney': self.TZ_AEST,
+                      'America/Toronto': self.TZ_EST,
+                      'America/New_York': self.TZ_EST}
+
+        return tzname_map[tzname]
+
     def testRangeCmp1(self):
         self.assertEqual(tz.tzstr("EST5EDT"),
                          tz.tzrange("EST", -18000, "EDT", -14400,

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -933,7 +933,22 @@ class TZRangeTest(unittest.TestCase, TzFoldMixin):
         self.assertFalse(TZR != ComparesEqual)
 
 
-class TZStrTest(unittest.TestCase):
+class TZStrTest(unittest.TestCase, TzFoldMixin):
+    # POSIX string indicating change to summer time on the 2nd Sunday in March
+    # at 2AM, and ending the 1st Sunday in November at 2AM. (valid >= 2007)
+    TZ_EST = 'EST+5EDT,M3.2.0/2,M11.1.0/2'
+
+    # POSIX string for AEST/AEDT (valid >= 2008)
+    TZ_AEST = 'AEST-10AEDT,M10.1.0/2,M4.1.0/3'
+
+    def gettz(self, tzname):
+        # Actual time zone changes are handled by the _gettz_context function
+        tzname_map = {'Australia/Sydney': self.TZ_AEST,
+                      'America/Toronto': self.TZ_EST,
+                      'America/New_York': self.TZ_EST}
+
+        return tz.tzstr(tzname_map[tzname])
+
     def testStrStart1(self):
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr("EST5EDT")).tzname(), "EST")

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1177,20 +1177,6 @@ class TZICalTest(unittest.TestCase, TzFoldMixin):
 
         return tzc
 
-    # Fold known fails
-    @unittest.skip('Known failure: Fold not implemented')
-    def testFoldNegativeUTCOffset(self):
-        pass
-
-    @unittest.skip('Known failure: Fold not implemented')
-    def testFoldPositiveUTCOffset(self):
-        pass
-
-    @unittest.skip('Known failure: Fold not implemented')
-    def testFoldIndependence(self):
-        pass
-
-
     def testRepr(self):
         instr = StringIO(TZICAL_PST8PDT)
         instr.name = 'StringIO(PST8PDT)'

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1119,8 +1119,8 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         TZS1 = tz.tzstr('EST5EDT4')
         TZS2 = tz.tzstr('EST')
 
-        self.assertEqual(repr(TZS1), "tzstr('EST5EDT4')")
-        self.assertEqual(repr(TZS2), "tzstr('EST')")
+        self.assertEqual(repr(TZS1), "tzstr(" + repr('EST5EDT4') + ")")
+        self.assertEqual(repr(TZS2), "tzstr(" + repr('EST') + ")")
 
     def testTzStrFailure(self):
         with self.assertRaises(ValueError):
@@ -1133,7 +1133,7 @@ class TZICalTest(unittest.TestCase):
         instr.name = 'StringIO(PST8PDT)'
         tzc = tz.tzical(instr)
 
-        self.assertEqual(repr(tzc), "tzical('StringIO(PST8PDT)')")
+        self.assertEqual(repr(tzc), "tzical(" + repr(instr.name) + ")")
 
     # Test performance
     def _test_us_zone(self, tzc, func, values, start):

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -876,36 +876,30 @@ class TZRangeTest(unittest.TestCase):
 
         # Standard abbreviation different
         TZR2 = tz.tzrange('ET', -18000, 'EDT', -14400)
-
         self.assertNotEqual(TZR1, TZR2)
 
         # DST abbreviation different
         TZR3 = tz.tzrange('EST', -18000, 'EMT', -14400)
-
         self.assertNotEqual(TZR1, TZR3)
 
         # STD offset different
         TZR4 = tz.tzrange('EST', -14000, 'EDT', -14400)
-
         self.assertNotEqual(TZR1, TZR4)
 
         # DST offset different
         TZR5 = tz.tzrange('EST', -18000, 'EDT', -18000)
-
         self.assertNotEqual(TZR1, TZR5)
 
         # Start delta different
         TZR6 = tz.tzrange('EST', -18000, 'EDT', -14400,
                           start=relativedelta(hours=+1, month=3,
                                               day=1, weekday=SU(+2)))
-
         self.assertNotEqual(TZR1, TZR6)
                                  
         # End delta different
         TZR7 = tz.tzrange('EST', -18000, 'EDT', -14400,
             end=relativedelta(hours=+1, month=11,
                               day=1, weekday=SU(+2)))
-
         self.assertNotEqual(TZR1, TZR7)
 
     def testRangeInequalityUnsupported(self):
@@ -916,7 +910,7 @@ class TZRangeTest(unittest.TestCase):
         self.assertFalse(TZR != ComparesEqual)
 
 
-class TZTest(unittest.TestCase):
+class TZStrTest(unittest.TestCase):
     def testStrStart1(self):
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr("EST5EDT")).tzname(), "EST")
@@ -1012,9 +1006,69 @@ class TZTest(unittest.TestCase):
                          tz.tzstr("EST5EDT4,M4.1.0/02:00:00,M10-5-0/02:00"))
 
     def testStrCmp2(self):
+        # TODO: This is parsing the default arguments.
         self.assertEqual(tz.tzstr("EST5EDT"),
                          tz.tzstr("EST5EDT,4,1,0,7200,10,-1,0,7200,3600"))
 
+    def testStrInequality(self):
+        TZS1 = tz.tzstr('EST5EDT4')
+
+        # Standard abbreviation different
+        TZS2 = tz.tzstr('ET5EDT4')
+        self.assertNotEqual(TZS1, TZS2)
+
+        # DST abbreviation different
+        TZS3 = tz.tzstr('EST5EMT')
+        self.assertNotEqual(TZS1, TZS3)
+
+        # STD offset different
+        TZS4 = tz.tzstr('EST4EDT4')
+        self.assertNotEqual(TZS1, TZS4)
+
+        # DST offset different
+        TZS5 = tz.tzstr('EST5EDT3')
+        self.assertNotEqual(TZS1, TZS5)
+
+    def testStrInequalityStartEnd(self):
+        TZS1 = tz.tzstr('EST5EDT4')
+
+        # Start delta different
+        TZS2 = tz.tzstr('EST5EDT4,M4.2.0/02:00:00,M10-5-0/02:00')
+        self.assertNotEqual(TZS1, TZS2)
+                                 
+        # End delta different
+        TZS3 = tz.tzstr('EST5EDT4,M4.2.0/02:00:00,M11-5-0/02:00')
+        self.assertNotEqual(TZS1, TZS3)
+
+    def testPosixOffset(self):
+        TZ1 = tz.tzstr('UTC-3')
+        self.assertEqual(datetime(2015, 1, 1, tzinfo=TZ1).utcoffset(),
+                         timedelta(hours=-3))
+
+        TZ2 = tz.tzstr('UTC-3', posix_offset=True)
+        self.assertEqual(datetime(2015, 1, 1, tzinfo=TZ2).utcoffset(),
+                         timedelta(hours=+3))
+
+    def testStrInequalityUnsupported(self):
+        TZS = tz.tzstr('EST5EDT')
+
+        self.assertFalse(TZS == 4)
+        self.assertTrue(TZS == ComparesEqual)
+        self.assertFalse(TZS != ComparesEqual)
+
+    def testTzStrRepr(self):
+        TZS1 = tz.tzstr('EST5EDT4')
+        TZS2 = tz.tzstr('EST')
+
+        self.assertEqual(repr(TZS1), "tzstr('EST5EDT4')")
+        self.assertEqual(repr(TZS2), "tzstr('EST')")
+
+    def testTzStrFailure(self):
+        with self.assertRaises(ValueError):
+            tz.tzstr('InvalidString;439999')
+
+
+class TZTest(unittest.TestCase):
     def testFileStart1(self):
         tzc = tz.tzfile(BytesIO(base64.b64decode(TZFILE_EST5EDT)))
         self.assertEqual(datetime(2003, 4, 6, 1, 59, tzinfo=tzc).tzname(), "EST")

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1127,7 +1127,57 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
             tz.tzstr('InvalidString;439999')
 
 
-class TZICalTest(unittest.TestCase):
+class TZICalTest(unittest.TestCase, TzFoldMixin):
+
+    def gettz(self, tzname):
+        TZ_EST = (
+            'BEGIN:VTIMEZONE',
+            'TZID:US-Eastern',
+            'BEGIN:STANDARD',
+            'DTSTART:19971029T020000',
+            'RRULE:FREQ=YEARLY;BYDAY=+1SU;BYMONTH=11',
+            'TZOFFSETFROM:-0400',
+            'TZOFFSETTO:-0500',
+            'TZNAME:EST',
+            'END:STANDARD',
+            'BEGIN:DAYLIGHT',
+            'DTSTART:19980301T020000',
+            'RRULE:FREQ=YEARLY;BYDAY=+2SU;BYMONTH=03',
+            'TZOFFSETFROM:-0500',
+            'TZOFFSETTO:-0400',
+            'TZNAME:EDT',
+            'END:DAYLIGHT',
+            'END:VTIMEZONE'
+            )
+
+        TZ_AEST = (
+            'BEGIN:VTIMEZONE',
+            'TZID:Australia-Sydney',
+            'BEGIN:STANDARD',
+            'DTSTART:19980301T020000',
+            'RRULE:FREQ=YEARLY;BYDAY=+1SU;BYMONTH=04',
+            'TZOFFSETFROM:+1000',
+            'TZOFFSETTO:+1100',
+            'TZNAME:AEST',
+            'END:STANDARD',
+            'BEGIN:DAYLIGHT',
+            'DTSTART:19971029T030000',
+            'RRULE:FREQ=YEARLY;BYDAY=+1SU;BYMONTH=10',
+            'TZOFFSETFROM:+1100',
+            'TZOFFSETTO:+1000',
+            'TZNAME:AEDT',
+            'END:DAYLIGHT',
+            'END:VTIMEZONE'
+            )
+
+        tzname_map = {'Australia/Sydney': TZ_AEST,
+                      'America/Toronto': TZ_EST,
+                      'America/New_York': TZ_EST}
+
+        tzc = tz.tzical(StringIO('\n'.join(tzname_map[tzname]))).get()
+
+        return tzc
+
     def testRepr(self):
         instr = StringIO(TZICAL_PST8PDT)
         instr.name = 'StringIO(PST8PDT)'

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -770,7 +770,7 @@ class tzrange(datetime.tzinfo):
                 self._end_delta == other._end_delta)
 
     def __ne__(self, other):
-        return not self.__eq__(other)
+        return not (self == other)
 
     def __repr__(self):
         return "%s(...)" % self.__class__.__name__

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -99,6 +99,9 @@ class tzoffset(datetime.tzinfo):
 
 
 class tzlocal(_tzinfo):
+    """
+    A :class:`tzinfo` subclass built around the ``time`` timezone functions.
+    """
     def __init__(self):
         super(tzlocal, self).__init__()
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -30,7 +30,9 @@ EPOCH = datetime.datetime.utcfromtimestamp(0)
 EPOCHORDINAL = EPOCH.toordinal()
 
 class tzutc(datetime.tzinfo):
-
+    """
+    This is a tzinfo object that represents the UTC time zone.
+    """
     def utcoffset(self, dt):
         return ZERO
 
@@ -252,9 +254,26 @@ class _tzfile(object):
 
 
 class tzfile(_tzinfo):
+    """
+    This is a ``tzinfo`` subclass that allows one to use the ``tzfile(5)``
+    format timezone files to extract current and historical zone information.
 
-    # http://www.twinsun.com/tz/tz-link.htm
-    # ftp://ftp.iana.org/tz/tz*.tar.gz
+    :param fileobj:
+        This can be an opened file stream or a file name that the time zone
+        information can be read from.
+
+    :param filename:
+        This is an optional parameter specifying the source of the time zone
+        information in the event that ``fileobj`` is a file object. If omitted
+        and ``fileobj`` is a file stream, this parameter will be set either to
+        ``fileobj``'s ``name`` attribute or to ``repr(fileobj)``.
+
+    See `Sources for Time Zone and Daylight Saving Time Data 
+    <http://www.twinsun.com/tz/tz-link.htm>`_ for more information. Time zone
+    files can be compiled from the `IANA Time Zone database files
+    <https://www.iana.org/time-zones>`_ with the `zic time zone compiler
+    <https://www.freebsd.org/cgi/man.cgi?query=zic&sektion=8>`_
+    """
 
     def __init__(self, fileobj, filename=None):
         super(tzfile, self).__init__()

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1000,14 +1000,15 @@ class tzical(object):
             self._s = fileobj
             # ical should be encoded in UTF-8 with CRLF
             fileobj = open(fileobj, 'r')
-        elif hasattr(fileobj, "name"):
-            self._s = fileobj.name
+            file_opened_here = True
         else:
-            self._s = repr(fileobj)
+            self._s = getattr(fileobj, 'name', repr(fileobj))
+            fileobj = _ContextWrapper(fileobj)
 
         self._vtz = {}
 
-        self._parse_rfc(fileobj.read())
+        with fileobj as fobj:
+            self._parse_rfc(fobj.read())
 
     def keys(self):
         return list(self._vtz.keys())
@@ -1032,11 +1033,11 @@ class tzical(object):
         else:
             signal = +1
         if len(s) == 4:
-            return (int(s[:2])*3600+int(s[2:])*60)*signal
+            return (int(s[:2]) * 3600 + int(s[2:]) * 60) * signal
         elif len(s) == 6:
-            return (int(s[:2])*3600+int(s[2:4])*60+int(s[4:]))*signal
+            return (int(s[:2]) * 3600 + int(s[2:4]) * 60 + int(s[4:])) * signal
         else:
-            raise ValueError("invalid offset: "+s)
+            raise ValueError("invalid offset: " + s)
 
     def _parse_rfc(self, s):
         lines = s.splitlines()

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -58,7 +58,15 @@ class tzutc(datetime.tzinfo):
 
 
 class tzoffset(datetime.tzinfo):
+    """
+    A simple class for representing a fixed offset from UTC.
 
+    :param name:
+        The timezone name, to be returned when ``tzname()`` is called.
+
+    :param offset:
+        The time zone offset in seconds.
+    """
     def __init__(self, name, offset):
         self._name = name
         self._offset = datetime.timedelta(seconds=offset)
@@ -85,7 +93,7 @@ class tzoffset(datetime.tzinfo):
     def __repr__(self):
         return "%s(%s, %s)" % (self.__class__.__name__,
                                repr(self._name),
-                               self._offset.days*86400+self._offset.seconds)
+                               int(_total_seconds(self._offset)))
 
     __reduce__ = object.__reduce__
 


### PR DESCRIPTION
This PR is not ready for merging, I just want to fire off the CI as I work on it. This will resolve #249. 

So far it includes:
* Improved documentation for many classes in the `tz` module.
* Fold support for `tzstr`, `tzrange` and `tzlocal`.
* Improved test coverage for `tzical`

Before merging, the following still needs to be done:
 - [x] Fold support for `tzical`


Deferring these two:
 -  <strike>Documentation for `tzfile`</strike>
 - <strike>Implementation of #253 </strike>

I will also possibly implement #260, depending on how it's best to implement #253.