### PR TITLE
Clean up unused imports

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -35,7 +35,7 @@ import time
 import collections
 import re
 from io import StringIO
-from calendar import monthrange, isleap
+from calendar import monthrange
 
 from six import text_type, binary_type, integer_types
 

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -2,12 +2,11 @@
 from __future__ import unicode_literals
 from ._common import unittest
 
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 
 from dateutil.tz import tzoffset
 from dateutil.parser import *
 
-import six
 from six import assertRaisesRegex, PY3
 from six.moves import StringIO
 

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 from ._common import WarningTestMixin, unittest
 
-import calendar
 from datetime import datetime, date
 from six import PY3
 

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -11,12 +11,9 @@ from datetime import time as dt_time
 from datetime import tzinfo
 from six import BytesIO, StringIO
 
-import os
-import subprocess
 import sys
 import base64
 import copy
-import itertools
 
 from functools import partial
 

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -1,8 +1,7 @@
 from six import PY3
-from six.moves import _thread
 
 from datetime import datetime, timedelta, tzinfo
-import copy
+
 
 ZERO = timedelta(0)
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -13,13 +13,8 @@ import time
 import sys
 import os
 import bisect
-import copy
 
-from operator import itemgetter
-
-from contextlib import contextmanager
-
-from six import string_types, PY3
+from six import string_types
 from ._common import tzname_in_python2, _tzinfo, _total_seconds
 from ._common import tzrangebase, enfold
 

--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -12,7 +12,6 @@ except ValueError:
     # ValueError is raised on non-Windows systems for some horrible reason.
     raise ImportError("Running tzwin on non-Windows system")
 
-from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase
 
 __all__ = ["tzwin", "tzwinlocal", "tzres"]

--- a/dateutil/zoneinfo/__init__.py
+++ b/dateutil/zoneinfo/__init__.py
@@ -1,9 +1,5 @@
 # -*- coding: utf-8 -*-
-import logging
-import os
 import warnings
-import tempfile
-import shutil
 import json
 
 from tarfile import TarFile


### PR DESCRIPTION
Discovered using flake8. If you'd like, I can add routine flake8 testing
to the CI configuration to prevent new unused imports.