### PR TITLE
Resolve ymd validation

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -409,7 +409,7 @@ class _ymd(list):
 
     def resolve_ymd(self, mstridx, yearfirst, dayfirst):
         len_ymd = len(self)
-        year, month, day = (None, None, None)
+        (year, month, day) = (None, None, None)
 
         if len_ymd > 3:
             raise ValueError("More than three YMD values")
@@ -429,39 +429,39 @@ class _ymd(list):
             # Two members with numbers
             if self[0] > 31:
                 # 99-01
-                year, month = self
+                (year, month) = self
             elif self[1] > 31:
                 # 01-99
-                month, year = self
+                (month, year) = self
             elif dayfirst and self[1] <= 12:
                 # 13-01
-                day, month = self
+                (day, month) = self
             else:
                 # 01-13
-                month, day = self
+                (month, day) = self
 
         elif len_ymd == 3:
             # Three members
             if mstridx == 0:
-                month, day, year = self
+                (month, day, year) = self
             elif mstridx == 1:
                 if self[0] > 31 or (yearfirst and self[2] <= 31):
                     # 99-Jan-01
-                    year, month, day = self
+                    (year, month, day) = self
                 else:
                     # 01-Jan-01
                     # Give precendence to day-first, since
                     # two-digit years is usually hand-written.
-                    day, month, year = self
+                    (day, month, year) = self
 
             elif mstridx == 2:
                 # WTF!?
                 if self[1] > 31:
                     # 01-99-Jan
-                    day, year, month = self
+                    (day, year, month) = self
                 else:
                     # 99-01-Jan
-                    year, day, month = self
+                    (year, day, month) = self
 
             else:
                 if self[0] > 31 or \
@@ -469,17 +469,17 @@ class _ymd(list):
                    (yearfirst and self[1] <= 12 and self[2] <= 31):
                     # 99-01-01
                     if dayfirst and self[2] <= 12:
-                        year, day, month = self
+                        (year, day, month) = self
                     else:
-                        year, month, day = self
+                        (year, month, day) = self
                 elif self[0] > 12 or (dayfirst and self[1] <= 12):
                     # 13-01-01
-                    day, month, year = self
+                    (day, month, year) = self
                 else:
                     # 01-13-01
-                    month, day, year = self
+                    (month, day, year) = self
 
-        return year, month, day
+        return (year, month, day)
 
 
 class parser(object):

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -378,25 +378,6 @@ class _ymd(list):
         self.tzstr = tzstr
         self.mstridx = -1
 
-    @property
-    def has_year(self):
-        """
-        has_year checks whether a token has been appended that is
-        unambiguously a year.  Or more precisely, that is unambiguously
-        neither a day nor a month.
-        """
-        return self.century_specified or any(x > 31 for x in self)
-
-    @property
-    def has_month(self):
-        """
-        self.mstridx is assigned when a value is appended based on a
-        month-name, which is unambiguously a month.  has_month is
-        True if and only if this has occurred.
-        """
-        return self.mstridx != -1
-
-
     @staticmethod
     def token_could_be_year(token, year):
         try:
@@ -558,16 +539,16 @@ class _ymd(list):
             # Two members with numbers
             if self[0] > 31:
                 # 99-01
-                (year, month) = self
+                year, month = self
             elif self[1] > 31:
                 # 01-99
-                (month, year) = self
+                month, year = self
             elif dayfirst and self[1] <= 12:
                 # 13-01
-                (day, month) = self
+                day, month = self
             else:
                 # 01-13
-                (month, day) = self
+                month, day = self
 
         elif len_ymd == 3:
             # Three members
@@ -589,17 +570,17 @@ class _ymd(list):
                    (yearfirst and self[1] <= 12 and self[2] <= 31):
                     # 99-01-01
                     if dayfirst and self[2] <= 12:
-                        (year, day, month) = self
+                        year, day, month = self
                     else:
-                        (year, month, day) = self
+                        year, month, day = self
                 elif self[0] > 12 or (dayfirst and self[1] <= 12):
                     # 13-01-01
-                    (day, month, year) = self
+                    day, month, year = self
                 else:
                     # 01-13-01
-                    (month, day, year) = self
+                    month, day, year = self
 
-        return (year, month, day)
+        return year, month, day
 
 
 class parser(object):
@@ -958,7 +939,6 @@ class parser(object):
                                     ymd.append(value)
                                     assert mstridx == -1
                                     mstridx = len(ymd)-1
-                                    ymd.mstridx = mstridx
                                 else:
                                     return None, None
 
@@ -973,7 +953,6 @@ class parser(object):
                                     ymd.append(value)
                                     assert mstridx == -1
                                     mstridx = len(ymd)-1
-                                    ymd.mstridx = mstridx
                                 else:
                                     ymd.append(l[i])
 
@@ -1023,7 +1002,6 @@ class parser(object):
                     ymd.append(value)
                     assert mstridx == -1
                     mstridx = len(ymd)-1
-                    ymd.mstridx = mstridx
 
                     i += 1
                     if i < len_l:

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -376,7 +376,6 @@ class _ymd(list):
         super(self.__class__, self).__init__(*args, **kwargs)
         self.century_specified = False
         self.tzstr = tzstr
-        self.mstridx = -1
 
     @staticmethod
     def token_could_be_year(token, year):
@@ -500,11 +499,6 @@ class _ymd(list):
         return (year, month, day)
 
     def resolve_ymd(self, mstridx, yearfirst, dayfirst, guess_fail=False):
-        if mstridx == -1:
-            # If the user does not pass a non-null mstridx, use the
-            # inferred value.
-            mstridx = self.mstridx
-
         len_ymd = len(self)
         (year, month, day) = (None, None, None)
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -427,7 +427,98 @@ class _ymd(list):
 
         super(self.__class__, self).append(int(val))
 
-    def resolve_ymd(self, mstridx, yearfirst, dayfirst):
+
+    def _resolve_known_month(self, mstridx, yearfirst, dayfirst, guess_fail=False):
+        (year, month, day) = (None, None, None)
+
+        candidates = [x for x in self]
+        if mstridx != -1:
+            month = candidates.pop(mstridx)
+
+        gt31 = [x for x in candidates if x > 31 or x == 0]
+        # If there is a zero, it must be a truncated year, e.g. "00"
+        # is intended to be "2000".
+        if len(gt31) > 1:
+            raise ValueError("More than one YMD value exceeds 31", candidates)
+
+        elif gt31:
+            year = gt31[0]
+            candidates.remove(year) ## Is this operation ungainly?
+            day = candidates[0]
+
+        else:
+            # We need to choose between two possible assignments:
+            # (year, day) or (day, year).  the next check is to see
+            # if one or both of these induces a valid datetime.
+            mr0 = monthrange(candidates[0], month)[1]
+            mr1 = monthrange(candidates[1], month)[1]
+            
+            if candidates[1] > mr0 and candidates[0] > mr1:
+                # There are no valid assigments.
+                msg = "Neither assignment option produces a valid year/month/day for month %s"
+                raise ValueError(msg % month, candidates)
+
+            elif candidates[1] > mr0:
+                # There is only one valid assigment.
+                (day, year) = candidates
+            
+            elif candidates[0] > mr1:
+                # There is only one valid assigment.
+                (year, day) = candidates
+
+            elif yearfirst:
+                # Both assignments are valid: default to the user's
+                # specified preference.
+                (year, day) = candidates
+            
+            elif dayfirst:
+                # Both assignments are valid: default to the user's
+                # specified preference.
+                (day, year) = candidates
+
+            elif guess_fail:
+                # In the face of ambiguity...
+                raise ValueError('Failing instead of guessing', candidates)
+                ## is this part of what find_probable_year_index is for?
+            else:
+                # Finally if there is no other way to judge between the
+                # two options, use US conventions preferring the year be
+                # either first or last, preferably last.
+                #
+                # These tokens were appended to the list in the order
+                # they were found*, so we can ask what ordering of tokens
+                # makes the most sense.
+                #
+                # For example, suppose the remaining tokens are (20, 14)
+                # and the month found was Feb.  The date is either
+                # "Feb 20, 2014" or "Feb 14, 2020".  Which one of these
+                # makes the most sense depends on what order the three
+                # appear in.
+                #
+                # Feb 20 14 --> choose "Feb 20 2014" over "Feb 2020 14"
+                # 20 14 Feb --> choose "2020 14 Feb" over "20 2014 Feb"
+                # 20 Feb 14 --> choose "20 Feb 2014" over "2020 Feb 14"
+                #
+                # This last cast is less clear-cut than the others.
+                #
+                # * This behavior should probably not be relied on
+                # staying constant.
+
+                if mstridx == 0:
+                    # Put the year at the end
+                    (day, year) = candidates
+                elif mstridx == 1:
+                    # Both the beginning and the end are available for the year,
+                    # but we prefer the end.
+                    (day, year) = candidates
+                elif mstridx == 2:
+                    # To avoid having the year be "in the middle", we choose
+                    # to put the year first
+                    (year, day) = candidates
+        
+        return (year, month, day)
+
+    def resolve_ymd(self, mstridx, yearfirst, dayfirst, guess_fail=False):
         if mstridx == -1:
             # If the user does not pass a non-null mstridx, use the
             # inferred value.
@@ -436,8 +527,21 @@ class _ymd(list):
         len_ymd = len(self)
         (year, month, day) = (None, None, None)
 
+        candidates = [x for x in self]
+        gt31 = [x for x in candidates if x > 31 or x == 0]
+        # If there is a zero, it must be a truncated year, e.g. "00"
+        # is intended to be "2000".
+        if len(gt31) > 1:
+            raise ValueError("More than one YMD value exceeds 31", candidates)
+        
+        lt13 = [x for x in candidates if 0 < x < 13]
+        if len_ymd == 3 and lt13 == []:
+            raise ValueError("No YMD values are between 1 and 12", candidates)
+
         if len_ymd > 3:
             raise ValueError("More than three YMD values")
+        
+
         elif len_ymd == 1 or (mstridx != -1 and len_ymd == 2):
             # One member, or two members with a month string
             if mstridx != -1:
@@ -467,28 +571,19 @@ class _ymd(list):
 
         elif len_ymd == 3:
             # Three members
-            if mstridx == 0:
-                (month, day, year) = self
-            elif mstridx == 1:
-                if self[0] > 31 or (yearfirst and self[2] <= 31):
-                    # 99-Jan-01
-                    (year, month, day) = self
-                else:
-                    # 01-Jan-01
-                    # Give precendence to day-first, since
-                    # two-digit years is usually hand-written.
-                    (day, month, year) = self
 
-            elif mstridx == 2:
-                # WTF!?
-                if self[1] > 31:
-                    # 01-99-Jan
-                    (day, year, month) = self
-                else:
-                    # 99-01-Jan
-                    (year, day, month) = self
+            if len(lt13) == 1 and mstridx == -1:
+                # There is only one token that can possibly be the month,
+                # so we can infer mstridx.
+                mstridx = candidates.index(lt13[0])
 
-            else:
+            if mstridx != -1:
+                (year, month, day) = self._resolve_known_month(mstridx,
+                                                    yearfirst,
+                                                    dayfirst,
+                                                    guess_fail
+                                                    )
+            else:    
                 if self[0] > 31 or \
                     self.find_probable_year_index(_timelex.split(self.tzstr)) == 0 or \
                    (yearfirst and self[1] <= 12 and self[2] <= 31):

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, date
 
 from dateutil.tz import tzoffset
 from dateutil.parser import *
+from dateutil.parser import _ymd
 
 import six
 from six import assertRaisesRegex, PY3
@@ -901,14 +902,21 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse(dstr), expected)
 
     def testYMDResolveRaises(self):
-        # Within resolve_ymd, the message raised should be
-        # "More than one YMD value exceeds 31"
-        assertRaisesRegex(self, ValueError, 'Unknown string format',
-                          parse, '32 04 2016')
+        ymd = _ymd('32 04 2016')
+        ymd.append(32)
+        ymd.append(04)
+        ymd.append(2016)
+        assertRaisesRegex(self, ValueError, 'More than one YMD value exceeds 31', 
+            ymd.resolve_ymd, mstridx=-1, yearfirst=False, dayfirst=False
+            )
+
+    def testYMDResolveNoMonthOptions(self):
+        ymd = _ymd('14 13 2016')
+        ymd.append(14)
+        ymd.append(13)
+        ymd.append(2016)
+        assertRaisesRegex(self, ValueError, 'No YMD values are between 1 and 12', 
+            ymd.resolve_ymd, mstridx=-1, yearfirst=False, dayfirst=False
+            )
+
         
-        # Within resolve_ymd, the message raised should be
-        # "No YMD values are between 1 and 12"
-        assertRaisesRegex(self, ValueError, 'Unknown string format',
-                          parse, '14 13 2016')
-
-

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -904,7 +904,7 @@ class ParserTest(unittest.TestCase):
     def testYMDResolveRaises(self):
         ymd = _ymd('32 04 2016')
         ymd.append(32)
-        ymd.append(04)
+        ymd.append(4)
         ymd.append(2016)
         assertRaisesRegex(self, ValueError, 'More than one YMD value exceeds 31', 
             ymd.resolve_ymd, mstridx=-1, yearfirst=False, dayfirst=False


### PR DESCRIPTION
This branch implements a _ymd method "_resolve_known_month" called from within resolve_ymd.  This does the following:

1) In cases where there is not a month-name but a month can be inferred, infer mstridx.  For example, if we see "31/04/30", then despite not having explicitly seen "Apr", we can infer mstridx as 1.

2) If the month has been pinned down, check which (year, day) assignments imply valid dates.  Using the "31 Apr 30" example, "Apr 30, 2031" is valid, but "Apr 31, 2030" is not.  This branch returns datetime.datetime(2031, 4, 30), whereas the status-quo raises "ValueError: day is out of range for month".
\
Tests for this are implemented, several of which fail under the status-quo.

3) If there are multiple valid options and neither yearfirst nor dayfirst are specified, an optional argument "guess_fail" (default False) raises in order to refuse the temptation to guess.
\
Finally, choices between multiple valid options are based on US conventions, matching the current logic.

