### PR TITLE
Quickfix: assertion before setting mstridx

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -854,8 +854,8 @@ class parser(object):
 
                                 if value is not None:
                                     ymd.append(value)
-                                    mstridx = len(ymd)-1
                                     assert mstridx == -1
+                                    mstridx = len(ymd)-1
                                 else:
                                     ymd.append(l[i])
 


### PR DESCRIPTION
If that branch was reached, asserting `mstridx == -1` immediately after setting `mstridx = len(ymd)-1` should always fail (`ymd` is not empty at this point).  I'll circle back to add a test case to cover this.