### PR TITLE
Fix improper indent in parser.

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -798,14 +798,16 @@ class parser(object):
                         if idx == 0:               # h
                             res.minute = int(value)
 
-                            if value % 1:
-                                res.second = int(60*(value % 1))
+                            sec_remainder = value % 1
+                            if sec_remainder:
+                                res.second = int(60 * sec_remainder)
                         elif idx == 1:             # m
                             res.second, res.microsecond = \
                                 _parsems(value_repr)
 
-                        if idx == 0 or idx == 1:
-                            i += 1
+                        # We don't need to advance the tokens here because the
+                        # i == len_l call indicates that we're looking at all
+                        # the tokens already.
 
                     elif i+1 < len_l and l[i] == ':':
                         # HH:MM[:SS[.ss]]

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -793,17 +793,19 @@ class parser(object):
                     elif (i == len_l and l[i-2] == ' ' and
                           info.hms(l[i-3]) is not None):
                         # X h MM or X m SS
-                        idx = info.hms(l[i-3]) + 1
+                        idx = info.hms(l[i-3])
 
-                        if idx == 1:
+                        if idx == 0:               # h
                             res.minute = int(value)
 
                             if value % 1:
                                 res.second = int(60*(value % 1))
-                            elif idx == 2:
-                                res.second, res.microsecond = \
-                                    _parsems(value_repr)
-                                i += 1
+                        elif idx == 1:             # m
+                            res.second, res.microsecond = \
+                                _parsems(value_repr)
+
+                        if idx == 0 or idx == 1:
+                            i += 1
 
                     elif i+1 < len_l and l[i] == ':':
                         # HH:MM[:SS[.ss]]

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -452,6 +452,10 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("10 h 36", default=self.default),
                          datetime(2003, 9, 25, 10, 36))
 
+    def testHourWithLetterStrip5(self):
+        self.assertEqual(parse("10 h 36.5", default=self.default),
+                         datetime(2003, 9, 25, 10, 36, 30))
+
     def testMinuteWithLettersSpaces1(self):
         self.assertEqual(parse("36 m 5", default=self.default),
                          datetime(2003, 9, 25, 0, 36, 5))

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -452,6 +452,22 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("10 h 36", default=self.default),
                          datetime(2003, 9, 25, 10, 36))
 
+    def testMinuteWithLettersSpaces1(self):
+        self.assertEqual(parse("36 m 5", default=self.default),
+                         datetime(2003, 9, 25, 0, 36, 5))
+
+    def testMinuteWithLettersSpaces2(self):
+        self.assertEqual(parse("36 m 5 s", default=self.default),
+                         datetime(2003, 9, 25, 0, 36, 5))
+
+    def testMinuteWithLettersSpaces3(self):
+        self.assertEqual(parse("36 m 05", default=self.default),
+                         datetime(2003, 9, 25, 0, 36, 5))
+
+    def testMinuteWithLettersSpaces4(self):
+        self.assertEqual(parse("36 m 05 s", default=self.default),
+                         datetime(2003, 9, 25, 0, 36, 5))
+
     def testAMPMNoHour(self):
         with self.assertRaises(ValueError):
             parse("AM")


### PR DESCRIPTION
Fixes #333. Still not 100% sure if the `i += 1` that was never being reached is strictly necessary, but I think that that is supposed to advance the tokens properly. Not entirely sure why the values were already being advanced properly, but all the tests seem to pass, so I think we're good. 

cc: @jbrockmendel @mrForce