### PR TITLE
Fix all instances of flake8 F841

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -550,11 +550,8 @@ class parser(object):
         """
 
         if default is None:
-            effective_dt = datetime.datetime.now()
             default = datetime.datetime.now().replace(hour=0, minute=0,
                                                       second=0, microsecond=0)
-        else:
-            effective_dt = default
 
         res, skipped_tokens = self._parse(timestr, **kwargs)
 

--- a/dateutil/test/test_imports.py
+++ b/dateutil/test/test_imports.py
@@ -128,7 +128,13 @@ class ImportTZWinTest(unittest.TestCase):
         from dateutil import tzwin
 
     def testTzwinStar(self):
-        tzwin_all = ["tzwin", "tzwinlocal"]
+        from dateutil.tzwin import tzwin
+        from dateutil.tzwin import tzwinlocal
+
+        tzwin_all = [tzwin, tzwinlocal]
+
+        for var in tzwin_all:
+            self.assertIsNot(var, None)
 
 
 class ImportZoneInfoTest(unittest.TestCase):

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -4641,7 +4641,7 @@ class RRuleSetTest(unittest.TestCase):
 class WeekdayTest(unittest.TestCase):
     def testInvalidNthWeekday(self):
         with self.assertRaises(ValueError):
-            zeroth_friday = FR(0)
+            FR(0)
 
     def testWeekdayCallable(self):
         # Calling a weekday instance generates a new weekday instance with the

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -385,7 +385,6 @@ class TzFoldMixin(object):
             SYD1 = self.gettz(tzname)
 
             t0_u = datetime(2012, 3, 31, 14, 30, tzinfo=tz.tzutc())  # AEST
-            t1_u = datetime(2012, 3, 31, 16, 30, tzinfo=tz.tzutc())  # AEDT
 
             t0_syd0 = t0_u.astimezone(SYD0)
             t0_syd1 = t0_u.astimezone(SYD1)
@@ -434,7 +433,6 @@ class TzWinFoldMixin(object):
 
         with self.context(tzname):
             # Calling fromutc() alters the tzfile object
-            SYD = self.tzclass(*args)
             SYD0 = self.tzclass(*args)
             SYD1 = self.tzclass(*args)
 
@@ -939,11 +937,11 @@ class ZoneInfoGettzTest(GettzTest, WarningTestMixin):
 
     def testZoneInfoDeprecated(self):
         with self.assertWarns(DeprecationWarning):
-            tzi = zoneinfo.gettz('US/Eastern')
+            zoneinfo.gettz('US/Eastern')
 
     def testZoneInfoMetadataDeprecated(self):
         with self.assertWarns(DeprecationWarning):
-            tzdb_md = zoneinfo.gettz_db_metadata()
+            zoneinfo.gettz_db_metadata()
 
 
 class TZRangeTest(unittest.TestCase, TzFoldMixin):
@@ -1501,7 +1499,7 @@ class TZTest(unittest.TestCase):
         # work NEW_YORK must be in TZif version 1 format i.e. no more data
         # after TZif v1 header + data has been read
         fileobj = BytesIO(base64.b64decode(NEW_YORK))
-        tzc = tz.tzfile(fileobj)
+        tz.tzfile(fileobj)
         # we expect no remaining file content now, i.e. zero-length; if there's
         # still data we haven't read the file format correctly
         remaining_tzfile_content = fileobj.read()

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -469,10 +469,9 @@ class tzfile(_tzinfo):
         # The pairs of values are sorted in ascending order
         # by time.
 
-        # Not used, for now (but read anyway for correct file position)
+        # Not used, for now (but seek for correct file position)
         if leapcnt:
-            leap = struct.unpack(">%dl" % (leapcnt*2),
-                                 fileobj.read(leapcnt*8))
+            fileobj.seek(leapcnt * 8, os.SEEK_CUR)
 
         # Then there are tzh_ttisstdcnt standard/wall
         # indicators, each stored as a one-byte value;
@@ -1098,7 +1097,6 @@ class tzical(object):
             self._s = fileobj
             # ical should be encoded in UTF-8 with CRLF
             fileobj = open(fileobj, 'r')
-            file_opened_here = True
         else:
             self._s = getattr(fileobj, 'name', repr(fileobj))
             fileobj = _ContextWrapper(fileobj)


### PR DESCRIPTION
F841 local variable `name` is assigned to but never used

Now use seek to skip over lzh_leapcnt pairs in tz.py. As the values are
unused, no need to read them and convert them to Python objects. It is
only wasted cycles and memory. Skip over with seek() instead.

Rewrote testTzwinStar based on surrounding similar tests. Previous
version did not achieve an interesting result.

I believe non of the removals have intended side effects, If I'm
mistaken, please let me know.