### PR TITLE
Explicitly added both CI builds.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 coverage:
   status:
     patch: false
+    changes: false
     project:
       default:
         target: '80'


### PR DESCRIPTION
Codecov right now is updating the webhooks before both CIs comes in, and isn't waiting for both. This _should_ fix that.

I can't seem to get it to stop commenting, or restrict to status-only requirements, but I guess that's not critical.