### PR TITLE
Bug #278: Incorrect fuzzy date parsing.

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -436,6 +436,9 @@ class _ymd(list):
             elif dayfirst and self[1] <= 12:
                 # 13-01
                 day, month = self
+
+            elif self[0] > 12 and self[1] <= 12:
+                day, month = self
             else:
                 # 01-13
                 month, day = self
@@ -711,6 +714,11 @@ class parser(object):
 
                         if len_li == 4:
                             res.minute = int(s[2:])
+
+                    elif len_li == 5 and len_l == 1 and value_repr.count('.') == 1:
+                        after_split = value_repr.split('.')
+                        ymd.append(after_split[0])
+                        ymd.append(after_split[1])
 
                     elif len_li == 6 or (len_li > 6 and l[i-1].find('.') == 6):
                         # YYMMDD or HHMMSS[.ss]

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -579,6 +579,11 @@ class ParserTest(unittest.TestCase):
 
         self.assertEqual(parse(s1, fuzzy=True), datetime(1945, 1, 29, 14, 45))
 
+    def testFuzzyWithDotNotation(self):
+        s1 = "27.08"
+        today_year = date.today().year
+        self.assertEqual(parse(s1, fuzzy=True), datetime(today_year, 8, 27, 0, 0))
+
     def testExtraSpace(self):
         self.assertEqual(parse("  July   4 ,  1976   12:01:02   am  "),
                          datetime(1976, 7, 4, 0, 1, 2))


### PR DESCRIPTION
Bug related to #278.
- Added test case to bug.
- Fix bug when first part of ymd object is larger than 12 and length of ymd array == 2 - it's exactly date not month.
- Added rule for case when date in format "DD.MM" or "MM.DD"
