### PR TITLE
Replace all star imports with explicit imports

### DIFF
--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -5,7 +5,7 @@ from ._common import unittest
 from datetime import datetime, timedelta
 
 from dateutil.tz import tzoffset
-from dateutil.parser import *
+from dateutil.parser import parse, parserinfo
 
 from six import assertRaisesRegex, PY3
 from six.moves import StringIO

--- a/dateutil/test/test_relativedelta.py
+++ b/dateutil/test/test_relativedelta.py
@@ -5,7 +5,7 @@ from ._common import unittest, WarningTestMixin, NotAValue
 import calendar
 from datetime import datetime, date, timedelta
 
-from dateutil.relativedelta import *
+from dateutil.relativedelta import relativedelta, MO, TU, WE, FR, SU
 
 
 class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -5,7 +5,12 @@ from ._common import WarningTestMixin, unittest
 from datetime import datetime, date
 from six import PY3
 
-from dateutil.rrule import *
+from dateutil.rrule import (
+    rrule, rruleset, rrulestr,
+    YEARLY, MONTHLY, WEEKLY, DAILY,
+    HOURLY, MINUTELY, SECONDLY,
+    MO, TU, WE, TH, FR, SA, SU
+)
 
 
 class RRuleTest(WarningTestMixin, unittest.TestCase):


### PR DESCRIPTION
Fixes all flake8 error F405:

F405 'parse' may be undefined, or defined from star imports: dateutil.parser