### PR TITLE
Allow for two day names shorter than 3 letters (#343)

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -309,7 +309,7 @@ class parserinfo(object):
         return name.lower() in self._jump
 
     def weekday(self, name):
-        if len(name) >= 3:
+        if len(name) >= min(len(n) for n in self._weekdays.keys()):
             try:
                 return self._weekdays[name.lower()]
             except KeyError:
@@ -317,7 +317,7 @@ class parserinfo(object):
         return None
 
     def month(self, name):
-        if len(name) >= 3:
+        if len(name) >= min(len(n) for n in self._months.keys()):
             try:
                 return self._months[name.lower()] + 1
             except KeyError:

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -806,6 +806,25 @@ class ParserTest(unittest.TestCase):
         dt = myparser.parse("01/Foo/2007")
         self.assertEqual(dt, datetime(2007, 1, 1))
 
+    def testCustomParserShortDaynames(self):
+        # Horacio Hoyos discovered that day names shorter than 3 characters,
+        # for example two letter German day name abbreviations, don't work:
+        # https://github.com/dateutil/dateutil/issues/343
+        from dateutil.parser import parserinfo, parser
+
+        class GermanParserInfo(parserinfo):
+            WEEKDAYS = [("Mo", "Montag"),
+                        ("Di", "Dienstag"),
+                        ("Mi", "Mittwoch"),
+                        ("Do", "Donnerstag"),
+                        ("Fr", "Freitag"),
+                        ("Sa", "Samstag"),
+                        ("So", "Sonntag")]
+
+        myparser = parser(GermanParserInfo())
+        dt = myparser.parse("Sa 21. Jan 2017")
+        self.assertEqual(dt, datetime(2017, 1, 21))
+
     def testNoYearFirstNoDayFirst(self):
         dtstr = '090107'
 


### PR DESCRIPTION
Possibly a fix for issue #343 

Issue summary: Short day names had to be at least 3 characters long to be recognized, which works for the default day names (`Mon`, `Tue`, ...) but not necessarily for custom `WEEKDAYS` names such as German day name abbreviations (`Mo`, `Di`, ...).

* This PR changes the check from a comparison against a constant value (`3`) to a value calculated from the entries of the `WEEKDAYS` setting. 
* Since the same applies to `MONTHS`, applying the equivalent change there. 
* Added a test for the case of German day names, which fails before the change and passes after.

A possible next step would be to cache the return value of `min(len(n) for n in self._weekdays.keys())` to avoid re-computation. Please let me know if that would be preferred here. 