### PR TITLE
Deprecated zoneinfo.gettz and added new preferred method.

### DIFF
--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -314,7 +314,7 @@ class tzrangebase(_tzinfo):
         :return:
             Returns ``True`` if ambiguous, ``False`` otherwise.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         if not self.hasdst:
             return False

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1335,9 +1335,11 @@ def gettz(name=None):
                         tz = tzwin(name)
                     except WindowsError:
                         tz = None
+
                 if not tz:
-                    from dateutil.zoneinfo import gettz
-                    tz = gettz(name)
+                    from dateutil.zoneinfo import get_zonefile_instance
+                    tz = get_zonefile_instance().get(name)
+
                 if not tz:
                     for c in name:
                         # name must have at least one offset to be a tzstr


### PR DESCRIPTION
Per #11, this deprecates `dateutil.zoneinfo.gettz()`. The new workflow is to generate a `ZoneInfoFile` instance and use `ZoneInfoFile.get` to retrieve time zones.

A new method, `zoneinfo.get_zonefile_instance()` is provided to make it easier to get the old "singleton" behavior.