### PR TITLE
Remove unnecessary dict.keys() calls

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -309,7 +309,7 @@ class parserinfo(object):
         return name.lower() in self._jump
 
     def weekday(self, name):
-        if len(name) >= min(len(n) for n in self._weekdays.keys()):
+        if len(name) >= min(len(n) for n in self._weekdays):
             try:
                 return self._weekdays[name.lower()]
             except KeyError:
@@ -317,7 +317,7 @@ class parserinfo(object):
         return None
 
     def month(self, name):
-        if len(name) >= min(len(n) for n in self._months.keys()):
+        if len(name) >= min(len(n) for n in self._months):
             try:
                 return self._months[name.lower()] + 1
             except KeyError:

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1105,7 +1105,7 @@ class tzical(object):
         """
         Retrieves the available time zones as a list.
         """
-        return list(self._vtz.keys())
+        return list(self._vtz)
 
     def get(self, tzid=None):
         """


### PR DESCRIPTION
iter(dict) is equivalent to iter(dict.keys()). Fixed all code to simply
act on the dictionary. Provides simpler, more concise syntax and avoids
the extra function call.

Inspired by Lennart Regebro's PyCon 2017 presentation "Prehistoric
Patterns in Python". Available at:

https://www.youtube.com/watch?v=V5-JH23Vk0I