### PR TITLE
Implement PEP495 for all tzinfo objects.

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -887,9 +887,16 @@ class TZRangeTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(dt_std.tzname(), 'EST')
         self.assertEqual(dt_dst.tzname(), 'EDT')
 
+    def testTimeOnlyRangeFixed(self):
+        # This is a fixed-offset zone, so tzrange allows this
+        tz_range = tz.tzrange('dflt', stdoffset=timedelta(hours=-3))
+        self.assertEqual(dt_time(13, 20, tzinfo=tz_range).utcoffset(),
+                         timedelta(hours=-3))
+
     def testTimeOnlyRange(self):
-        # tzrange returns None
-        tz_range = tz.tzrange('dflt')
+        # tzrange returns None because this zone has DST
+        tz_range = tz.tzrange('EST', timedelta(hours=-5),
+                              'EDT', timedelta(hours=-4))
         self.assertIs(dt_time(13, 20, tzinfo=tz_range).utcoffset(), None)
 
     def testBrokenIsDstHandling(self):

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -211,7 +211,6 @@ class TzFoldMixin(object):
             self.assertEqual(t1_syd1.replace(tzinfo=None),
                              datetime(2012, 4, 1, 2, 30))
 
-            self.assertNotEqual(t0_syd0, t1_syd1)
             self.assertEqual(t0_syd0.utcoffset(), timedelta(hours=11))
             self.assertEqual(t1_syd1.utcoffset(), timedelta(hours=10))
 
@@ -269,7 +268,6 @@ class TzFoldMixin(object):
                 self.assertEqual(t1_tor1.replace(tzinfo=None),
                                  datetime(2011, 11, 6, 1, 30))
 
-                self.assertNotEqual(t0_tor0, t1_tor1)
                 self.assertEqual(t0_tor0.utcoffset(), timedelta(hours=-4.0))
                 self.assertEqual(t1_tor1.utcoffset(), timedelta(hours=-5.0))
 
@@ -324,11 +322,14 @@ class TzFoldMixin(object):
 
             # Ambiguous between 2015-11-01 1:30 EDT-4 and 2015-11-01 1:30 EST-5
             in_dst = pre_dst + hour
-            in_dst_tzname_0 = in_dst.tzname()     # Stash the tzname - EST
+            in_dst_tzname_0 = in_dst.tzname()     # Stash the tzname - EDT
 
             # Doing the arithmetic in UTC creates a date that is unambiguously
-            # 2015-11-01 1:30 EDT-4
-            in_dst_via_utc = (pre_dst.astimezone(UTC) + hour).astimezone(NYC)
+            # 2015-11-01 1:30 EDT-5
+            in_dst_via_utc = (pre_dst.astimezone(UTC) + 2*hour).astimezone(NYC)
+
+            # Make sure the dates are actually ambiguous
+            self.assertEqual(in_dst, in_dst_via_utc)
 
             # Make sure we got the right folding behavior
             self.assertNotEqual(in_dst_via_utc.tzname(), in_dst_tzname_0)

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -980,8 +980,10 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
     def testStrEnd1(self):
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr("EST5EDT")).tzname(), "EDT")
-        self.assertEqual(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr("EST5EDT")).tzname(), "EST")
+        
+        end = tz.enfold(datetime(2003, 10, 26, 1, 00,
+                                  tzinfo=tz.tzstr("EST5EDT")), fold=1)
+        self.assertEqual(end.tzname(), "EST")
 
     def testStrStart2(self):
         s = "EST5EDT,4,0,6,7200,10,0,26,7200,3600"
@@ -994,8 +996,10 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         s = "EST5EDT,4,0,6,7200,10,0,26,7200,3600"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
-        self.assertEqual(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)).tzname(), "EST")
+        
+        end = tz.enfold(datetime(2003, 10, 26, 1, 00,
+                                  tzinfo=tz.tzstr(s)), fold=1)
+        self.assertEqual(end.tzname(), "EST")
 
     def testStrStart3(self):
         s = "EST5EDT,4,1,0,7200,10,-1,0,7200,3600"
@@ -1008,8 +1012,10 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         s = "EST5EDT,4,1,0,7200,10,-1,0,7200,3600"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
-        self.assertEqual(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)).tzname(), "EST")
+
+        end = tz.enfold(datetime(2003, 10, 26, 1, 00,
+                                  tzinfo=tz.tzstr(s)), fold=1)
+        self.assertEqual(end.tzname(), "EST")
 
     def testStrStart4(self):
         s = "EST5EDT4,M4.1.0/02:00:00,M10-5-0/02:00"
@@ -1022,8 +1028,9 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         s = "EST5EDT4,M4.1.0/02:00:00,M10-5-0/02:00"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
-        self.assertEqual(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)).tzname(), "EST")
+        end = tz.enfold(datetime(2003, 10, 26, 1, 00, tzinfo=tz.tzstr(s)),
+                        fold=1)
+        self.assertEqual(end.tzname(), "EST")
 
     def testStrStart5(self):
         s = "EST5EDT4,95/02:00:00,298/02:00"
@@ -1036,8 +1043,9 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         s = "EST5EDT4,95/02:00:00,298/02"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
-        self.assertEqual(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)).tzname(), "EST")
+        end = tz.enfold(datetime(2003, 10, 26, 1, 00,
+                                  tzinfo=tz.tzstr(s)), fold=1)
+        self.assertEqual(end.tzname(), "EST")
 
     def testStrStart6(self):
         s = "EST5EDT4,J96/02:00:00,J299/02:00"
@@ -1050,8 +1058,10 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         s = "EST5EDT4,J96/02:00:00,J299/02"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
-        self.assertEqual(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)).tzname(), "EST")
+
+        end = tz.enfold(datetime(2003, 10, 26, 1, 00,
+                                 tzinfo=tz.tzstr(s)), fold=1)
+        self.assertEqual(end.tzname(), "EST")
 
     def testStrStr(self):
         # Test that tz.tzstr() won't throw an error if given a str instead

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -1,8 +1,10 @@
 from six import PY3
 from six.moves import _thread
 
-from datetime import datetime, tzinfo
+from datetime import datetime, timedelta, tzinfo
 import copy
+
+ZERO = timedelta(0)
 
 __all__ = ['tzname_in_python2', 'enfold']
 
@@ -52,49 +54,7 @@ else:
         if fold:
             return _DatetimeWithFold(*args)
         else:
-            return datetime.datetime(*args)
-
-def _fromutc(self, dt):
-    """
-    Given a timezone-aware datetime in a given timezone, calculates a
-    timezone-aware datetime in a new timezone.
-
-    Since this is the one time that we *know* we have an unambiguous
-    datetime object, we take this opportunity to determine whether the
-    datetime is ambiguous and in a "fold" state (e.g. if it's the first
-    occurence, chronologically, of the ambiguous datetime).
-
-    :param dt:
-        A timezone-aware :class:`datetime.dateime` object.
-    """
-
-    # Re-implement the algorithm from Python's datetime.py
-    if not isinstance(dt, datetime):
-        raise TypeError("fromutc() requires a datetime argument")
-    if dt.tzinfo is not self:
-        raise ValueError("dt.tzinfo is not self")
-
-    dtoff = dt.utcoffset()
-    if dtoff is None:
-        raise ValueError("fromutc() requires a non-None utcoffset() "
-                         "result")
-
-    # The original datetime.py code assumes that `dst()` defaults to
-    # zero during ambiguous times. PEP 495 inverts this presumption, so
-    # for pre-PEP 495 versions of python, we need to tweak the algorithm.
-    dtdst = dt.dst()
-    if dtdst is None:
-        raise ValueError("fromutc() requires a non-None dst() result")
-    delta = dtoff - dtdst
-    if delta:
-        dt += delta
-        # Set fold=1 so we can default to being in the fold for
-        # ambiguous dates.
-        dtdst = enfold(dt, fold=1).dst()
-        if dtdst is None:
-            raise ValueError("fromutc(): dt.dst gave inconsistent "
-                             "results; cannot convert")
-    return dt + dtdst
+            return datetime(*args)
 
 
 class _tzinfo(tzinfo):
@@ -148,6 +108,48 @@ class _tzinfo(tzinfo):
     def _fold(self, dt):
         return getattr(dt, 'fold', 0)
 
+    def _fromutc(self, dt):
+        """
+        Given a timezone-aware datetime in a given timezone, calculates a
+        timezone-aware datetime in a new timezone.
+
+        Since this is the one time that we *know* we have an unambiguous
+        datetime object, we take this opportunity to determine whether the
+        datetime is ambiguous and in a "fold" state (e.g. if it's the first
+        occurence, chronologically, of the ambiguous datetime).
+
+        :param dt:
+            A timezone-aware :class:`datetime.dateime` object.
+        """
+
+        # Re-implement the algorithm from Python's datetime.py
+        if not isinstance(dt, datetime):
+            raise TypeError("fromutc() requires a datetime argument")
+        if dt.tzinfo is not self:
+            raise ValueError("dt.tzinfo is not self")
+
+        dtoff = dt.utcoffset()
+        if dtoff is None:
+            raise ValueError("fromutc() requires a non-None utcoffset() "
+                             "result")
+
+        # The original datetime.py code assumes that `dst()` defaults to
+        # zero during ambiguous times. PEP 495 inverts this presumption, so
+        # for pre-PEP 495 versions of python, we need to tweak the algorithm.
+        dtdst = dt.dst()
+        if dtdst is None:
+            raise ValueError("fromutc() requires a non-None dst() result")
+        delta = dtoff - dtdst
+        if delta:
+            dt += delta
+            # Set fold=1 so we can default to being in the fold for
+            # ambiguous dates.
+            dtdst = enfold(dt, fold=1).dst()
+            if dtdst is None:
+                raise ValueError("fromutc(): dt.dst gave inconsistent "
+                                 "results; cannot convert")
+        return dt + dtdst
+
     def fromutc(self, dt):
         """
         Given a timezone-aware datetime in a given timezone, calculates a
@@ -169,4 +171,258 @@ class _tzinfo(tzinfo):
         # Set the default fold value for ambiguous dates
         return enfold(dt_wall, fold=_fold)
 
-_tzinfo._fromutc = _fromutc
+
+class tzrange(_tzinfo):
+    """
+    The ``tzrange`` object is a time zone specified by a set of offsets and
+    abbreviations, equivalent to the way the ``TZ`` variable can be specified
+    in POSIX-like systems, but using Python delta objects to specify DST
+    start, end and offsets.
+
+    :param stdabbr:
+        The abbreviation for standard time (e.g. ``'EST'``).
+
+    :param stdoffset:
+        An integer or :class:`datetime.timedelta` object or equivalent
+        specifying the base offset from UTC.
+
+        If unspecified, +00:00 is used.
+
+    :param dstabbr:
+        The abbreviation for DST / "Summer" time (e.g. ``'EDT'``).
+
+        If specified, with no other DST information, DST is assumed to occur
+        and the default behavior or ``dstoffset``, ``start`` and ``end`` is
+        used. If unspecified and no other DST information is specified, it
+        is assumed that this zone has no DST.
+
+        If this is unspecified and other DST information is *is* specified,
+        DST occurs in the zone but the time zone abbreviation is left
+        unchanged.
+
+    :param dstoffset:
+        A an integer or :class:`datetime.timedelta` object or equivalent
+        specifying the UTC offset during DST. If unspecified and any other DST
+        information is specified, it is assumed to be the STD offset +1 hour.
+
+    :param start:
+        A :class:`relativedelta.relativedelta` object or equivalent specifying
+        the time and time of year that daylight savings time starts. To specify,
+        for example, that DST starts at 2AM on the 2nd Sunday in March, pass:
+
+            ``relativedelta(hours=2, month=3, day=1, weekday=SU(+2))``
+
+        If unspecified and any other DST information is specified, the default
+        value is 2 AM on the first Sunday in April.
+
+    :param end:
+        A :class:`relativedelta.relativedelta` object or equivalent representing
+        the time and time of year that daylight savings time ends, with the
+        same specification method as in ``start``. One note is that this should
+        point to the first time in the *standard* zone, so if a transition
+        occurs at 2AM in the DST zone and the clocks are set back 1 hour to 1AM,
+        set the `hours` parameter to +1.
+
+
+    **Examples:**
+
+    .. testsetup:: tzrange
+
+        from dateutil.tz import tzrange, tzstr
+
+    .. doctest:: tzrange
+
+        >>> tzstr('EST5EDT') == tzrange("EST", -18000, "EDT")
+        True
+
+        >>> from dateutil.relativedelta import *
+        >>> range1 = tzrange("EST", -18000, "EDT")
+        >>> range2 = tzrange("EST", -18000, "EDT", -14400,
+        ...                  relativedelta(hours=+2, month=4, day=1,
+        ...                                weekday=SU(+1)),
+        ...                  relativedelta(hours=+1, month=10, day=31,
+        ...                                weekday=SU(-1)))
+        >>> tzstr('EST5EDT') == range1 == range2
+        True
+
+    """
+    def __init__(self, stdabbr, stdoffset=None,
+                 dstabbr=None, dstoffset=None,
+                 start=None, end=None):
+        super(tzrange, self).__init__()
+
+        global relativedelta
+        from dateutil import relativedelta
+
+        self._std_abbr = stdabbr
+        self._dst_abbr = dstabbr
+
+        try:
+            stdoffset = _total_seconds(stdoffset)
+        except (TypeError, AttributeError):
+            pass
+
+        try:
+            dstoffset = _total_seconds(dstoffset)
+        except (TypeError, AttributeError):
+            pass
+
+        if stdoffset is not None:
+            self._std_offset = timedelta(seconds=stdoffset)
+        else:
+            self._std_offset = ZERO
+
+        if dstoffset is not None:
+            self._dst_offset = timedelta(seconds=dstoffset)
+        elif dstabbr and stdoffset is not None:
+            self._dst_offset = self._std_offset+timedelta(hours=+1)
+        else:
+            self._dst_offset = ZERO
+
+        if dstabbr and start is None:
+            self._start_delta = relativedelta.relativedelta(
+                hours=+2, month=4, day=1, weekday=relativedelta.SU(+1))
+        else:
+            self._start_delta = start
+
+        if dstabbr and end is None:
+            self._end_delta = relativedelta.relativedelta(
+                hours=+1, month=10, day=31, weekday=relativedelta.SU(-1))
+        else:
+            self._end_delta = end
+
+        self._dst_base_offset = self._dst_offset - self._std_offset
+
+    def utcoffset(self, dt):
+        if dt is None:
+            return None
+
+        if self._isdst(dt):
+            return self._dst_offset
+        else:
+            return self._std_offset
+
+    def dst(self, dt):
+        if self._isdst(dt):
+            return self._dst_offset - self._std_offset
+        else:
+            return ZERO
+
+    @tzname_in_python2
+    def tzname(self, dt):
+        if self._isdst(dt):
+            return self._dst_abbr
+        else:
+            return self._std_abbr
+
+    def fromutc(self, dt):
+        """ Given a datetime in UTC, return local time """
+        if not isinstance(dt, datetime):
+            raise TypeError("fromutc() requires a datetime argument")
+
+        if dt.tzinfo is not self:
+            raise ValueError("dt.tzinfo is not self")
+
+        # Get transitions - if there are none, fixed offset
+        transitions = self._transitions(dt.year)
+        if transitions is None:
+            return dt + self.utcoffset(dt)
+
+        # Get the transition times in UTC
+        dston, dstoff = transitions
+
+        dston -= self._std_offset
+        dstoff -= self._std_offset
+
+        utc_transitions = (dston, dstoff)
+        dt_utc = dt.replace(tzinfo=None)
+
+
+        isdst = self._naive_isdst(dt_utc, utc_transitions)
+
+        if isdst:
+            dt_wall = dt + self._dst_offset
+        else:
+            dt_wall = dt + self._std_offset
+
+        _fold = int(not isdst and self.is_ambiguous(dt_wall))
+
+        return enfold(dt_wall, fold=_fold)
+
+    def is_ambiguous(self, dt):
+        transitions = self._transitions(dt.year)
+        if transitions is None:
+            return False
+
+        start, end = transitions
+
+        dt = dt.replace(tzinfo=None)
+        return (end <= dt < end + self._dst_base_offset)
+
+    def _isdst(self, dt):
+        transitions = self._transitions(dt.year)
+
+        if transitions is None:
+            return False
+
+        dt = dt.replace(tzinfo=None)
+
+        isdst = self._naive_isdst(dt, transitions)
+
+        # Handle ambiguous dates
+        if not isdst and self.is_ambiguous(dt):
+            return not self._fold(dt)
+        else:
+            return isdst
+
+    def _naive_isdst(self, dt, transitions):
+        dston, dstoff = transitions
+
+        dt = dt.replace(tzinfo=None)
+
+        if dston < dstoff:
+            isdst = dston <= dt < dstoff
+        else:
+            isdst = not dstoff <= dt < dston
+
+        return isdst
+
+    def _transitions(self, year):
+        if not self._start_delta:
+            return None
+
+        base_year = datetime(year, 1, 1)
+
+        start = base_year + self._start_delta
+        end = base_year + self._end_delta
+
+        return (start, end)
+
+    def __eq__(self, other):
+        if not isinstance(other, tzrange):
+            return NotImplemented
+
+        return (self._std_abbr == other._std_abbr and
+                self._dst_abbr == other._dst_abbr and
+                self._std_offset == other._std_offset and
+                self._dst_offset == other._dst_offset and
+                self._start_delta == other._start_delta and
+                self._end_delta == other._end_delta)
+
+    __hash__ = None
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def __repr__(self):
+        return "%s(...)" % self.__class__.__name__
+
+    __reduce__ = object.__reduce__
+
+
+def _total_seconds(td):
+    # Python 2.6 doesn't have a total_seconds() method on timedelta objects
+    return ((td.seconds + td.days * 86400) * 1000000 +
+            td.microseconds) // 1000000
+
+_total_seconds = getattr(timedelta, 'total_seconds', _total_seconds)

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -1,10 +1,11 @@
 from six import PY3
 from six.moves import _thread
 
-import datetime
+from datetime import datetime, tzinfo
 import copy
 
-__all__ = ['tzname_in_python2']
+__all__ = ['tzname_in_python2', 'enfold']
+
 
 def tzname_in_python2(namefunc):
     """Change unicode output into bytestrings in Python 2
@@ -22,21 +23,94 @@ def tzname_in_python2(namefunc):
     return adjust_encoding
 
 
-class _tzinfo(datetime.tzinfo):
+# The following is adapted from Alexander Belopolsky's tz library
+# https://github.com/abalkin/tz
+if hasattr(datetime, 'fold'):
+    # This is the pre-python 3.6 fold situation
+    def enfold(dt, fold=1):
+        return dt.replace(fold=fold)
+
+    _fromutc = tzinfo
+else:
+    class _DatetimeWithFold(datetime):
+        """
+        This is a class designed to provide a PEP 495-compliant interface for
+        Python versions before 3.6.
+        """
+        __slots__ = ()
+
+        @property
+        def fold(self):
+            return 1
+
+    def enfold(dt, fold=1):
+        if getattr(dt, 'fold', 0) == fold:
+            return dt
+
+        args = dt.timetuple()[:6]
+        args += (dt.microsecond, dt.tzinfo)
+
+        if fold:
+            return _DatetimeWithFold(*args)
+        else:
+            return datetime.datetime(*args)
+
+    def _fromutc(self, dt):
+        """
+        Given a timezone-aware datetime in a given timezone, calculates a
+        timezone-aware datetime in a new timezone.
+
+        Since this is the one time that we *know* we have an unambiguous
+        datetime object, we take this opportunity to determine whether the
+        datetime is ambiguous and in a "fold" state (e.g. if it's the first
+        occurence, chronologically, of the ambiguous datetime).
+
+        :param dt:
+            A timezone-aware :class:`datetime.dateime` object.
+        """
+
+        # Re-implement the algorithm from Python's datetime.py
+        if not isinstance(dt, datetime):
+            raise TypeError("fromutc() requires a datetime argument")
+        if dt.tzinfo is not self:
+            raise ValueError("dt.tzinfo is not self")
+
+        dtoff = dt.utcoffset()
+        if dtoff is None:
+            raise ValueError("fromutc() requires a non-None utcoffset() "
+                             "result")
+
+        # The original datetime.py code assumes that `dst()` defaults to
+        # zero during ambiguous times. PEP 495 inverts this presumption, so
+        # for pre-PEP 495 versions of python, we need to tweak the algorithm.
+        dtdst = dt.dst()
+        if dtdst is None:
+            raise ValueError("fromutc() requires a non-None dst() result")
+        delta = dtoff - dtdst
+        if delta:
+            dt += delta
+            # Set fold=1 so we can default to being in the fold for
+            # ambiguous dates.
+            dtdst = enfold(dt, fold=1).dst()
+            if dtdst is None:
+                raise ValueError("fromutc(): dt.dst gave inconsistent "
+                                 "results; cannot convert")
+        return dt + dtdst
+
+
+class _tzinfo(tzinfo):
     """
-    Base class for all `dateutil` `tzinfo` objects.
+    Base class for all ``dateutil`` ``tzinfo`` objects.
     """
     
     def __init__(self, *args, **kwargs):
         super(_tzinfo, self).__init__(*args, **kwargs)
 
-        self._fold = None
+    def _is_ambiguous(self, dt):
+        wall_0 = enfold(dt, fold=0)
+        wall_1 = enfold(dt, fold=1)
 
-    def _as_fold_naive(self):
-        tzi = copy.copy(self)
-        tzi._fold = None
-
-        return tzi
+        return wall_0.utcoffset() != wall_1.utcoffset()
 
     def _fold_status(self, dt_utc, dt_wall):
         """
@@ -60,9 +134,16 @@ class _tzinfo(datetime.tzinfo):
         if _fold is None:
             # This is always true on the DST side, but _fold has no meaning
             # outside of ambiguous times.
-            _fold = (dt_wall - dt_utc) != (dt_utc.utcoffset() - dt_utc.dst())
+            if self._is_ambiguous(dt_wall):
+                delta_wall = dt_wall - dt_utc
+                _fold = int(delta_wall == (dt_utc.utcoffset() - dt_utc.dst()))
+            else:
+                _fold = 0
 
         return _fold
+
+    def _fold(self, dt):
+        return getattr(dt, 'fold', 0)
 
     def fromutc(self, dt):
         """
@@ -74,28 +155,15 @@ class _tzinfo(datetime.tzinfo):
         datetime is ambiguous and in a "fold" state (e.g. if it's the first
         occurance, chronologically, of the ambiguous datetime).
 
-        .. caution ::
-
-            This creates a stateful ``tzinfo`` object that may not behave as
-            expected when performing arithmetic on timezone-aware datetimes.
-
         :param dt:
             A timezone-aware :class:`datetime.dateime` object.
         """
-        # Use a fold-naive version of this tzinfo for calculations
-        tzi = self._as_fold_naive()
-        dt = dt.replace(tzinfo=tzi)
-
-        dt_wall = super(_tzinfo, tzi).fromutc(dt)
+        dt_wall = self._fromutc(dt)
 
         # Calculate the fold status given the two datetimes.
         _fold = self._fold_status(dt, dt_wall)
 
         # Set the default fold value for ambiguous dates
-        if _fold != self._fold:
-            tzi._fold = _fold
-        else:
-            dt_wall = dt_wall.replace(tzinfo=self)
+        return enfold(dt_wall, fold=_fold)
 
-        return dt_wall
-    
+_tzinfo._fromutc = _fromutc

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -46,6 +46,9 @@ class tzutc(datetime.tzinfo):
     def tzname(self, dt):
         return "UTC"
 
+    def is_ambiguous(self, dt):
+        return False
+
     def __eq__(self, other):
         if not isinstance(other, (tzutc, tzoffset)):
             return NotImplemented
@@ -83,6 +86,9 @@ class tzoffset(datetime.tzinfo):
 
     def dst(self, dt):
         return ZERO
+
+    def is_ambiguous(self, dt):
+        return False
 
     @tzname_in_python2
     def tzname(self, dt):
@@ -145,14 +151,14 @@ class tzlocal(_tzinfo):
     def tzname(self, dt):
         return time.tzname[self._isdst(dt)]
 
-    def _naive_is_dst(self, dt):
-        timestamp = _datetime_to_timestamp(dt)
-        return time.localtime(timestamp + time.timezone).tm_isdst
-
     def is_ambiguous(self, dt):
         naive_dst = self._naive_is_dst(dt)
         return (not naive_dst and
                 (naive_dst != self._naive_is_dst(dt - self._dst_saved)))
+
+    def _naive_is_dst(self, dt):
+        timestamp = _datetime_to_timestamp(dt)
+        return time.localtime(timestamp + time.timezone).tm_isdst
 
     def _isdst(self, dt, fold_naive=True):
         # We can't use mktime here. It is unstable when deciding if
@@ -191,7 +197,7 @@ class tzlocal(_tzinfo):
                 return not self._fold(dt)
             else:
                 return True
-        
+
         return dstval
 
     def __eq__(self, other):
@@ -1288,6 +1294,81 @@ def gettz(name=None):
                         elif name in time.tzname:
                             tz = tzlocal()
     return tz
+
+
+def datetime_exists(dt, tz=None):
+    """
+    Given a datetime and a time zone, determine whether or not a given datetime
+    would fall in a gap.
+
+    :param dt:
+        A :class:`datetime.datetime` (whose time zone will be ignored if ``tz``
+        is provided.)
+
+    :param tz:
+        A :class:`datetime.tzinfo` with support for the ``fold`` attribute. If
+        ``None`` or not provided, the datetime's own time zone will be used.
+    
+    :return:
+        Returns a boolean value whether or not the "wall time" exists in ``tz``.
+    """
+    if tz is None:
+        if dt.tzinfo is None:
+            raise ValueError('Datetime is naive and no time zone provided.')
+        tz = dt.tzinfo
+
+    dt = dt.replace(tzinfo=None)
+
+    # This is essentially a test of whether or not the datetime can survive
+    # a round trip to UTC.
+    dt_rt = dt.replace(tzinfo=tz).astimezone(tzutc()).astimezone(tz)
+    dt_rt = dt_rt.replace(tzinfo=None)
+
+    return dt == dt_rt
+
+
+def datetime_ambiguous(dt, tz=None):
+    """
+    Given a datetime and a time zone, determine whether or not a given datetime
+    is ambiguous (i.e if there are two times differentiated only by their DST
+    status).
+
+    :param dt:
+        A :class:`datetime.datetime` (whose time zone will be ignored if ``tz``
+        is provided.)
+
+    :param tz:
+        A :class:`datetime.tzinfo` with support for the ``fold`` attribute. If
+        ``None`` or not provided, the datetime's own time zone will be used.
+    
+    :return:
+        Returns a boolean value whether or not the "wall time" is ambiguous in
+        ``tz``.
+    """
+    if tz is None:
+        if dt.tzinfo is None:
+            raise ValueError('Datetime is naive and no time zone provided.')
+
+        tz = dt.tzinfo
+
+    # If a time zone defines its own "is_ambiguous" function, we'll use that.
+    is_ambiguous_fn = getattr(tz, 'is_ambiguous', None)
+    if is_ambiguous_fn is not None:
+        try:
+            return tz.is_ambiguous(dt)
+        except:
+            pass
+
+    # If it doesn't come out and tell us it's ambiguous, we'll just check if
+    # the fold attribute has any effect on this particular date and time.
+    dt = dt.replace(tzinfo=tz)
+    wall_0 = enfold(dt, fold=0)
+    wall_1 = enfold(dt, fold=1)
+
+    same_offset = wall_0.utcoffset() == wall_1.utcoffset()
+    same_dst = wall_0.dst() == wall_1.dst()
+
+    return not (same_offset and same_dst)
 
 
 def _datetime_to_timestamp(dt):

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -792,6 +792,16 @@ class tzrange(_tzinfo):
         else:
             return self._std_abbr
 
+    def _is_ambiguous(self, dt):
+        transitions = self._transitions(dt.year)
+        if transitions is None:
+            return False
+
+        start, end = transitions
+
+        dt = dt.replace(tzinfo=None)
+        return (end <= dt < end + self._dst_base_offset)
+
     def _isdst(self, dt):
         transitions = self._transitions(dt.year)
 
@@ -803,9 +813,8 @@ class tzrange(_tzinfo):
         dt = dt.replace(tzinfo=None)
 
         # Handle ambiguous dates
-        if self._fold is not None:
-            if end <= dt < end + self._dst_base_offset:
-                return self._fold
+        if self._is_ambiguous(dt):
+            return not self._fold(dt)
 
         if start < end:
             return start <= dt < end

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -984,7 +984,7 @@ class _tzicalvtz(_tzinfo):
         dt = dt.replace(tzinfo=None)
 
         try:
-            return self._cachecomp[self._cachedate.index((dt, self._fold))]
+            return self._cachecomp[self._cachedate.index((dt, self._fold(dt)))]
         except ValueError:
             pass
 
@@ -1011,7 +1011,7 @@ class _tzicalvtz(_tzinfo):
             else:
                 lastcomp = comp[0]
 
-        self._cachedate.insert(0, (dt, self._fold))
+        self._cachedate.insert(0, (dt, self._fold(dt)))
         self._cachecomp.insert(0, lastcomp)
 
         if len(self._cachedate) > 10:
@@ -1021,7 +1021,7 @@ class _tzicalvtz(_tzinfo):
         return lastcomp
 
     def _find_compdt(self, comp, dt):
-        if comp.tzoffsetdiff < ZERO and not self._fold:
+        if comp.tzoffsetdiff < ZERO and self._fold(dt):
             dt -= comp.tzoffsetdiff
 
         compdt = comp.rrule.before(dt, inc=True)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -20,7 +20,8 @@ from operator import itemgetter
 from contextlib import contextmanager
 
 from six import string_types, PY3
-from ._common import tzname_in_python2, _tzinfo, enfold
+from ._common import tzname_in_python2, _tzinfo, _total_seconds
+from ._common import tzrange, enfold
 
 try:
     from .win import tzwin, tzwinlocal
@@ -649,211 +650,6 @@ class tzfile(_tzinfo):
         return (self.__class__, (None, self._filename), self.__dict__)
 
 
-class tzrange(_tzinfo):
-    """
-    The ``tzrange`` object is a time zone specified by a set of offsets and
-    abbreviations, equivalent to the way the ``TZ`` variable can be specified
-    in POSIX-like systems, but using Python delta objects to specify DST
-    start, end and offsets.
-
-    :param stdabbr:
-        The abbreviation for standard time (e.g. ``'EST'``).
-
-    :param stdoffset:
-        An integer or :class:`datetime.timedelta` object or equivalent
-        specifying the base offset from UTC.
-
-        If unspecified, +00:00 is used.
-
-    :param dstabbr:
-        The abbreviation for DST / "Summer" time (e.g. ``'EDT'``).
-
-        If specified, with no other DST information, DST is assumed to occur
-        and the default behavior or ``dstoffset``, ``start`` and ``end`` is
-        used. If unspecified and no other DST information is specified, it
-        is assumed that this zone has no DST.
-
-        If this is unspecified and other DST information is *is* specified,
-        DST occurs in the zone but the time zone abbreviation is left
-        unchanged.
-
-    :param dstoffset:
-        A an integer or :class:`datetime.timedelta` object or equivalent
-        specifying the UTC offset during DST. If unspecified and any other DST
-        information is specified, it is assumed to be the STD offset +1 hour.
-
-    :param start:
-        A :class:`relativedelta.relativedelta` object or equivalent specifying
-        the time and time of year that daylight savings time starts. To specify,
-        for example, that DST starts at 2AM on the 2nd Sunday in March, pass:
-
-            ``relativedelta(hours=2, month=3, day=1, weekday=SU(+2))``
-
-        If unspecified and any other DST information is specified, the default
-        value is 2 AM on the first Sunday in April.
-
-    :param end:
-        A :class:`relativedelta.relativedelta` object or equivalent representing
-        the time and time of year that daylight savings time ends, with the
-        same specification method as in ``start``. One note is that this should
-        point to the first time in the *standard* zone, so if a transition
-        occurs at 2AM in the DST zone and the clocks are set back 1 hour to 1AM,
-        set the `hours` parameter to +1.
-
-
-    **Examples:**
-
-    .. testsetup:: tzrange
-
-        from dateutil.tz import tzrange, tzstr
-
-    .. doctest:: tzrange
-
-        >>> tzstr('EST5EDT') == tzrange("EST", -18000, "EDT")
-        True
-
-        >>> from dateutil.relativedelta import *
-        >>> range1 = tzrange("EST", -18000, "EDT")
-        >>> range2 = tzrange("EST", -18000, "EDT", -14400,
-        ...                  relativedelta(hours=+2, month=4, day=1,
-        ...                                weekday=SU(+1)),
-        ...                  relativedelta(hours=+1, month=10, day=31,
-        ...                                weekday=SU(-1)))
-        >>> tzstr('EST5EDT') == range1 == range2
-        True
-
-    """
-    def __init__(self, stdabbr, stdoffset=None,
-                 dstabbr=None, dstoffset=None,
-                 start=None, end=None):
-        super(tzrange, self).__init__()
-
-        global relativedelta
-        from dateutil import relativedelta
-
-        self._std_abbr = stdabbr
-        self._dst_abbr = dstabbr
-
-        try:
-            stdoffset = _total_seconds(stdoffset)
-        except (TypeError, AttributeError):
-            pass
-
-        try:
-            dstoffset = _total_seconds(dstoffset)
-        except (TypeError, AttributeError):
-            pass
-
-        if stdoffset is not None:
-            self._std_offset = datetime.timedelta(seconds=stdoffset)
-        else:
-            self._std_offset = ZERO
-
-        if dstoffset is not None:
-            self._dst_offset = datetime.timedelta(seconds=dstoffset)
-        elif dstabbr and stdoffset is not None:
-            self._dst_offset = self._std_offset+datetime.timedelta(hours=+1)
-        else:
-            self._dst_offset = ZERO
-
-        if dstabbr and start is None:
-            self._start_delta = relativedelta.relativedelta(
-                hours=+2, month=4, day=1, weekday=relativedelta.SU(+1))
-        else:
-            self._start_delta = start
-
-        if dstabbr and end is None:
-            self._end_delta = relativedelta.relativedelta(
-                hours=+1, month=10, day=31, weekday=relativedelta.SU(-1))
-        else:
-            self._end_delta = end
-
-        self._dst_base_offset = self._dst_offset - self._std_offset
-
-    def utcoffset(self, dt):
-        if dt is None:
-            return None
-
-        if self._isdst(dt):
-            return self._dst_offset
-        else:
-            return self._std_offset
-
-    def dst(self, dt):
-        if self._isdst(dt):
-            return self._dst_offset - self._std_offset
-        else:
-            return ZERO
-
-    @tzname_in_python2
-    def tzname(self, dt):
-        if self._isdst(dt):
-            return self._dst_abbr
-        else:
-            return self._std_abbr
-
-    def is_ambiguous(self, dt):
-        transitions = self._transitions(dt.year)
-        if transitions is None:
-            return False
-
-        start, end = transitions
-
-        dt = dt.replace(tzinfo=None)
-        return (end <= dt < end + self._dst_base_offset)
-
-    def _isdst(self, dt):
-        transitions = self._transitions(dt.year)
-
-        if transitions is None:
-            return False
-
-        start, end = transitions
-
-        dt = dt.replace(tzinfo=None)
-
-        # Handle ambiguous dates
-        if self.is_ambiguous(dt):
-            return not self._fold(dt)
-
-        if start < end:
-            return start <= dt < end
-        else:
-            return not end <= dt < start
-
-    def _transitions(self, year):
-        if not self._start_delta:
-            return None
-
-        base_year = datetime.datetime(year, 1, 1)
-
-        start = base_year + self._start_delta
-        end = base_year + self._end_delta
-
-        return (start, end)
-
-    def __eq__(self, other):
-        if not isinstance(other, tzrange):
-            return NotImplemented
-
-        return (self._std_abbr == other._std_abbr and
-                self._dst_abbr == other._dst_abbr and
-                self._std_offset == other._std_offset and
-                self._dst_offset == other._dst_offset and
-                self._start_delta == other._start_delta and
-                self._end_delta == other._end_delta)
-
-    __hash__ = None
-
-    def __ne__(self, other):
-        return not (self == other)
-
-    def __repr__(self):
-        return "%s(...)" % self.__class__.__name__
-
-    __reduce__ = object.__reduce__
-
-
 class tzstr(tzrange):
     """
     ``tzstr`` objects are time zone objects specified by a time-zone string as
@@ -914,6 +710,7 @@ class tzstr(tzrange):
                 self._end_delta = self._delta(res.end, isend=1)
 
     def _delta(self, x, isend=0):
+        from dateutil import relativedelta
         kwargs = {}
         if x.month is not None:
             kwargs["month"] = x.month
@@ -1329,12 +1126,6 @@ def gettz(name=None):
                             tz = tzlocal()
     return tz
 
-def _total_seconds(td):
-    # Python 2.6 doesn't have a total_seconds() method on timedelta objects
-    return ((td.seconds + td.days * 86400) * 1000000 +
-            td.microseconds) // 1000000
-
-_total_seconds = getattr(datetime.timedelta, 'total_seconds', _total_seconds)
 
 def _datetime_to_timestamp(dt):
     """

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 
 from six import string_types, PY3
 from ._common import tzname_in_python2, _tzinfo, _total_seconds
-from ._common import tzrange, enfold
+from ._common import tzrangebase, enfold
 
 try:
     from .win import tzwin, tzwinlocal
@@ -650,6 +650,167 @@ class tzfile(_tzinfo):
         return (self.__class__, (None, self._filename), self.__dict__)
 
 
+class tzrange(tzrangebase):
+    """
+    The ``tzrange`` object is a time zone specified by a set of offsets and
+    abbreviations, equivalent to the way the ``TZ`` variable can be specified
+    in POSIX-like systems, but using Python delta objects to specify DST
+    start, end and offsets.
+
+    :param stdabbr:
+        The abbreviation for standard time (e.g. ``'EST'``).
+
+    :param stdoffset:
+        An integer or :class:`datetime.timedelta` object or equivalent
+        specifying the base offset from UTC.
+
+        If unspecified, +00:00 is used.
+
+    :param dstabbr:
+        The abbreviation for DST / "Summer" time (e.g. ``'EDT'``).
+
+        If specified, with no other DST information, DST is assumed to occur
+        and the default behavior or ``dstoffset``, ``start`` and ``end`` is
+        used. If unspecified and no other DST information is specified, it
+        is assumed that this zone has no DST.
+
+        If this is unspecified and other DST information is *is* specified,
+        DST occurs in the zone but the time zone abbreviation is left
+        unchanged.
+
+    :param dstoffset:
+        A an integer or :class:`datetime.timedelta` object or equivalent
+        specifying the UTC offset during DST. If unspecified and any other DST
+        information is specified, it is assumed to be the STD offset +1 hour.
+
+    :param start:
+        A :class:`relativedelta.relativedelta` object or equivalent specifying
+        the time and time of year that daylight savings time starts. To specify,
+        for example, that DST starts at 2AM on the 2nd Sunday in March, pass:
+
+            ``relativedelta(hours=2, month=3, day=1, weekday=SU(+2))``
+
+        If unspecified and any other DST information is specified, the default
+        value is 2 AM on the first Sunday in April.
+
+    :param end:
+        A :class:`relativedelta.relativedelta` object or equivalent representing
+        the time and time of year that daylight savings time ends, with the
+        same specification method as in ``start``. One note is that this should
+        point to the first time in the *standard* zone, so if a transition
+        occurs at 2AM in the DST zone and the clocks are set back 1 hour to 1AM,
+        set the `hours` parameter to +1.
+
+
+    **Examples:**
+
+    .. testsetup:: tzrange
+
+        from dateutil.tz import tzrange, tzstr
+
+    .. doctest:: tzrange
+
+        >>> tzstr('EST5EDT') == tzrange("EST", -18000, "EDT")
+        True
+
+        >>> from dateutil.relativedelta import *
+        >>> range1 = tzrange("EST", -18000, "EDT")
+        >>> range2 = tzrange("EST", -18000, "EDT", -14400,
+        ...                  relativedelta(hours=+2, month=4, day=1,
+        ...                                weekday=SU(+1)),
+        ...                  relativedelta(hours=+1, month=10, day=31,
+        ...                                weekday=SU(-1)))
+        >>> tzstr('EST5EDT') == range1 == range2
+        True
+
+    """
+    def __init__(self, stdabbr, stdoffset=None,
+                 dstabbr=None, dstoffset=None,
+                 start=None, end=None):
+
+        global relativedelta
+        from dateutil import relativedelta
+
+        self._std_abbr = stdabbr
+        self._dst_abbr = dstabbr
+
+        try:
+            stdoffset = _total_seconds(stdoffset)
+        except (TypeError, AttributeError):
+            pass
+
+        try:
+            dstoffset = _total_seconds(dstoffset)
+        except (TypeError, AttributeError):
+            pass
+
+        if stdoffset is not None:
+            self._std_offset = datetime.timedelta(seconds=stdoffset)
+        else:
+            self._std_offset = ZERO
+
+        if dstoffset is not None:
+            self._dst_offset = datetime.timedelta(seconds=dstoffset)
+        elif dstabbr and stdoffset is not None:
+            self._dst_offset = self._std_offset + datetime.timedelta(hours=+1)
+        else:
+            self._dst_offset = ZERO
+
+        if dstabbr and start is None:
+            self._start_delta = relativedelta.relativedelta(
+                hours=+2, month=4, day=1, weekday=relativedelta.SU(+1))
+        else:
+            self._start_delta = start
+
+        if dstabbr and end is None:
+            self._end_delta = relativedelta.relativedelta(
+                hours=+1, month=10, day=31, weekday=relativedelta.SU(-1))
+        else:
+            self._end_delta = end
+
+        self._dst_base_offset_ = self._dst_offset - self._std_offset
+        self.hasdst = bool(self._start_delta)
+
+    def transitions(self, year):
+        """
+        For a given year, get the DST on and off transition times, expressed
+        always on the standard time side. For zones with no transitions, this
+        function returns ``None``.
+
+        :param year:
+            The year whose transitions you would like to query.
+
+        :return:
+            Returns a :class:`tuple` of :class:`datetime.datetime` objects,
+            ``(dston, dstoff)`` for zones with an annual DST transition, or
+            ``None`` for fixed offset zones.
+        """
+        if not self.hasdst:
+            return None
+
+        base_year = datetime.datetime(year, 1, 1)
+
+        start = base_year + self._start_delta
+        end = base_year + self._end_delta
+
+        return (start, end)
+
+    def __eq__(self, other):
+        if not isinstance(other, tzrange):
+            return NotImplemented
+
+        return (self._std_abbr == other._std_abbr and
+                self._dst_abbr == other._dst_abbr and
+                self._std_offset == other._std_offset and
+                self._dst_offset == other._dst_offset and
+                self._start_delta == other._start_delta and
+                self._end_delta == other._end_delta)
+
+    @property
+    def _dst_base_offset(self):
+        return self._dst_base_offset_
+
+
 class tzstr(tzrange):
     """
     ``tzstr`` objects are time zone objects specified by a time-zone string as
@@ -708,6 +869,8 @@ class tzstr(tzrange):
             self._start_delta = self._delta(res.start)
             if self._start_delta:
                 self._end_delta = self._delta(res.end, isend=1)
+
+        self.hasdst = bool(self._start_delta)
 
     def _delta(self, x, isend=0):
         from dateutil import relativedelta

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -148,7 +148,7 @@ class tzlocal(_tzinfo):
         timestamp = _datetime_to_timestamp(dt)
         return time.localtime(timestamp + time.timezone).tm_isdst
 
-    def _is_ambiguous(self, dt):
+    def is_ambiguous(self, dt):
         naive_dst = self._naive_is_dst(dt)
         return (not naive_dst and
                 (naive_dst != self._naive_is_dst(dt - self._dst_saved)))
@@ -185,7 +185,7 @@ class tzlocal(_tzinfo):
         dstval = self._naive_is_dst(dt)
         fold = getattr(dt, 'fold', None)
 
-        if self._is_ambiguous(dt):
+        if self.is_ambiguous(dt):
             if fold is not None:
                 return not self._fold(dt)
             else:
@@ -570,7 +570,7 @@ class tzfile(_tzinfo):
 
         return self._get_ttinfo(idx)
 
-    def _is_ambiguous(self, dt, idx=None):
+    def is_ambiguous(self, dt, idx=None):
         if idx is None:
             idx = self._find_last_transition(dt)
 
@@ -595,7 +595,7 @@ class tzfile(_tzinfo):
             return idx
 
         # Get the current datetime as a timestamp
-        idx_offset = int(not _fold and self._is_ambiguous(dt, idx))
+        idx_offset = int(not _fold and self.is_ambiguous(dt, idx))
 
         return idx - idx_offset
 
@@ -792,7 +792,7 @@ class tzrange(_tzinfo):
         else:
             return self._std_abbr
 
-    def _is_ambiguous(self, dt):
+    def is_ambiguous(self, dt):
         transitions = self._transitions(dt.year)
         if transitions is None:
             return False
@@ -813,7 +813,7 @@ class tzrange(_tzinfo):
         dt = dt.replace(tzinfo=None)
 
         # Handle ambiguous dates
-        if self._is_ambiguous(dt):
+        if self.is_ambiguous(dt):
             return not self._fold(dt)
 
         if start < end:

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ envlist =
     py33,
     py34,
     py35,
+    py36
 
 [testenv]
-commands = python setup.py test -q
+commands = python setup.py test -q {posargs}
 deps =
     py26: unittest2
     six


### PR DESCRIPTION
This fixes #284 and #286 and adds Python 3.6 to the `tox.ini` to test the ability to fall back to real "fold" functionality.

This also adds the `is_ambiguous(dt)` function to all `_tzinfo` subclasses, and exposes the `enfold` function for backwards compatibility purposes, which is a first crack at #253.