### PR TITLE
Fix tz fold tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-  - "3.6-dev"
+  - "3.6"
   - "nightly"
   - "pypy-5.4"
   - "pypy3"
@@ -16,7 +16,6 @@ matrix:
   # pypy3 latest version is not playing nice.
   allow_failures:
     - python: "pypy3"
-    - python: "3.6-dev"
     - python: "nightly"
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
     - PYTHON: "C:/Python34-x64"
     - PYTHON: "C:/Python35"
     - PYTHON: "C:/Python35-x64"
+    - PYTHON: "C:/Python36"
+    - PYTHON: "C:/Python36-x64"
 install:
   # Add PostgreSQL (zic), Python and scripts directory to current path
   - set path=c:\Program Files\PostgreSQL\9.3\bin\;%PATH%


### PR DESCRIPTION
All the original fold and gap tests were written for an intermediate version of `tz` that stored state in the `tzinfo` object, which was abandoned to better be compliant with PEP-495, this PR cleans up a lot of that and also tests that these objects comply with the PEP-495 equality semantics (for the most part).

I've also merged in #365 here, because this fixes the `tzwin` tests so that they work properly with Python 3.6.