### PR TITLE
Use 2 spaces after top level definitions

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -70,6 +70,7 @@ class weekday(weekdaybase):
 
         super(weekday, self).__init__(wkday, n)
 
+
 MO, TU, WE, TH, FR, SA, SU = weekdays = tuple(weekday(x) for x in range(7))
 
 
@@ -1602,6 +1603,7 @@ class _rrulestr(object):
 
     def __call__(self, s, **kwargs):
         return self._parse_rfc(s, **kwargs)
+
 
 rrulestr = _rrulestr()
 

--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -217,6 +217,7 @@ def _total_seconds(td):
     return ((td.seconds + td.days * 86400) * 1000000 +
             td.microseconds) // 1000000
 
+
 total_seconds = getattr(datetime.timedelta, 'total_seconds', _total_seconds)
 
 
@@ -244,6 +245,7 @@ class NotAValueClass(object):
     __eq__ = __req__ = _op
     __le__ = __rle__ = _op
     __ge__ = __rge__ = _op
+
 
 NotAValue = NotAValueClass()
 
@@ -278,10 +280,13 @@ class ComparesEqualClass(object):
     __rlt__ = __lt__
     __rgt__ = __gt__
 
+
 ComparesEqual = ComparesEqualClass()
+
 
 class UnsetTzClass(object):
     """ Sentinel class for unset time zone variable """
     pass
+
 
 UnsetTz = UnsetTzClass()

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -377,4 +377,5 @@ def _total_seconds(td):
     return ((td.seconds + td.days * 86400) * 1000000 +
             td.microseconds) // 1000000
 
+
 _total_seconds = getattr(timedelta, 'total_seconds', _total_seconds)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1278,6 +1278,7 @@ class tzical(object):
     def __repr__(self):
         return "%s(%s)" % (self.__class__.__name__, repr(self._s))
 
+
 if sys.platform != "win32":
     TZFILES = ["/etc/localtime", "localtime"]
     TZPATHS = ["/usr/share/zoneinfo",

--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -34,6 +34,7 @@ def _settzkeyname():
     handle.Close()
     return TZKEYNAME
 
+
 TZKEYNAME = _settzkeyname()
 
 

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -50,5 +50,6 @@ def main():
             metadata=metadata)
     print("Done.")
 
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Brings code closer to flake8 compliance by passing rule:

E305 expected 2 blank lines after class or function definition

http://pycodestyle.pycqa.org/en/latest/intro.html#error-codes