### PR TITLE
Added support for timedelta objects when constructing tzoffsets

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -570,6 +570,12 @@ class TzUTCTest(unittest.TestCase):
 
 
 class TzOffsetTest(unittest.TestCase):
+    def testTimedeltaOffset(self):
+        est = tz.tzoffset('EST', timedelta(hours=-5))
+        est_s = tz.tzoffset('EST', -18000)
+
+        self.assertEqual(est, est_s)
+
     def testTzNameNone(self):
         gmt5 = tz.tzoffset(None, -18000)       # -5:00
         self.assertIs(datetime(2003, 10, 26, 0, 0, tzinfo=gmt5).tzname(),
@@ -585,6 +591,7 @@ class TzOffsetTest(unittest.TestCase):
         tname = 'EST'
         tzo = tz.tzoffset(tname, -5 * 3600)
         self.assertEqual(repr(tzo), "tzoffset(" + repr(tname) + ", -18000)")
+
 
     def testEquality(self):
         utc = tz.tzoffset('UTC', 0)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -69,10 +69,17 @@ class tzoffset(datetime.tzinfo):
         The timezone name, to be returned when ``tzname()`` is called.
 
     :param offset:
-        The time zone offset in seconds.
+        The time zone offset in seconds, or represented as a
+        :py:class:`datetime.timedelta` object.
     """
     def __init__(self, name, offset):
         self._name = name
+        
+        try:
+            # Allow a timedelta
+            offset = _total_seconds(offset)
+        except (TypeError, AttributeError):
+            pass
         self._offset = datetime.timedelta(seconds=offset)
 
     def utcoffset(self, dt):


### PR DESCRIPTION
Thought I had already added this feature. This allows `tzoffset` to be constructed from a `timedelta`.
