### PR TITLE
Fix unclosed file warning in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,8 @@ if isfile("MANIFEST"):
 
 
 TOPDIR = os.path.dirname(__file__) or "."
-VERSION = re.search('__version__ = "([^"]+)"',
-                    codecs.open(TOPDIR + "/dateutil/__init__.py",
-                                encoding='utf-8').read()).group(1)
+with codecs.open(TOPDIR + "/dateutil/__init__.py", encoding='utf-8') as f:
+    VERSION = re.search('__version__ = "([^"]+)"', f.read()).group(1)
 
 
 setup(name="python-dateutil",


### PR DESCRIPTION
With warnings turned on, appears as:

```
setup.py:17: ResourceWarning: unclosed file <_io.BufferedReader name='./dateutil/__init__.py'>
```