### PR TITLE
Fix all instances of flake8 E301 & E303

### DIFF
--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -251,6 +251,7 @@ class relativedelta(object):
     @property
     def weeks(self):
         return self.days // 7
+
     @weeks.setter
     def weeks(self, value):
         self.days = self.days - (self.weeks * 7) + value * 7

--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -186,7 +186,6 @@ class relativedelta(object):
                      "This is not a well-defined condition and will raise " +
                      "errors in future versions.", DeprecationWarning)
 
-
             if isinstance(weekday, integer_types):
                 self.weekday = weekdays[weekday]
             else:

--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -745,7 +745,6 @@ class rrule(rrulebase):
         new_kwargs.update(kwargs)
         return rrule(**new_kwargs)
 
-
     def _iter(self):
         year, month, day, hour, minute, second, weekday, yearday, _ = \
             self._dtstart.timetuple()

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -45,7 +45,6 @@ class ParserTest(unittest.TestCase):
             def read(self, *args, **kwargs):
                 return self.stream.read(*args, **kwargs)
 
-
         dstr = StringPassThrough(StringIO('2014 January 19'))
 
         self.assertEqual(parse(dstr), datetime(2014, 1, 19))
@@ -105,7 +104,6 @@ class ParserTest(unittest.TestCase):
                                tzinfos=self.tzinfos),
                          datetime(2003, 9, 25, 10, 36, 28,
                                   tzinfo=self.brsttz))
-
 
     def testDateCommandFormatReversed(self):
         self.assertEqual(parse("2003 10:36:28 BRST 25 Sep Thu",
@@ -558,7 +556,6 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse(s2, fuzzy_with_tokens=True),
                          (datetime(2060, 2, 21, 0, 0, 0),
                          ('http://biz.yahoo.com/ipo/p/', '.html')))
-
 
     def testFuzzyAMPMProblem(self):
         # Sometimes fuzzy parsing results in AM/PM flag being set without

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -119,6 +119,7 @@ class ParserTest(unittest.TestCase):
                                    tzinfos={"BRST": long(-10800)}),
                              datetime(2003, 9, 25, 10, 36, 28,
                                       tzinfo=self.brsttz))
+
     def testDateCommandFormatIgnoreTz(self):
         self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
                                ignoretz=True),

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -200,7 +200,6 @@ class TzFoldMixin(object):
             self.assertEqual(t0_syd0.utcoffset(), timedelta(hours=11))
             self.assertEqual(t1_syd1.utcoffset(), timedelta(hours=10))
 
-
     def testGapPositiveUTCOffset(self):
         # Test that we don't have a problem around gaps.
         tzname = self._get_tzname('Australia/Sydney')
@@ -658,7 +657,6 @@ class TzOffsetTest(unittest.TestCase):
         tname = 'EST'
         tzo = tz.tzoffset(tname, -5 * 3600)
         self.assertEqual(repr(tzo), "tzoffset(" + repr(tname) + ", -18000)")
-
 
     def testEquality(self):
         utc = tz.tzoffset('UTC', 0)
@@ -1320,7 +1318,6 @@ class TZICalTest(unittest.TestCase, TzFoldMixin):
         tzc = tz.tzical(instr)
 
         self.assertEqual(repr(tzc), "tzical(" + repr(instr.name) + ")")
-
 
     # Test performance
     def _test_us_zone(self, tzc, func, values, start):

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -290,7 +290,6 @@ class tzrangebase(_tzinfo):
         utc_transitions = (dston, dstoff)
         dt_utc = dt.replace(tzinfo=None)
 
-
         isdst = self._naive_isdst(dt_utc, utc_transitions)
 
         if isdst:

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1016,7 +1016,6 @@ class _tzicalvtz(_tzinfo):
         except ValueError:
             pass
 
-
         lastcompdt = None
         lastcomp = None
 


### PR DESCRIPTION
- E301 expected 1 blank line, found X
- E303 too many blank lines (X)

https://pep8.readthedocs.io/en/latest/intro.html#error-codes