### PR TITLE
respect parsed tz instead of preferring tzlocal

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -602,8 +602,6 @@ class parser(object):
                     raise ValueError("Offset must be tzinfo subclass, "
                                      "tz string, or int offset.")
                 ret = ret.replace(tzinfo=tzinfo)
-            elif res.tzname and res.tzname in time.tzname:
-                ret = ret.replace(tzinfo=tz.tzlocal())
             elif res.tzoffset == 0:
                 ret = ret.replace(tzinfo=tz.tzutc())
             elif res.tzoffset:

--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -8,9 +8,12 @@ import os
 import datetime
 import time
 import subprocess
+import sys
 import warnings
 import tempfile
 import pickle
+
+IS_WIN = sys.platform.startswith('win')
 
 
 class WarningTestMixin(object):

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from ._common import unittest
+from ._common import unittest, IS_WIN
 
 import os
 import time
@@ -13,6 +13,11 @@ from dateutil.parser import *
 import six
 from six import assertRaisesRegex, PY3
 from six.moves import StringIO
+
+if IS_WIN:
+    from ._common import TZWinContext as TZContext
+else:
+    from ._common import TZEnvContext as TZContext
 
 
 class ParserTest(unittest.TestCase):
@@ -134,15 +139,10 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 10, 36, 28))
 
     def testDateCommandFormatRespectTz(self):
-        orig = os.environ.pop("TZ", None)
-        os.environ["TZ"] = "Europe/London"
-        time.tzset()
-        self.assertEqual(parse("Wed, 02 Oct 2002 13:00:00 GMT"),
-                         datetime(2002, 10, 2, 13, 0, tzinfo=tzoffset('GMT', 0)))
-        del os.environ["TZ"]
-        if orig is not None:
-            os.environ["TZ"] = orig
-        time.tzset()
+        tz = "British Summer Time" if IS_WIN else "Europe/London"
+        with TZContext(tz):
+            self.assertEqual(parse("Wed, 02 Oct 2002 13:00:00 GMT"),
+                            datetime(2002, 10, 2, 13, 0, tzinfo=tzoffset('GMT', 0)))
 
     def testDateCommandFormatStrip1(self):
         self.assertEqual(parse("Thu Sep 25 10:36:28 2003"),

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -2,6 +2,9 @@
 from __future__ import unicode_literals
 from ._common import unittest
 
+import os
+import time
+
 from datetime import datetime, timedelta, date
 
 from dateutil.tz import tzoffset
@@ -10,6 +13,7 @@ from dateutil.parser import *
 import six
 from six import assertRaisesRegex, PY3
 from six.moves import StringIO
+
 
 class ParserTest(unittest.TestCase):
 
@@ -50,7 +54,6 @@ class ParserTest(unittest.TestCase):
 
             def read(self, *args, **kwargs):
                 return self.stream.read(*args, **kwargs)
-
 
         dstr = StringPassThrough(StringIO('2014 January 19'))
 
@@ -112,7 +115,6 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 10, 36, 28,
                                   tzinfo=self.brsttz))
 
-
     def testDateCommandFormatReversed(self):
         self.assertEqual(parse("2003 10:36:28 BRST 25 Sep Thu",
                                tzinfos=self.tzinfos),
@@ -125,10 +127,22 @@ class ParserTest(unittest.TestCase):
                                    tzinfos={"BRST": long(-10800)}),
                              datetime(2003, 9, 25, 10, 36, 28,
                                       tzinfo=self.brsttz))
+
     def testDateCommandFormatIgnoreTz(self):
         self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
                                ignoretz=True),
                          datetime(2003, 9, 25, 10, 36, 28))
+
+    def testDateCommandFormatRespectTz(self):
+        orig = os.environ.pop("TZ", None)
+        os.environ["TZ"] = "Europe/London"
+        time.tzset()
+        self.assertEqual(parse("Wed, 02 Oct 2002 13:00:00 GMT"),
+                         datetime(2002, 10, 2, 13, 0, tzinfo=tzoffset('GMT', 0)))
+        del os.environ["TZ"]
+        if orig is not None:
+            os.environ["TZ"] = orig
+        time.tzset()
 
     def testDateCommandFormatStrip1(self):
         self.assertEqual(parse("Thu Sep 25 10:36:28 2003"),

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from ._common import IS_WIN
 from ._common import unittest, PicklableMixin
 from ._common import total_seconds
 from ._common import TZEnvContext, TZWinContext
@@ -19,8 +20,6 @@ import copy
 import itertools
 
 from functools import partial
-
-IS_WIN = sys.platform.startswith('win')
 
 # dateutil imports
 from dateutil.relativedelta import relativedelta, SU


### PR DESCRIPTION
if the computer is in a timezone where daylight savings is observed,
such as Europe/London, and a date string specifies a timezone, the
parsed datetime may be incorrect if the parsed datetime falls within
daylight savings but the date string specified the standard time

this is especially problematic for users in GMT/BST when parsing
dates in http or email headers, which are frequently specified as
GMT

fixes #318 