### PR TITLE
Expose zoneinfo instance and other documentation fixes.

### DIFF
--- a/dateutil/_common.py
+++ b/dateutil/_common.py
@@ -1,0 +1,33 @@
+"""
+Common code used in multiple modules.
+"""
+
+class weekday(object):
+    __slots__ = ["weekday", "n"]
+
+    def __init__(self, weekday, n=None):
+        self.weekday = weekday
+        self.n = n
+
+    def __call__(self, n):
+        if n == self.n:
+            return self
+        else:
+            return self.__class__(self.weekday, n)
+
+    def __eq__(self, other):
+        try:
+            if self.weekday != other.weekday or self.n != other.n:
+                return False
+        except AttributeError:
+            return False
+        return True
+
+    __hash__ = None
+
+    def __repr__(self):
+        s = ("MO", "TU", "WE", "TH", "FR", "SA", "SU")[self.weekday]
+        if not self.n:
+            return s
+        else:
+            return "%s(%+d)" % (s, self.n)

--- a/dateutil/easter.py
+++ b/dateutil/easter.py
@@ -33,9 +33,9 @@ def easter(year, method=EASTER_WESTERN):
 
     These methods are represented by the constants:
 
-    EASTER_JULIAN   = 1
-    EASTER_ORTHODOX = 2
-    EASTER_WESTERN  = 3
+    * ``EASTER_JULIAN   = 1``
+    * ``EASTER_ORTHODOX = 2``
+    * ``EASTER_WESTERN  = 3``
 
     The default method is method 3.
 

--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -8,40 +8,11 @@ from math import copysign
 from six import integer_types
 from warnings import warn
 
-__all__ = ["relativedelta", "MO", "TU", "WE", "TH", "FR", "SA", "SU"]
-
-
-class weekday(object):
-    __slots__ = ["weekday", "n"]
-
-    def __init__(self, weekday, n=None):
-        self.weekday = weekday
-        self.n = n
-
-    def __call__(self, n):
-        if n == self.n:
-            return self
-        else:
-            return self.__class__(self.weekday, n)
-
-    def __eq__(self, other):
-        try:
-            if self.weekday != other.weekday or self.n != other.n:
-                return False
-        except AttributeError:
-            return False
-        return True
-
-    __hash__ = None
-
-    def __repr__(self):
-        s = ("MO", "TU", "WE", "TH", "FR", "SA", "SU")[self.weekday]
-        if not self.n:
-            return s
-        else:
-            return "%s(%+d)" % (s, self.n)
+from ._common import weekday
 
 MO, TU, WE, TH, FR, SA, SU = weekdays = tuple([weekday(x) for x in range(7)])
+
+__all__ = ["relativedelta", "MO", "TU", "WE", "TH", "FR", "SA", "SU"]
 
 
 class relativedelta(object):

--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -19,6 +19,8 @@ from six import advance_iterator, integer_types
 from six.moves import _thread, range
 import heapq
 
+from ._common import weekday as weekdaybase
+
 # For warning about deprecation of until and count
 from warnings import warn
 
@@ -58,37 +60,15 @@ FREQNAMES = ['YEARLY','MONTHLY','WEEKLY','DAILY','HOURLY','MINUTELY','SECONDLY']
 easter = None
 parser = None
 
-
-class weekday(object):
-    __slots__ = ["weekday", "n"]
-
-    def __init__(self, weekday, n=None):
+class weekday(weekdaybase):
+    """
+    This version of weekday does not allow n = 0.
+    """
+    def __init__(self, wkday, n=None):
         if n == 0:
-            raise ValueError("Can't create weekday with n == 0")
+            raise ValueError("Can't create weekday with n==0")
 
-        self.weekday = weekday
-        self.n = n
-
-    def __call__(self, n):
-        if n == self.n:
-            return self
-        else:
-            return self.__class__(self.weekday, n)
-
-    def __eq__(self, other):
-        try:
-            if self.weekday != other.weekday or self.n != other.n:
-                return False
-        except AttributeError:
-            return False
-        return True
-
-    def __repr__(self):
-        s = ("MO", "TU", "WE", "TH", "FR", "SA", "SU")[self.weekday]
-        if not self.n:
-            return s
-        else:
-            return "%s(%+d)" % (s, self.n)
+        super(weekday, self).__init__(wkday, n)
 
 MO, TU, WE, TH, FR, SA, SU = weekdays = tuple([weekday(x) for x in range(7)])
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -58,7 +58,7 @@ class tzutc(datetime.tzinfo):
         :return:
             Returns ``True`` if ambiguous, ``False`` otherwise.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         return False
 
@@ -119,7 +119,7 @@ class tzoffset(datetime.tzinfo):
         :return:
             Returns ``True`` if ambiguous, ``False`` otherwise.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         return False
 
@@ -196,7 +196,7 @@ class tzlocal(_tzinfo):
         :return:
             Returns ``True`` if ambiguous, ``False`` otherwise.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         naive_dst = self._naive_is_dst(dt)
         return (not naive_dst and
@@ -635,7 +635,7 @@ class tzfile(_tzinfo):
         :return:
             Returns ``True`` if ambiguous, ``False`` otherwise.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         if idx is None:
             idx = self._find_last_transition(dt)
@@ -1412,7 +1412,7 @@ def datetime_ambiguous(dt, tz=None):
         Returns a boolean value whether or not the "wall time" is ambiguous in
         ``tz``.
 
-    ..versionadded:: 2.6.0
+    .. versionadded:: 2.6.0
     """
     if tz is None:
         if dt.tzinfo is None:

--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -42,7 +42,7 @@ class tzres(object):
     Class for accessing `tzres.dll`, which contains timezone name related
     resources.
 
-    ..versionadded:: 2.5.0
+    .. versionadded:: 2.5.0
     """
     p_wchar = ctypes.POINTER(wintypes.WCHAR)        # Pointer to a wide char
 

--- a/dateutil/zoneinfo/__init__.py
+++ b/dateutil/zoneinfo/__init__.py
@@ -13,7 +13,7 @@ from contextlib import closing
 
 from dateutil.tz import tzfile
 
-__all__ = ["gettz", "gettz_db_metadata", "rebuild"]
+__all__ = ["get_zonefile_instance", "gettz", "gettz_db_metadata", "rebuild"]
 
 ZONEFILENAME = "dateutil-zoneinfo.tar.gz"
 METADATA_FN = 'METADATA'
@@ -71,8 +71,21 @@ class ZoneInfoFile(object):
             self.zones = dict()
             self.metadata = None
 
-    def get(self, name):
-        return self.zones.get(name)
+    def get(self, name, default=None):
+        """
+        Wrapper for :func:`ZoneInfoFile.zones.get`. This is a convenience method
+        for retrieving zones from the zone dictionary.
+        
+        :param name:
+            The name of the zone to retrieve. (Generally IANA zone names)
+
+        :param default:
+            The value to return in the event of a missing key.
+
+        .. versionadded:: 2.6.0
+
+        """
+        return self.zones.get(name, default)
 
 
 # The current API has gettz as a module function, although in fact it taps into


### PR DESCRIPTION
Last minute documentation fixes, also fixed the zonefile `__all__` so that the replacement command for `gettz()` is actually exposed.

At some point in the future we should also expose the `ZoneInfoFile` class itself to let people instantiate vs. their own streams, but I think that can be left for version 2.7.0.