### PR TITLE
Added new tz methods to documentation.

### DIFF
--- a/dateutil/tz/__init__.py
+++ b/dateutil/tz/__init__.py
@@ -1,4 +1,5 @@
 from .tz import *
 
 __all__ = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
-           "tzstr", "tzical", "tzwin", "tzwinlocal", "gettz"]
+           "tzstr", "tzical", "tzwin", "tzwinlocal", "gettz",
+           "enfold", "datetime_ambiguous", "datetime_exists"]

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -45,7 +45,7 @@ if hasattr(datetime, 'fold'):
             subclass of :py:class:`datetime.datetime` with the ``fold``
             attribute added, if ``fold`` is 1.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         return dt.replace(fold=fold)
 
@@ -56,7 +56,7 @@ else:
         Python versions before 3.6. It is used only for dates in a fold, so
         the ``fold`` attribute is fixed at ``1``.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         __slots__ = ()
 
@@ -80,7 +80,7 @@ else:
             subclass of :py:class:`datetime.datetime` with the ``fold``
             attribute added, if ``fold`` is 1.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
         if getattr(dt, 'fold', 0) == fold:
             return dt
@@ -111,7 +111,7 @@ class _tzinfo(tzinfo):
         :return:
             Returns ``True`` if ambiguous, ``False`` otherwise.
 
-        ..versionadded:: 2.6.0
+        .. versionadded:: 2.6.0
         """
 
         dt = dt.replace(tzinfo=self)
@@ -236,7 +236,7 @@ class tzrangebase(_tzinfo):
           abbreviations in DST and STD, respectively.
         * ``_hasdst``: Whether or not the zone has DST.
 
-    ..versionadded:: 2.6.0
+    .. versionadded:: 2.6.0
     """
     def __init__(self):
         raise NotImplementedError('tzrangebase is an abstract base class')


### PR DESCRIPTION
`tz.enfold`, `tz.datetime_ambiguous` and `tz.datetime_exists` are not currently in the documentation because they were not added to `tz/__init__.py:__all__`. This fixes that.