### PR TITLE
Remove unnecessary coerce to unicode/bytes code

### DIFF
--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -19,14 +19,8 @@ class ParserTest(unittest.TestCase):
         self.default = datetime(2003, 9, 25)
 
         # Parser should be able to handle bytestring and unicode
-        base_str = '2014-05-01 08:00:00'
-        try:
-            # Python 2.x
-            self.uni_str = unicode(base_str)
-            self.str_str = str(base_str)
-        except NameError:
-            self.uni_str = str(base_str)
-            self.str_str = bytes(base_str.encode())
+        self.uni_str = '2014-05-01 08:00:00'
+        self.str_str = self.uni_str.encode()
 
     def testEmptyString(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
As the file contains `from __future__ import unicode_literals`, the bare
string is already a unicode object. No need to coerce it. Further, it
can always be converted to a bytes object with `.encode()`, no need to
catch `NameError`.