### PR TITLE
Fix some Python 3 issues flagged by the -3 flag

### DIFF
--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -32,6 +32,8 @@ class weekday(object):
             return False
         return True
 
+    __hash__ = None
+
     def __repr__(self):
         s = ("MO", "TU", "WE", "TH", "FR", "SA", "SU")[self.weekday]
         if not self.n:
@@ -521,6 +523,8 @@ class relativedelta(object):
                 self.minute == other.minute and
                 self.second == other.second and
                 self.microsecond == other.microsecond)
+
+    __hash__ = None
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -52,6 +52,8 @@ class tzutc(datetime.tzinfo):
         return (isinstance(other, tzutc) or
                 (isinstance(other, tzoffset) and other._offset == ZERO))
 
+    __hash__ = None
+
     def __ne__(self, other):
         return not (self == other)
 
@@ -90,6 +92,8 @@ class tzoffset(datetime.tzinfo):
             return NotImplemented
 
         return self._offset == other._offset
+
+    __hash__ = None
 
     def __ne__(self, other):
         return not (self == other)
@@ -190,6 +194,8 @@ class tzlocal(_tzinfo):
         return (self._std_offset == other._std_offset and
                 self._dst_offset == other._dst_offset)
 
+    __hash__ = None
+
     def __ne__(self, other):
         return not (self == other)
 
@@ -226,6 +232,8 @@ class _ttinfo(object):
                 self.isstd == other.isstd and
                 self.isgmt == other.isgmt and
                 self.dstoffset == other.dstoffset)
+
+    __hash__ = None
 
     def __ne__(self, other):
         return not (self == other)
@@ -626,6 +634,8 @@ class tzfile(_tzinfo):
                 self._trans_idx == other._trans_idx and
                 self._ttinfo_list == other._ttinfo_list)
 
+    __hash__ = None
+
     def __ne__(self, other):
         return not (self == other)
 
@@ -823,6 +833,8 @@ class tzrange(_tzinfo):
                 self._dst_offset == other._dst_offset and
                 self._start_delta == other._start_delta and
                 self._end_delta == other._end_delta)
+
+    __hash__ = None
 
     def __ne__(self, other):
         return not (self == other)


### PR DESCRIPTION
I've been working through looking at adopting Python 3, and I've been utilizing the -3 flag to help idenitfy issues with Python 3.

Here's a quick write up I did last week:

https://gist.github.com/rowillia/c0feed97c1863b2d8e5a3ed73712df65

The -3 flagged a few issues in dateutil worth fixing, namely around __eq__ shadowing __hash__ in PY3.

Fixing these issues will help make the -3 flag less noisey for folks running dateutil in production.