### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ dateutil is available on PyPI
 https://pypi.python.org/pypi/python-dateutil/
 
 The documentation is hosted at:
-https://dateutil.readthedocs.org/
+https://dateutil.readthedocs.io/
 
 Code
 ====
@@ -134,7 +134,7 @@ dateutil has a comprehensive test suite, which can be run simply by running
 zoneinfo database, some tests will fail. Apart from that, all tests should pass.
 
 To easily test dateutil against all supported Python versions, you can use
-`tox <https://tox.readthedocs.org/en/latest/>`_.
+`tox <https://tox.readthedocs.io/en/latest/>`_.
 
 All github pull requests are automatically tested using travis and appveyor.
 

--- a/RELEASING
+++ b/RELEASING
@@ -59,7 +59,7 @@ Binary releases
 ----------
 It should always be possible to generate a universal wheel binary distribution
 for each release. Generally we do not generate .egg files. In order to generate
-a wheel, you need the wheel package (https://wheel.readthedocs.org/en/latest/)
+a wheel, you need the wheel package (https://wheel.readthedocs.io/en/latest/)
 installed, which can be installed with:
 
     pip install wheel

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(name="python-dateutil",
       description="Extensions to the standard Python datetime module",
       author="Paul Ganssle, Yaron de Leeuw",
       author_email="dateutil@python.org",
-      url="https://dateutil.readthedocs.org",
+      url="https://dateutil.readthedocs.io",
       license="Simplified BSD",
       long_description="""
 The dateutil module provides powerful extensions to the


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.