### PR TITLE
Make classes hashable 

### DIFF
--- a/dateutil/_common.py
+++ b/dateutil/_common.py
@@ -24,7 +24,14 @@ class weekday(object):
             return False
         return True
 
-    __hash__ = None
+    def __hash__(self):
+        return hash((
+          self.weekday,
+          self.n,
+        ))
+
+    def __ne__(self, other):
+        return not (self == other)
 
     def __repr__(self):
         s = ("MO", "TU", "WE", "TH", "FR", "SA", "SU")[self.weekday]
@@ -32,3 +39,5 @@ class weekday(object):
             return s
         else:
             return "%s(%+d)" % (s, self.n)
+
+# vim:ts=4:sw=4:et

--- a/dateutil/relativedelta.py
+++ b/dateutil/relativedelta.py
@@ -512,7 +512,25 @@ class relativedelta(object):
                 self.second == other.second and
                 self.microsecond == other.microsecond)
 
-    __hash__ = None
+    def __hash__(self):
+        return hash((
+            self.weekday,
+            self.years,
+            self.months,
+            self.days,
+            self.hours,
+            self.minutes,
+            self.seconds,
+            self.microseconds,
+            self.leapdays,
+            self.year,
+            self.month,
+            self.day,
+            self.hour,
+            self.minute,
+            self.second,
+            self.microsecond,
+        ))
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/dateutil/test/test_relativedelta.py
+++ b/dateutil/test/test_relativedelta.py
@@ -575,3 +575,11 @@ class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
         )
 
         self.assertEqual(expected, rd + td)
+
+    def testHashable(self):
+      try:
+        {relativedelta(minute=1): 'test'}
+      except:
+        self.fail("relativedelta() failed to hash!")
+
+# vim:ts=4:sw=4:et


### PR DESCRIPTION
This builds on https://github.com/dateutil/dateutil/pull/296 by making those classes hashable by explicitly providing the `__hash__` method

classes touched:
- relativedelta
- weekday