### PR TITLE
Append to skipped_tokens when not val_is_ampm

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -968,6 +968,9 @@ class parser(object):
 
                         res.ampm = value
 
+                    elif fuzzy:
+                        last_skipped_token_i = skip_token(skipped_tokens, 
+                                                    last_skipped_token_i, i, l)
                     i += 1
                     continue
 
@@ -1032,13 +1035,8 @@ class parser(object):
                 if not (info.jump(l[i]) or fuzzy):
                     return None, None
 
-                if last_skipped_token_i == i - 1:
-                    # recombine the tokens
-                    skipped_tokens[-1] += l[i]
-                else:
-                    # just append
-                    skipped_tokens.append(l[i])
-                last_skipped_token_i = i
+                last_skipped_token_i = skip_token(skipped_tokens,
+                                                last_skipped_token_i, i, l)
                 i += 1
 
             # Process year/month/day
@@ -1065,6 +1063,18 @@ class parser(object):
             return res, None
 
 DEFAULTPARSER = parser()
+
+
+def skip_token(skipped_tokens, last_skipped_token_i, i, l):
+    if last_skipped_token_i == i - 1:
+        # recombine the tokens
+        skipped_tokens[-1] += l[i]
+    else:
+        # just append
+        skipped_tokens.append(l[i])
+    last_skipped_token_i = i
+    return last_skipped_token_i
+
 
 
 def parse(timestr, parserinfo=None, **kwargs):

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -969,7 +969,7 @@ class parser(object):
                         res.ampm = value
 
                     elif fuzzy:
-                        last_skipped_token_i = skip_token(skipped_tokens, 
+                        last_skipped_token_i = self._skip_token(skipped_tokens, 
                                                     last_skipped_token_i, i, l)
                     i += 1
                     continue
@@ -1035,7 +1035,7 @@ class parser(object):
                 if not (info.jump(l[i]) or fuzzy):
                     return None, None
 
-                last_skipped_token_i = skip_token(skipped_tokens,
+                last_skipped_token_i = self._skip_token(skipped_tokens,
                                                 last_skipped_token_i, i, l)
                 i += 1
 
@@ -1062,18 +1062,20 @@ class parser(object):
         else:
             return res, None
 
+    @staticmethod
+    def _skip_token(skipped_tokens, last_skipped_token_i, i, l):
+        if last_skipped_token_i == i - 1:
+            # recombine the tokens
+            skipped_tokens[-1] += l[i]
+        else:
+            # just append
+            skipped_tokens.append(l[i])
+        last_skipped_token_i = i
+        return last_skipped_token_i
+
+
 DEFAULTPARSER = parser()
 
-
-def skip_token(skipped_tokens, last_skipped_token_i, i, l):
-    if last_skipped_token_i == i - 1:
-        # recombine the tokens
-        skipped_tokens[-1] += l[i]
-    else:
-        # just append
-        skipped_tokens.append(l[i])
-    last_skipped_token_i = i
-    return last_skipped_token_i
 
 
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -1077,8 +1077,6 @@ class parser(object):
 DEFAULTPARSER = parser()
 
 
-
-
 def parse(timestr, parserinfo=None, **kwargs):
     """
 

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -551,13 +551,19 @@ class ParserTest(unittest.TestCase):
                                   tzinfo=self.brsttz))
 
     def testFuzzyWithTokens(self):
-        s = "Today is 25 of September of 2003, exactly " \
+        s1 = "Today is 25 of September of 2003, exactly " \
             "at 10:49:41 with timezone -03:00."
-        self.assertEqual(parse(s, fuzzy_with_tokens=True),
+        self.assertEqual(parse(s1, fuzzy_with_tokens=True),
                          (datetime(2003, 9, 25, 10, 49, 41,
                                    tzinfo=self.brsttz),
                          ('Today is ', 'of ', ', exactly at ',
                           ' with timezone ', '.')))
+
+        s2 = "http://biz.yahoo.com/ipo/p/600221.html"
+        self.assertEqual(parse(s2, fuzzy_with_tokens=True),
+                         (datetime(2060, 2, 21, 0, 0, 0),
+                         ('http://biz.yahoo.com/ipo/p/', '.html')))
+
 
     def testFuzzyAMPMProblem(self):
         # Sometimes fuzzy parsing results in AM/PM flag being set without


### PR DESCRIPTION
Fuzzy-parsing drops tokens in cases where a token is initially assessed with val_is_ampm==True (line 941) and later determined not to be (line 950).  A motivating example:

    >>> dateutil.parser.parse('http://biz.yahoo.com/ipo/p/600221.html', fuzzy_with_tokens=True)[1]
    (u'http://biz.yahoo.com/ipo/', u'/', u'.html')

This pull request prevents the "p" from being dropped, so this becomes:

    >>> dateutil.parser.parse('http://biz.yahoo.com/ipo/p/600221.html', fuzzy_with_tokens=True)[1]
    (u'http://biz.yahoo.com/ipo/p/', u'.html')


