### PR TITLE
add rejected timestr in exception message providing more information to caller

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -556,10 +556,10 @@ class parser(object):
         res, skipped_tokens = self._parse(timestr, **kwargs)
 
         if res is None:
-            raise ValueError("Unknown string format")
+            raise ValueError("Unknown string format:", timestr)
 
         if len(res) == 0:
-            raise ValueError("String does not contain a date.")
+            raise ValueError("String does not contain a date:", timestr)
 
         repl = {}
         for attr in ("year", "month", "day", "hour",


### PR DESCRIPTION
helpful if exeption is catched above for displaying instead of being blind, e.g. diagnosting broken vcalendar items:

```
vobject.base.ParseError: "In transformToNative, unhandled exception on line None: <class 'ValueError'>: ('Unknown string format:', '1970DTSTART:19700329T020000')"
vobject.base.ParseError: "In transformToNative, unhandled exception on line None: <class 'ValueError'>: ('Unknown string format:', '19701TZOFFSETFROM:-0000')"
```

(don't ask how such entries can occur...)
