### PR TITLE
Tweak CI due to version inconsistencies and other issues.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,38 @@ python:
   - "3.5"
   - "pypy"
   - "pypy3"
+
+matrix:
+  # pypy3 latest version is not playing nice.
+  allow_failures:
+    - python: "pypy3"
+
 before_install:
+  # Travis version of Pypy is old and is causing some jobs to fail, so
+  # we should build this ourselves
+  - "export PYENV_ROOT=$HOME/.pyenv"
+  - |
+    if [ "$TRAVIS_PYTHON_VERSION" = "pypy" ]; then
+      export PYPY_VERSION="5.4.1"
+      source ./ci_tools/pypy_upgrade.sh
+    fi
+  # Install codecov
   - if [[ $TRAVIS_PYTHON_VERSION == '3.2' ]]; then pip install coverage==3.7.1; fi
   - pip install codecov
+
 install:
   - pip install six
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
   - ./ci_tools/retry.sh python updatezinfo.py
+
+cache:
+  directories:
+    - $HOME/.pyenv
+    - $HOME/.cache/pip
+
 script:
   - coverage run --omit=setup.py,dateutil/test/* setup.py test
+
 after_success:
   - codecov
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,15 @@ install:
   - set path=c:\Program Files\PostgreSQL\9.3\bin\;%PATH%
   - set path=%PATH%;%PYTHON%;%PYTHON%/Scripts
 
+  # If this isn't done, I guess Appveyor will install to the Python2.7 version
+  - set pip_cmd=%PYTHON%/python.exe -m pip
+
   # Download scripts and dependencies
   - ps: Start-FileDownload 'https://bootstrap.pypa.io/get-pip.py'
-  - "python get-pip.py"
-  - "pip install six"
-  - "pip install coverage"
-  - "pip install codecov"
+  - "%PYTHON%/python.exe get-pip.py"
+  - "%pip_cmd% install six"
+  - "%pip_cmd% install coverage"
+  - "%pip_cmd% install codecov"
 
   # This frequently fails with network errors, so we'll retry it up to 5 times
   # with a 1 minute rate limit.

--- a/ci_tools/pypy_upgrade.sh
+++ b/ci_tools/pypy_upgrade.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Need to install an upgraded version of pypy.
+if [ -f "$PYENV_ROOT/bin/pyenv" ]; then
+  pushd "$PYENV_ROOT" && git pull && popd
+else
+  rm -rf "$PYENV_ROOT" && git clone --depth 1 https://github.com/yyuu/pyenv.git "$PYENV_ROOT"
+fi
+
+"$PYENV_ROOT/bin/pyenv" install --skip-existing "pypy-$PYPY_VERSION"
+virtualenv --python="$PYENV_ROOT/versions/pypy-$PYPY_VERSION/bin/python" "$HOME/virtualenvs/pypy-$PYPY_VERSION"
+source "$HOME/virtualenvs/pypy-$PYPY_VERSION/bin/activate"
+fi


### PR DESCRIPTION
It seems that something related to #302 is causing only old versions of pypy to fail, and travis only supplies old versions. This change will make pypy3 passing optional (no newer version is available) and forces an upgrade in travis.

There is also some sort of issue in Appveyor where the `pip` command isn't being found in the path for the right version of Python for some reason. This PR explicitly uses the right version of pip.