### PR TITLE
Add 3.6-dev and nightlies as allowed-fail build targets in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6-dev"
+  - "nightly"
   - "pypy"
   - "pypy3"
 
@@ -13,6 +15,8 @@ matrix:
   # pypy3 latest version is not playing nice.
   allow_failures:
     - python: "pypy3"
+    - python: "3.6-dev"
+    - python: "nightly"
 
 before_install:
   # Travis version of Pypy is old and is causing some jobs to fail, so


### PR DESCRIPTION
Python 3.6 is particularly important in this case because of the code paths with differences due to PEP-495 support.