### PR TITLE
Fix bug on French Windows systems when using local timezone under Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ before_install:
 
 install:
   - pip install six
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install Unidecode unittest2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install Unidecode; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 'pypy-5.4' ]]; then pip install Unidecode; fi
   - ./ci_tools/retry.sh python updatezinfo.py
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - ps: Start-FileDownload 'https://bootstrap.pypa.io/get-pip.py'
   - "%PYTHON%/python.exe get-pip.py"
   - "%pip_cmd% install six"
+  - "%pip_cmd% install Unidecode"
   - "%pip_cmd% install coverage"
   - "%pip_cmd% install codecov"
 

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -1,8 +1,14 @@
-from six import PY3
+from six import PY2
 
 from functools import wraps
 
 from datetime import datetime, timedelta, tzinfo
+
+if PY2:
+    from unidecode import unidecode
+
+import locale
+from six import text_type
 
 
 ZERO = timedelta(0)
@@ -18,8 +24,8 @@ def tzname_in_python2(namefunc):
     """
     def adjust_encoding(*args, **kwargs):
         name = namefunc(*args, **kwargs)
-        if name is not None and not PY3:
-            name = name.encode()
+        if PY2 and isinstance(name, text_type):
+            name = unidecode(name)
 
         return name
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -13,8 +13,9 @@ import time
 import sys
 import os
 import bisect
+import locale
 
-from six import string_types
+from six import string_types, PY2
 from ._common import tzname_in_python2, _tzinfo, _total_seconds
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs
@@ -27,6 +28,19 @@ except ImportError:
 ZERO = datetime.timedelta(0)
 EPOCH = datetime.datetime.utcfromtimestamp(0)
 EPOCHORDINAL = EPOCH.toordinal()
+
+
+def _gettznames():
+    """Get current time zone names in Unicode."""
+
+    def decode(x):
+        """Decode from byte string in current locale."""
+        return x.decode(locale.getpreferredencoding())
+
+    names = time.tzname
+    if PY2:
+        names = tuple(map(decode, names))
+    return names
 
 
 class tzutc(datetime.tzinfo):
@@ -191,7 +205,7 @@ class tzlocal(_tzinfo):
 
     @tzname_in_python2
     def tzname(self, dt):
-        return time.tzname[self._isdst(dt)]
+        return _gettznames()[self._isdst(dt)]
 
     def is_ambiguous(self, dt):
         """
@@ -1404,7 +1418,7 @@ def gettz(name=None):
                     else:
                         if name in ("GMT", "UTC"):
                             tz = tzutc()
-                        elif name in time.tzname:
+                        elif name in _gettznames():
                             tz = tzlocal()
     return tz
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ datetime module available in the Python standard library.
       package_data={"dateutil.zoneinfo": ["dateutil-zoneinfo.tar.gz"]},
       zip_safe=True,
       requires=["six"],
-      install_requires=["six >=1.5"],  # XXX fix when packaging is sane again
+      install_requires=[
+          "six >=1.5",
+          "Unidecode>=0.04.21",
+      ],  # XXX fix when packaging is sane again
       classifiers=[
           'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,6 @@ envlist =
 commands = python setup.py test -q {posargs}
 deps =
     py26: unittest2
+    py26: Unidecode
+    py27: Unidecode
     six


### PR DESCRIPTION
When I try to run the following snippet, I get the following output:

```python
>>> from datetime import datetime
>>> from dateutil.tz import tzlocal
>>>
>>> now = datetime.now()
>>> print tzlocal().tzname(now)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...\dateutil\tz\_common.py", line 22, in adjust_encoding
    name = name.encode()
UnicodeDecodeError: 'ascii' codec can't decode byte 0x92 in position 12: ordinal not in range(128)
```

This happens because ``time.tzname[1]`` contains non-ASCII characters in the current code page.  We need to decode this using ``locale.getpreferredencoding()`` to get a Unicode string
that is safe to use.

Additionally, since Python 2 forces ``.tzname()`` to return a byte string, the ``adjust_encoding()`` utility tries to re-encode to ASCII.  This is obviously not possible so the best path seems to be to remove diacritics to lossily convert the stirng to ASCII.