### PR TITLE
Avoid duplicate test names

### DIFF
--- a/dateutil/test/test_relativedelta.py
+++ b/dateutil/test/test_relativedelta.py
@@ -422,7 +422,7 @@ class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
         self.assertEqual(rd2.normalized(),
             relativedelta(days=1, hours=11, minutes=31, seconds=12))
 
-    def testRelativeDeltaNormalizeFractionalDays(self):
+    def testRelativeDeltaNormalizeFractionalDays2(self):
         # Equivalent to (hours=1, minutes=30)
         rd1 = relativedelta(hours=1.5)
 
@@ -453,7 +453,7 @@ class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
         self.assertEqual(rd1.normalized(),
             relativedelta(seconds=45, microseconds=25000))
 
-    def testRelativeDeltaFractionalPositiveOverflow(self):
+    def testRelativeDeltaFractionalPositiveOverflow2(self):
         # Equivalent to (days=1, hours=14)
         rd1 = relativedelta(days=1.5, hours=2)
         self.assertEqual(rd1.normalized(),

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -2871,12 +2871,6 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
         self._rrulestr_reverse_test(rule)
 
     def testToStrYearlyByMonth(self):
-        rule = rrule(YEARLY, count=3, bymonth=(1, 3),
-                     dtstart=datetime(1997, 9, 2, 9, 0))
-
-        self._rrulestr_reverse_test(rule)
-
-    def testToStrYearlyByMonth(self):
         self._rrulestr_reverse_test(rrule(YEARLY,
                                           count=3,
                                           bymonth=(1, 3),


### PR DESCRIPTION
The two `testToStrYearlyByMonth` tests were functionally identical, so I
combined them into one.

The other tests used slightly different test data, so kept both
instances, but could also delete one if preferred.