### PR TITLE
Make parse() accept anything which has a nullary decode() method

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -59,8 +59,10 @@ class _timelex(object):
 
             if not hasattr(instream, 'read'):
                 raise TypeError(
-                    'Parser must be a string or character stream, not '
-                    '{itype}'.format(itype=instream.__class__.__name__)
+                    'Parser must be a character stream, a string, or '
+                    'decodable to a string, not {itype}'.format(
+                        itype=instream.__class__.__name__
+                    )
                 )
 
         self.instream = instream

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -37,7 +37,7 @@ import re
 from io import StringIO
 from calendar import monthrange
 
-from six import text_type, binary_type, integer_types
+from six import text_type, integer_types
 
 from . import relativedelta
 from . import tz
@@ -50,15 +50,18 @@ class _timelex(object):
     _split_decimal = re.compile("([.,])")
 
     def __init__(self, instream):
-        if isinstance(instream, binary_type):
-            instream = instream.decode()
+        if not hasattr(instream, 'read'):
+            if hasattr(instream, 'decode'):
+                instream = instream.decode()
 
-        if isinstance(instream, text_type):
-            instream = StringIO(instream)
+            if isinstance(instream, text_type):
+                instream = StringIO(instream)
 
-        if getattr(instream, 'read', None) is None:
-            raise TypeError('Parser must be a string or character stream, not '
-                            '{itype}'.format(itype=instream.__class__.__name__))
+            if not hasattr(instream, 'read'):
+                raise TypeError(
+                    'Parser must be a string or character stream, not '
+                    '{itype}'.format(itype=instream.__class__.__name__)
+                )
 
         self.instream = instream
         self.charstack = []

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -58,6 +58,13 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse(self.str_str),
                          parse(self.uni_str))
 
+    def testParseBytes(self):
+        self.assertEqual(parse(b'2014 January 19'), datetime(2014, 1, 19))
+
+    def testParseBytearray(self):
+        self.assertEqual(parse(bytearray(b'2014 January 19')),
+                         datetime(2014, 1, 19))
+
     def testParserParseStr(self):
         from dateutil.parser import parser
 


### PR DESCRIPTION
This change fixes Issue #417, by making `parse()` use duck typing rather than explicitly checking whether it's been given a `bytes`. Now any object which has a nullary `decode()` method can be passed to `parse()`.