### PR TITLE
Prevent improper behavior when a tzfile is attached to a datetime.time object.

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -845,6 +845,21 @@ class GettzTest(unittest.TestCase, TzFoldMixin):
         tz_get = self.gettz('Europe/Minsk')
         self.assertIs(dt_time(13, 20, tzinfo=tz_get).utcoffset(), None)
 
+    def testTimeOnlyGettzDST(self):
+        # gettz returns None
+        tz_get = self.gettz('Europe/Minsk')
+        self.assertIs(dt_time(13, 20, tzinfo=tz_get).dst(), None)
+
+    def testTimeOnlyGettzTzName(self):
+        tz_get = self.gettz('Europe/Minsk')
+        self.assertIs(dt_time(13, 20, tzinfo=tz_get).tzname(), None)
+
+    def testTimeOnlyFormatZ(self):
+        tz_get = self.gettz('Europe/Minsk')
+        t = dt_time(13, 20, tzinfo=tz_get)
+
+        self.assertEqual(t.strftime('%H%M%Z'), '1320')
+
     def testPortugalDST(self):
         # In 1996, Portugal changed from CET to WET
         PORTUGAL = self.gettz('Portugal')

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -675,6 +675,9 @@ class tzfile(_tzinfo):
         return self._find_ttinfo(dt).delta
 
     def dst(self, dt):
+        if dt is None:
+            return None
+
         if not self._ttinfo_dst:
             return ZERO
         
@@ -689,7 +692,7 @@ class tzfile(_tzinfo):
 
     @tzname_in_python2
     def tzname(self, dt):
-        if not self._ttinfo_std:
+        if not self._ttinfo_std or dt is None:
             return None
         return self._find_ttinfo(dt).abbr
 


### PR DESCRIPTION
Fixes #292.