### PR TITLE
Fix warning on French Windows systems when parsing date times under Python 2

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -34,15 +34,24 @@ import string
 import time
 import collections
 import re
+import locale
 from io import StringIO
 from calendar import monthrange
 
-from six import text_type, binary_type, integer_types
+from six import text_type, binary_type, integer_types, PY2
 
 from . import relativedelta
 from . import tz
 
 __all__ = ["parse", "parserinfo"]
+
+
+TZNAME = time.tzname
+if PY2:
+    TZNAME = tuple(
+        name.decode(locale.getpreferredencoding())
+        for name in TZNAME
+    )
 
 
 class _timelex(object):
@@ -602,7 +611,7 @@ class parser(object):
                     raise ValueError("Offset must be tzinfo subclass, "
                                      "tz string, or int offset.")
                 ret = ret.replace(tzinfo=tzinfo)
-            elif res.tzname and res.tzname in time.tzname:
+            elif res.tzname and res.tzname in TZNAME:
                 ret = ret.replace(tzinfo=tz.tzlocal())
             elif res.tzoffset == 0:
                 ret = ret.replace(tzinfo=tz.tzutc())


### PR DESCRIPTION
When parsing a date time in some conditions, ``dateutil.parser.parse()`` emits the following warning:

```
UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
```

This warning comes when testing if a unicode timezone name is in``time.tzname``.  I'm not sure exactly how to trigger this code path, but I can reproduce the warning on my system using the following snippet:

```python
>>> import time
>>> print time.tzname
('Est', 'Est (heure d\x92\xe9t\xe9)')
>>> print u'Est' in time.tzname
__main__:1: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
True
```

The problem is that ``time.tzname[1]`` contains a byte string with non-ASCII characters in the current code page.

To remove the warning, we should ensure to decode ``time.tzname`` using ``locale.getpreferredencoding()`` so that we have somthing that can safely compare with unicode strings.