### PR TITLE
Less of a PR than an exposition/discussion

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -1274,13 +1274,6 @@ class InvalidDatetimeError(ValueError): pass
 class InvalidDateError(InvalidDatetimeError): pass
 class InvalidTimeError(InvalidDatetimeError): pass
 
-class ProgrammingError(AssertionError):
-    """ProgrammingError is for if we reach a state that we *think* should
-    be unreachable and would otherwise be inclined to assert is impossible.
-    Since an AssertionError is useful a user, a ProgrammingError clarifies
-    that they should file a bug report.
-    """
-
 
 def _parse_hms(i, l, info, res):
     # TODO: This is still a mess.  Can we make this recursive instead of
@@ -1335,7 +1328,7 @@ def _parse_hms(i, l, info, res):
     return i
 
 
-# TODO: requre len(token) >= 3 like we do for the between-parens version?
+# TODO: require len(token) >= 3 like we do for the between-parens version?
 # do some other validation here instead of putting it off?  As of now, "Q"
 # will be accepted as a timezone...
 def _could_be_tzname(hour, tzname, tzoffset, token):
@@ -1416,7 +1409,7 @@ def _recombine_skipped(tokens, skipped_idxs):
 
     """
     skipped_tokens = []
-    for idx in sorted(list(skipped_idxs)):
+    for idx in sorted(skipped_idxs):
         if idx-1 in skipped_idxs:
             skipped_tokens[-1] = skipped_tokens[-1] + tokens[idx]
         else:

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -417,8 +417,12 @@ class _ymd(list):
         if hasattr(val, '__len__'):
             if val.isdigit() and len(val) > 2:
                 self.century_specified = True
+                assert label in [None, 'Y']
+                label = 'Y'
         elif val > 100:
             self.century_specified = True
+            assert label in [None, 'Y']
+            label = 'Y'
 
         super(self.__class__, self).append(int(val))
 
@@ -728,7 +732,7 @@ class parser(object):
                         # YYMMDD or HHMMSS[.ss]
                         s = l[i]
 
-                        if not ymd and l[i].find('.') == -1:
+                        if not ymd and '.' not in l[i]:
                             #ymd.append(info.convertyear(int(s[:2])))
 
                             ymd.append(s[:2])
@@ -744,7 +748,7 @@ class parser(object):
                     elif len_li in (8, 12, 14):
                         # YYYYMMDD
                         s = l[i]
-                        ymd.append(s[:4])
+                        ymd.append(s[:4], 'Y')
                         ymd.append(s[4:6])
                         ymd.append(s[6:8])
 
@@ -916,7 +920,7 @@ class parser(object):
                                 # TODO: not hit in tests
                             else:
                                 # Convert it here to become unambiguous
-                                ymd.append(str(info.convertyear(value)))
+                                ymd.append(str(info.convertyear(value)), 'Y')
                             i += 5
 
                         else:

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -907,15 +907,15 @@ class parser(object):
                               and info.pertain(l[i+2])):
                             # Jan of 01
                             # In this case, 01 is clearly year
-                            try:
+                            if l[i+4].isdigit():
+                                # Convert it here to become unambiguous
                                 value = int(l[i+4])
-                            except ValueError:
+                                year = str(info.convertyear(value))
+                                ymd.append(year, 'Y')
+                            else:
                                 # Wrong guess
                                 pass
                                 # TODO: not hit in tests
-                            else:
-                                # Convert it here to become unambiguous
-                                ymd.append(str(info.convertyear(value)), 'Y')
                             i += 4
 
 
@@ -957,6 +957,7 @@ class parser(object):
                     signal = (-1, 1)[l[i] == '+']
                     len_li = len(l[i+1])
 
+                    # TODO: check that l[i+1] is integer?
                     if len_li == 4:
                         # -0300
                         hour_offset = int(l[i+1][:2])

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -881,15 +881,15 @@ class parser(object):
                     continue
 
                 # Check weekday
-                value = info.weekday(l[i])
-                if value is not None:
+                elif info.weekday(l[i]) is not None:
+                    value = info.weekday(l[i])
                     res.weekday = value
                     i += 1
                     continue
 
                 # Check month name
-                value = info.month(l[i])
-                if value is not None:
+                elif info.month(l[i]) is not None:
+                    value = info.month(l[i])
                     ymd.append(value, 'M')
 
                     i += 1
@@ -923,8 +923,8 @@ class parser(object):
                     continue
 
                 # Check am/pm
-                value = info.ampm(l[i])
-                if value is not None:
+                elif info.ampm(l[i]) is not None:
+                    value = info.ampm(l[i])
                     val_is_ampm = _ampm_validity(res.hour, res.ampm, fuzzy)
 
                     if val_is_ampm:
@@ -938,7 +938,7 @@ class parser(object):
                     continue
 
                 # Check for a timezone name
-                if (res.hour is not None and len(l[i]) <= 5
+                elif (res.hour is not None and len(l[i]) <= 5
                     and res.tzname is None and res.tzoffset is None
                     and all(x in string.ascii_uppercase for x in l[i])):
                     res.tzname = l[i]
@@ -961,7 +961,7 @@ class parser(object):
                     continue
 
                 # Check for a numbered timezone
-                if res.hour is not None and l[i] in ('+', '-'):
+                elif res.hour is not None and l[i] in ('+', '-'):
                     signal = (-1, 1)[l[i] == '+']
                     len_li = len(l[i+1])
 
@@ -992,11 +992,12 @@ class parser(object):
                     continue
 
                 # Check jumps
-                if not (info.jump(l[i]) or fuzzy):
+                elif not (info.jump(l[i]) or fuzzy):
                     return None, None
 
-                skipped_idxs.add(i)
-                i += 1
+                else:
+                    skipped_idxs.add(i)
+                    i += 1
 
             # Process year/month/day
             year, month, day = ymd.resolve_ymd(yearfirst, dayfirst)

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -764,7 +764,6 @@ class parser(object):
                             i += 1
 
                         idx = info.hms(l[i+1])
-                        i += 1
 
                         while True:
                             if idx == 0:
@@ -780,12 +779,12 @@ class parser(object):
 
                             i += 1
 
-                            if i >= len_l or idx == 2:
+                            if i+1 >= len_l or idx == 2:
                                 break
 
                             # 12h00
                             try:
-                                value_repr = l[i]
+                                value_repr = l[i+1]
                                 value = float(value_repr)
                             except ValueError:
                                 break
@@ -793,11 +792,13 @@ class parser(object):
                                 i += 1
                                 idx += 1
 
-                                if i < len_l:
-                                    newidx = info.hms(l[i])
+                                if i+1 < len_l:
+                                    newidx = info.hms(l[i+1])
 
                                     if newidx is not None:
                                         idx = newidx
+
+                        i += 1
 
                     elif (i+1 == len_l and l[i-1] == ' ' and info.hms(l[i-2]) is not None):
                         # X h MM or X m SS
@@ -853,7 +854,6 @@ class parser(object):
                                 i += 2
 
                             i += 3
-
                         else:
                             i += 2
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -998,15 +998,12 @@ class parser(object):
 
             # Process year/month/day
             year, month, day = ymd.resolve_ymd(yearfirst, dayfirst)
-            if year is not None:
-                res.year = year
-                res.century_specified = ymd.century_specified
 
-            if month is not None:
-                res.month = month
+            res.century_specified = ymd.century_specified
+            res.year = year
+            res.month = month
+            res.day = day
 
-            if day is not None:
-                res.day = day
 
         except (IndexError, ValueError, AssertionError):
             return None, None

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -721,8 +721,11 @@ class parser(object):
                     len_li = len(l[i])
 
                     if (len(ymd) == 3 and len_li in (2, 4)
-                        and res.hour is None and (i+1 >= len_l or (l[i+1] != ':' and
-                                                  info.hms(l[i+1]) is None))):
+                        and res.hour is None
+                        and (i+1 >= len_l
+                            or (l[i+1] != ':' and info.hms(l[i+1]) is None)
+                            )
+                        ):
                         # 19990101T23[59]
                         s = l[i]
                         res.hour = int(s[:2])
@@ -742,7 +745,7 @@ class parser(object):
                             ymd.append(s[4:])
                         else:
                             # 19990101T235959[.59]
-                            res.hour = int(s[:2])
+                            res.hour = int(s[:2]) # TODO: not checking that res.hour is not already set?
                             res.minute = int(s[2:4])
                             res.second, res.microsecond = _parsems(s[4:])
 
@@ -834,10 +837,10 @@ class parser(object):
                         ymd.append(value_repr)
 
                         if i+2 < len_l and not info.jump(l[i+2]):
-                            try:
+                            if l[i+2].isdigit():
                                 # 01-01[-01]
                                 ymd.append(l[i+2])
-                            except ValueError:
+                            else:
                                 # 01-Jan[-01]
                                 value = info.month(l[i+2])
 
@@ -1316,7 +1319,7 @@ class ProgrammingError(AssertionError):
 
 
 
-# TODO: requre len(toekn) >= 3 like we do for the between-parens version?
+# TODO: requre len(token) >= 3 like we do for the between-parens version?
 # do some other validation here instead of putting it off?  As of now, "Q"
 # will be accepted as a timezone...
 def _could_be_tzname(hour, tzname, tzoffset, token):
@@ -1377,6 +1380,7 @@ def _parse_min_sec(value):
         second = int(60 * sec_remainder)
     return (minute, second)
 
+
 def _parsems(value):
     """Parse a I[.F] seconds value into (seconds, microseconds)."""
     if "." not in value:
@@ -1384,6 +1388,7 @@ def _parsems(value):
     else:
         i, f = value.split(".")
         return int(i), int(f.ljust(6, "0")[:6])
+
 
 def _recombine_skipped(tokens, skipped_idxs):
     """

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -876,13 +876,11 @@ class parser(object):
                     elif not fuzzy:
                         raise InvalidDatetimeError(timestr)
 
-                    i += 1
 
                 # Check weekday
                 elif info.weekday(l[i]) is not None:
                     value = info.weekday(l[i])
                     res.weekday = value
-                    i += 1
 
                 # Check month name
                 elif info.month(l[i]) is not None:
@@ -918,7 +916,6 @@ class parser(object):
                             i += 4
 
 
-                    i += 1
 
                 # Check am/pm
                 elif info.ampm(l[i]) is not None:
@@ -932,7 +929,6 @@ class parser(object):
                     elif fuzzy:
                         skipped_idxs.add(i)
 
-                    i += 1
 
                 # Check for a timezone name
                 elif (res.hour is not None and len(l[i]) <= 5
@@ -954,7 +950,6 @@ class parser(object):
                             # is *not* GMT.
                             res.tzname = None
 
-                    i += 1
 
                 # Check for a numbered timezone
                 elif res.hour is not None and l[i] in ('+', '-'):
@@ -985,7 +980,7 @@ class parser(object):
                         res.tzname = l[i+4]
                         i += 4
 
-                    i += 2
+                    i += 1
 
                 # Check jumps
                 elif not (info.jump(l[i]) or fuzzy):
@@ -993,7 +988,7 @@ class parser(object):
 
                 else:
                     skipped_idxs.add(i)
-                    i += 1
+                i += 1
 
             # Process year/month/day
             year, month, day = ymd.resolve_ymd(yearfirst, dayfirst)

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -726,7 +726,6 @@ class parser(object):
 
                         if len_li == 4:
                             res.minute = int(s[2:])
-                        i += 1
 
                     elif len_li == 6 or (len_li > 6 and l[i].find('.') == 6):
                         # YYMMDD or HHMMSS[.ss]
@@ -743,7 +742,6 @@ class parser(object):
                             res.hour = int(s[:2])
                             res.minute = int(s[2:4])
                             res.second, res.microsecond = _parsems(s[4:])
-                        i += 1
 
                     elif len_li in (8, 12, 14):
                         # YYYYMMDD
@@ -758,7 +756,6 @@ class parser(object):
 
                             if len_li > 12:
                                 res.second = int(s[12:])
-                        i += 1
 
                     elif ((i+1 < len_l and info.hms(l[i+1]) is not None)
                         or (i+2 < len_l and l[i+1] == ' ' and info.hms(l[i+2]) is not None)
@@ -803,7 +800,6 @@ class parser(object):
                                         idx = newidx
                                 i += 2
 
-                        i += 1
 
                     elif (i+1 == len_l and l[i-1] == ' ' and info.hms(l[i-2]) is not None):
                         # X h MM or X m SS
@@ -814,7 +810,6 @@ class parser(object):
                         elif idx == 1:             # m
                             res.second, res.microsecond = _parsems(value_repr)
 
-                        i += 1
                         # We don't need to advance the tokens here because the
                         # i == len_l call indicates that we're looking at all
                         # the tokens already.
@@ -829,7 +824,7 @@ class parser(object):
                             res.second, res.microsecond = _parsems(l[i+4])
                             i += 2
 
-                        i += 3
+                        i += 2
 
                     elif i+1 < len_l and l[i+1] in ('-', '/', '.'):
                         sep = l[i+1]
@@ -858,9 +853,8 @@ class parser(object):
                                     ymd.append(l[i+4])
                                 i += 2
 
-                            i += 3
-                        else:
-                            i += 2
+                            i += 1
+                        i += 1
 
                     elif i+1 >= len_l or info.jump(l[i+1]):
                         if i+2 < len_l and info.ampm(l[i+2]) is not None:
@@ -871,18 +865,18 @@ class parser(object):
                         else:
                             # Year, month or day
                             ymd.append(value)
-                        i += 2
+                        i += 1
 
                     elif info.ampm(l[i+1]) is not None:
                         # 12am
                         hour = int(value)
                         res.hour = _adjust_ampm(hour, info.ampm(l[i+1]))
-                        i += 2
+                        i += 1
 
                     elif not fuzzy:
                         raise InvalidDatetimeError(timestr)
-                    else:
-                        i += 1
+
+                    i += 1
 
                 # Check weekday
                 elif info.weekday(l[i]) is not None:
@@ -904,9 +898,9 @@ class parser(object):
                             if i+3 < len_l and l[i+3] == sep:
                                 # Jan-01-99
                                 ymd.append(l[i+4])
-                                i += 5
-                            else:
-                                i += 3
+                                i += 2
+
+                            i += 2
 
                         elif (i+4 < len_l and l[i+1] == l[i+3] == ' '
                               and info.pertain(l[i+2])):
@@ -921,12 +915,10 @@ class parser(object):
                             else:
                                 # Convert it here to become unambiguous
                                 ymd.append(str(info.convertyear(value)), 'Y')
-                            i += 5
+                            i += 4
 
-                        else:
-                            i += 1
-                    else:
-                        i += 1
+
+                    i += 1
 
                 # Check am/pm
                 elif info.ampm(l[i]) is not None:
@@ -981,18 +973,19 @@ class parser(object):
                         res.tzoffset = int(l[i+1][:2])*3600
                     else:
                         raise InvalidDatetimeError(timestr)
-                    i += 2
 
                     res.tzoffset *= signal
 
                     # Look for a timezone name between parenthesis
-                    if (i+3 < len_l and
-                        info.jump(l[i]) and l[i+1] == '(' and l[i+3] == ')' and
-                        3 <= len(l[i+2]) <= 5 and
-                        all(x in string.ascii_uppercase for x in l[i+2])):
+                    if (i+5 < len_l and
+                        info.jump(l[i+2]) and l[i+3] == '(' and l[i+5] == ')' and
+                        3 <= len(l[i+4]) <= 5 and
+                        all(x in string.ascii_uppercase for x in l[i+4])):
                         # -0300 (BRST)
-                        res.tzname = l[i+2]
+                        res.tzname = l[i+4]
                         i += 4
+
+                    i += 2
 
                 # Check jumps
                 elif not (info.jump(l[i]) or fuzzy):

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -860,13 +860,8 @@ class parser(object):
                     elif i >= len_l or info.jump(l[i]):
                         if i+1 < len_l and info.ampm(l[i+1]) is not None:
                             # 12 am
-                            res.hour = int(value)
-
-                            if res.hour < 12 and info.ampm(l[i+1]) == 1:
-                                res.hour += 12
-                            elif res.hour == 12 and info.ampm(l[i+1]) == 0:
-                                res.hour = 0
-
+                            hour = int(value)
+                            res.hour = _adjust_ampm(hour, info.ampm(l[i+1]))
                             i += 1
                         else:
                             # Year, month or day
@@ -875,12 +870,8 @@ class parser(object):
                     elif info.ampm(l[i]) is not None:
 
                         # 12am
-                        res.hour = int(value)
-
-                        if res.hour < 12 and info.ampm(l[i]) == 1:
-                            res.hour += 12
-                        elif res.hour == 12 and info.ampm(l[i]) == 0:
-                            res.hour = 0
+                        hour = int(value)
+                        res.hour = _adjust_ampm(hour, info.ampm(l[i]))
                         i += 1
 
                     elif not fuzzy:
@@ -960,11 +951,7 @@ class parser(object):
                                              '12-hour clock.')
 
                     if val_is_ampm:
-                        if value == 1 and res.hour < 12:
-                            res.hour += 12
-                        elif value == 0 and res.hour == 12:
-                            res.hour = 0
-
+                        res.hour = _adjust_ampm(res.hour, value)
                         res.ampm = value
 
                     elif fuzzy:
@@ -1346,6 +1333,13 @@ DEFAULTTZPARSER = _tzparser()
 def _parsetz(tzstr):
     return DEFAULTTZPARSER.parse(tzstr)
 
+
+def _adjust_ampm(hour, ampm):
+    if hour < 12 and ampm == 1:
+        hour += 12
+    elif hour == 12 and ampm == 0:
+        hour = 0
+    return hour
 
 
 def _parse_min_sec(value):

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -777,26 +777,27 @@ class parser(object):
                             elif idx == 2:
                                 (res.second, res.microsecond) = _parsems(value_repr)
 
-                            i += 1
 
-                            if i+1 >= len_l or idx == 2:
+                            if i+2 >= len_l or idx == 2:
+                                i += 1
                                 break
 
                             # 12h00
                             try:
-                                value_repr = l[i+1]
+                                value_repr = l[i+2]
                                 value = float(value_repr)
                             except ValueError:
+                                i += 1
                                 break
                             else:
-                                i += 1
                                 idx += 1
 
-                                if i+1 < len_l:
-                                    newidx = info.hms(l[i+1])
+                                if i+3 < len_l:
+                                    newidx = info.hms(l[i+3])
 
                                     if newidx is not None:
                                         idx = newidx
+                                i += 2
 
                         i += 1
 
@@ -912,6 +913,7 @@ class parser(object):
                             except ValueError:
                                 # Wrong guess
                                 pass
+                                # TODO: not hit in tests
                             else:
                                 # Convert it here to become unambiguous
                                 ymd.append(str(info.convertyear(value)))
@@ -1315,6 +1317,8 @@ class ProgrammingError(AssertionError):
     Since an AssertionError is useful a user, a ProgrammingError clarifies
     that they should file a bug report.
     """
+
+
 
 def _ampm_validity(hour, ampm, fuzzy):
     """

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -767,44 +767,8 @@ class parser(object):
                         or (i+2 < len_l and l[i+1] == ' ' and info.hms(l[i+2]) is not None)
                             ):
                         # HH[ ]h or MM[ ]m or SS[.ss][ ]s
-                        if l[i+1] == ' ':
-                            i += 1
+                        i = _parse_hms(i, l, info, res)
 
-                        idx = info.hms(l[i+1])
-
-                        while True:
-                            if idx == 0:
-                                res.hour = int(value)
-                                if value % 1:
-                                    res.minute = int(60*(value % 1))
-
-                            elif idx == 1:
-                                (res.minute, res.second) = _parse_min_sec(value)
-
-                            elif idx == 2:
-                                (res.second, res.microsecond) = _parsems(value_repr)
-
-
-                            if i+2 >= len_l or idx == 2:
-                                i += 1
-                                break
-
-                            # 12h00
-                            try:
-                                value_repr = l[i+2]
-                                value = float(value_repr)
-                            except ValueError:
-                                i += 1
-                                break
-                            else:
-                                idx += 1
-
-                                if i+3 < len_l:
-                                    newidx = info.hms(l[i+3])
-
-                                    if newidx is not None:
-                                        idx = newidx
-                                i += 2
 
 
                     elif (i+1 == len_l and l[i-1] == ' ' and info.hms(l[i-2]) is not None):
@@ -1317,6 +1281,57 @@ class ProgrammingError(AssertionError):
     """
 
 
+def _parse_hms(i, l, info, res):
+    # TODO: This is still a mess.  Can we make this recursive instead of
+    # using a while loop?
+    len_l = len(l)
+
+    if ((i+1 < len_l and info.hms(l[i+1]) is not None)
+        or (i+2 < len_l and l[i+1] == ' ' and info.hms(l[i+2]) is not None)
+            ):
+        # HH[ ]h or MM[ ]m or SS[.ss][ ]s
+
+        value_repr = l[i]
+        value = float(value_repr)
+
+        if l[i+1] == ' ':
+            i += 1
+
+        idx = info.hms(l[i+1])
+        while True:
+            if idx == 0:
+                res.hour = int(value)
+                if value % 1:
+                    res.minute = int(60*(value % 1))
+
+            elif idx == 1:
+                (res.minute, res.second) = _parse_min_sec(value)
+
+            elif idx == 2:
+                (res.second, res.microsecond) = _parsems(value_repr)
+
+
+            if i+2 >= len_l or idx == 2:
+                i += 1
+                break
+
+            # 12h00
+            try:
+                value_repr = l[i+2]
+                value = float(value_repr)
+            except ValueError:
+                i += 1
+                break
+            else:
+                idx += 1
+
+                if i+3 < len_l:
+                    newidx = info.hms(l[i+3])
+
+                    if newidx is not None:
+                        idx = newidx
+                i += 2
+    return i
 
 
 # TODO: requre len(token) >= 3 like we do for the between-parens version?

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -771,10 +771,7 @@ class parser(object):
                                     res.minute = int(60*(value % 1))
 
                             elif idx == 1:
-                                res.minute = int(value)
-
-                                if value % 1:
-                                    res.second = int(60*(value % 1))
+                                (res.minute, res.second) = _parse_min_sec(value)
 
                             elif idx == 2:
                                 res.second, res.microsecond = \
@@ -807,11 +804,7 @@ class parser(object):
                         idx = info.hms(l[i-3])
 
                         if idx == 0:               # h
-                            res.minute = int(value)
-
-                            sec_remainder = value % 1
-                            if sec_remainder:
-                                res.second = int(60 * sec_remainder)
+                            (res.minute, res.second) = _parse_min_sec(value)
                         elif idx == 1:             # m
                             res.second, res.microsecond = \
                                 _parsems(value_repr)
@@ -825,10 +818,7 @@ class parser(object):
                         res.hour = int(value)
                         i += 1
                         value = float(l[i])
-                        res.minute = int(value)
-
-                        if value % 1:
-                            res.second = int(60*(value % 1))
+                        (res.minute, res.second) = _parse_min_sec(value)
 
                         i += 1
 
@@ -1356,6 +1346,16 @@ DEFAULTTZPARSER = _tzparser()
 def _parsetz(tzstr):
     return DEFAULTTZPARSER.parse(tzstr)
 
+
+
+def _parse_min_sec(value):
+    minute = int(value)
+    second = None
+
+    sec_remainder = value % 1
+    if sec_remainder:
+        second = int(60 * sec_remainder)
+    return (minute, second)
 
 def _parsems(value):
     """Parse a I[.F] seconds value into (seconds, microseconds)."""

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -878,49 +878,49 @@ class parser(object):
                         return None, None
                     else:
                         i += 1
-                    continue
 
                 # Check weekday
                 elif info.weekday(l[i]) is not None:
                     value = info.weekday(l[i])
                     res.weekday = value
                     i += 1
-                    continue
 
                 # Check month name
                 elif info.month(l[i]) is not None:
                     value = info.month(l[i])
                     ymd.append(value, 'M')
 
-                    i += 1
-                    if i < len_l:
-                        if l[i] in ('-', '/'):
+                    if i+1 < len_l:
+                        if l[i+1] in ('-', '/'):
                             # Jan-01[-99]
-                            sep = l[i]
-                            i += 1
-                            ymd.append(l[i])
-                            i += 1
+                            sep = l[i+1]
+                            ymd.append(l[i+2])
 
-                            if i < len_l and l[i] == sep:
+                            if i+3 < len_l and l[i+3] == sep:
                                 # Jan-01-99
-                                i += 1
-                                ymd.append(l[i])
-                                i += 1
+                                ymd.append(l[i+4])
+                                i += 5
+                            else:
+                                i += 3
 
-                        elif (i+3 < len_l and l[i] == l[i+2] == ' '
-                              and info.pertain(l[i+1])):
+                        elif (i+4 < len_l and l[i+1] == l[i+3] == ' '
+                              and info.pertain(l[i+2])):
                             # Jan of 01
                             # In this case, 01 is clearly year
                             try:
-                                value = int(l[i+3])
+                                value = int(l[i+4])
                             except ValueError:
                                 # Wrong guess
                                 pass
                             else:
                                 # Convert it here to become unambiguous
                                 ymd.append(str(info.convertyear(value)))
-                            i += 4
-                    continue
+                            i += 5
+
+                        else:
+                            i += 1
+                    else:
+                        i += 1
 
                 # Check am/pm
                 elif info.ampm(l[i]) is not None:
@@ -935,7 +935,6 @@ class parser(object):
                         skipped_idxs.add(i)
 
                     i += 1
-                    continue
 
                 # Check for a timezone name
                 elif (res.hour is not None and len(l[i]) <= 5
@@ -958,7 +957,6 @@ class parser(object):
                             res.tzname = None
 
                     i += 1
-                    continue
 
                 # Check for a numbered timezone
                 elif res.hour is not None and l[i] in ('+', '-'):
@@ -989,7 +987,6 @@ class parser(object):
                         # -0300 (BRST)
                         res.tzname = l[i+2]
                         i += 4
-                    continue
 
                 # Check jumps
                 elif not (info.jump(l[i]) or fuzzy):

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -925,30 +925,7 @@ class parser(object):
                 # Check am/pm
                 value = info.ampm(l[i])
                 if value is not None:
-                    # For fuzzy parsing, 'a' or 'am' (both valid English words)
-                    # may erroneously trigger the AM/PM flag. Deal with that
-                    # here.
-                    val_is_ampm = True
-
-                    # If there's already an AM/PM flag, this one isn't one.
-                    if fuzzy and res.ampm is not None:
-                        val_is_ampm = False
-
-                    # If AM/PM is found and hour is not, raise a ValueError
-                    if res.hour is None:
-                        if fuzzy:
-                            val_is_ampm = False
-                        else:
-                            raise ValueError('No hour specified with ' +
-                                             'AM or PM flag.')
-                    elif not 0 <= res.hour <= 12:
-                        # If AM/PM is found, it's a 12 hour clock, so raise
-                        # an error for invalid range
-                        if fuzzy:
-                            val_is_ampm = False
-                        else:
-                            raise ValueError('Invalid hour specified for ' +
-                                             '12-hour clock.')
+                    val_is_ampm = _ampm_validity(res.hour, res.ampm, fuzzy)
 
                     if val_is_ampm:
                         res.hour = _adjust_ampm(res.hour, value)
@@ -1332,6 +1309,35 @@ DEFAULTTZPARSER = _tzparser()
 
 def _parsetz(tzstr):
     return DEFAULTTZPARSER.parse(tzstr)
+
+
+def _ampm_validity(hour, ampm, fuzzy):
+    """
+    For fuzzy parsing, 'a' or 'am' (both valid English words)
+    may erroneously trigger the AM/PM flag. Deal with that
+    here.
+    """
+    val_is_ampm = True
+
+    # If there's already an AM/PM flag, this one isn't one.
+    if fuzzy and ampm is not None:
+        val_is_ampm = False
+
+    # If AM/PM is found and hour is not, raise a ValueError
+    if hour is None:
+        if fuzzy:
+            val_is_ampm = False
+        else:
+            raise ValueError('No hour specified with AM or PM flag.')
+    elif not 0 <= hour <= 12:
+        # If AM/PM is found, it's a 12 hour clock, so raise
+        # an error for invalid range
+        if fuzzy:
+            val_is_ampm = False
+        else:
+            raise ValueError('Invalid hour specified for 12-hour clock.')
+
+    return val_is_ampm
 
 
 def _adjust_ampm(hour, ampm):

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -961,22 +961,21 @@ class parser(object):
                 # Check for a numbered timezone
                 if res.hour is not None and l[i] in ('+', '-'):
                     signal = (-1, 1)[l[i] == '+']
-                    i += 1
-                    len_li = len(l[i])
+                    len_li = len(l[i+1])
 
                     if len_li == 4:
                         # -0300
-                        res.tzoffset = int(l[i][:2])*3600+int(l[i][2:])*60
-                    elif i+1 < len_l and l[i+1] == ':':
+                        res.tzoffset = int(l[i+1][:2])*3600+int(l[i+1][2:])*60
+                    elif i+2 < len_l and l[i+2] == ':':
                         # -03:00
-                        res.tzoffset = int(l[i])*3600+int(l[i+2])*60
+                        res.tzoffset = int(l[i+1])*3600+int(l[i+3])*60
                         i += 2
                     elif len_li <= 2:
                         # -[0]3
-                        res.tzoffset = int(l[i][:2])*3600
+                        res.tzoffset = int(l[i+1][:2])*3600
                     else:
                         return None, None
-                    i += 1
+                    i += 2
 
                     res.tzoffset *= signal
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -825,7 +825,7 @@ class parser(object):
                         value = float(l[i+2])
                         (res.minute, res.second) = _parse_min_sec(value)
 
-                        if i+3 < len_l and l[i+3] == ':':
+                        if i+4 < len_l and l[i+3] == ':':
                             res.second, res.microsecond = _parsems(l[i+4])
                             i += 2
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -690,15 +690,16 @@ class parser(object):
 
         res = self._result()
         l = _timelex.split(timestr)         # Splits the timestr into tokens
+        tokens = l # alias that is easier to grep
 
         skipped_idxs = set()
 
-        try:
-            # year/month/day list
-            ymd = _ymd(timestr)
+        # year/month/day list
+        ymd = _ymd(timestr)
 
-            len_l = len(l)
-            i = 0
+        len_l = len(l)
+        i = 0
+        try:
             while i < len_l:
 
                 # Check if it's a number
@@ -806,8 +807,7 @@ class parser(object):
                         if idx == 0:               # h
                             (res.minute, res.second) = _parse_min_sec(value)
                         elif idx == 1:             # m
-                            res.second, res.microsecond = \
-                                _parsems(value_repr)
+                            res.second, res.microsecond = _parsems(value_repr)
 
                         # We don't need to advance the tokens here because the
                         # i == len_l call indicates that we're looking at all

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -617,21 +617,7 @@ class parser(object):
         if not ignoretz:
             if (isinstance(tzinfos, collections.Callable) or
                     tzinfos and res.tzname in tzinfos):
-
-                if isinstance(tzinfos, collections.Callable):
-                    tzdata = tzinfos(res.tzname, res.tzoffset)
-                else:
-                    tzdata = tzinfos.get(res.tzname)
-
-                if isinstance(tzdata, datetime.tzinfo):
-                    tzinfo = tzdata
-                elif isinstance(tzdata, text_type):
-                    tzinfo = tz.tzstr(tzdata)
-                elif isinstance(tzdata, integer_types):
-                    tzinfo = tz.tzoffset(res.tzname, tzdata)
-                else:
-                    raise ValueError("Offset must be tzinfo subclass, "
-                                     "tz string, or int offset.")
+                tzinfo = _build_tzinfo(tzinfos, res.tzname, res.tzoffset)
                 ret = ret.replace(tzinfo=tzinfo)
             elif res.tzname and res.tzname in time.tzname:
                 ret = ret.replace(tzinfo=tz.tzlocal())
@@ -1395,5 +1381,23 @@ def _recombine_skipped(tokens, skipped_idxs):
         else:
             skipped_tokens.append(tokens[idx])
     return skipped_tokens
+
+
+def _build_tzinfo(tzinfos, tzname, tzoffset):
+    if isinstance(tzinfos, collections.Callable):
+        tzdata = tzinfos(tzname, tzoffset)
+    else:
+        tzdata = tzinfos.get(tzname)
+
+    if isinstance(tzdata, datetime.tzinfo):
+        tzinfo = tzdata
+    elif isinstance(tzdata, text_type):
+        tzinfo = tz.tzstr(tzdata)
+    elif isinstance(tzdata, integer_types):
+        tzinfo = tz.tzoffset(tzname, tzdata)
+    else:
+        raise ValueError("Offset must be tzinfo subclass, "
+                         "tz string, or int offset.")
+    return tzinfo
 
 # vim:ts=4:sw=4:et

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -841,7 +841,7 @@ class parser(object):
                                 if value is not None:
                                     ymd.append(value, 'M')
                                 else:
-                                    return None, None
+                                    raise InvalidDatetimeError(timestr)
 
                             if i+3 < len_l and l[i+3] == sep:
                                 # We have three members
@@ -875,7 +875,7 @@ class parser(object):
                         i += 2
 
                     elif not fuzzy:
-                        return None, None
+                        raise InvalidDatetimeError(timestr)
                     else:
                         i += 1
 
@@ -974,7 +974,7 @@ class parser(object):
                         # -[0]3
                         res.tzoffset = int(l[i+1][:2])*3600
                     else:
-                        return None, None
+                        raise InvalidDatetimeError(timestr)
                     i += 2
 
                     res.tzoffset *= signal
@@ -990,7 +990,7 @@ class parser(object):
 
                 # Check jumps
                 elif not (info.jump(l[i]) or fuzzy):
-                    return None, None
+                    raise InvalidDatetimeError(timestr)
 
                 else:
                     skipped_idxs.add(i)
@@ -1305,6 +1305,16 @@ DEFAULTTZPARSER = _tzparser()
 def _parsetz(tzstr):
     return DEFAULTTZPARSER.parse(tzstr)
 
+class InvalidDatetimeError(ValueError): pass
+class InvalidDateError(InvalidDatetimeError): pass
+class InvalidTimeError(InvalidDatetimeError): pass
+
+class ProgrammingError(AssertionError):
+    """ProgrammingError is for if we reach a state that we *think* should
+    be unreachable and would otherwise be inclined to assert is impossible.
+    Since an AssertionError is useful a user, a ProgrammingError clarifies
+    that they should file a bug report.
+    """
 
 def _ampm_validity(hour, ampm, fuzzy):
     """

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -755,8 +755,8 @@ class parser(object):
                                 res.second = int(s[12:])
 
                     elif ((i < len_l and info.hms(l[i]) is not None) or
-                          (i+1 < len_l and l[i] == ' ' and
-                           info.hms(l[i+1]) is not None)):
+                          (i+1 < len_l and l[i] == ' ' and info.hms(l[i+1]) is not None)
+                          ):
 
                         # HH[ ]h or MM[ ]m or SS[.ss][ ]s
                         if l[i] == ' ':
@@ -767,7 +767,6 @@ class parser(object):
                         while True:
                             if idx == 0:
                                 res.hour = int(value)
-
                                 if value % 1:
                                     res.minute = int(60*(value % 1))
 
@@ -775,8 +774,7 @@ class parser(object):
                                 (res.minute, res.second) = _parse_min_sec(value)
 
                             elif idx == 2:
-                                res.second, res.microsecond = \
-                                    _parsems(value_repr)
+                                (res.second, res.microsecond) = _parsems(value_repr)
 
                             i += 1
 
@@ -799,8 +797,7 @@ class parser(object):
                                     if newidx is not None:
                                         idx = newidx
 
-                    elif (i == len_l and l[i-2] == ' ' and
-                          info.hms(l[i-3]) is not None):
+                    elif (i == len_l and l[i-2] == ' ' and info.hms(l[i-3]) is not None):
                         # X h MM or X m SS
                         idx = info.hms(l[i-3])
 
@@ -857,6 +854,7 @@ class parser(object):
                                     ymd.append(l[i])
 
                                 i += 1
+
                     elif i >= len_l or info.jump(l[i]):
                         if i+1 < len_l and info.ampm(l[i+1]) is not None:
                             # 12 am
@@ -867,8 +865,8 @@ class parser(object):
                             # Year, month or day
                             ymd.append(value)
                         i += 1
-                    elif info.ampm(l[i]) is not None:
 
+                    elif info.ampm(l[i]) is not None:
                         # 12am
                         hour = int(value)
                         res.hour = _adjust_ampm(hour, info.ampm(l[i]))
@@ -1347,6 +1345,9 @@ def _adjust_ampm(hour, ampm):
 
 
 def _parse_min_sec(value):
+    # TODO: Every usage of this function sets res.second to the return value.
+    # Are there any cases where second will be returned as None and we *dont*
+    # want to set res.second = None?
     minute = int(value)
     second = None
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -712,11 +712,11 @@ class parser(object):
                 if value is not None:
                     # Token is a number
                     len_li = len(l[i])
-                    i += 1
 
                     if (len(ymd) == 3 and len_li in (2, 4)
-                        and res.hour is None and (i >= len_l or (l[i] != ':' and
-                                                  info.hms(l[i]) is None))):
+                        and res.hour is None and (i+1 >= len_l or (l[i+1] != ':' and
+                                                  info.hms(l[i+1]) is None))):
+                        i += 1
                         # 19990101T23[59]
                         s = l[i-1]
                         res.hour = int(s[:2])
@@ -724,7 +724,8 @@ class parser(object):
                         if len_li == 4:
                             res.minute = int(s[2:])
 
-                    elif len_li == 6 or (len_li > 6 and l[i-1].find('.') == 6):
+                    elif len_li == 6 or (len_li > 6 and l[i].find('.') == 6):
+                        i += 1
                         # YYMMDD or HHMMSS[.ss]
                         s = l[i-1]
 
@@ -741,6 +742,7 @@ class parser(object):
                             res.second, res.microsecond = _parsems(s[4:])
 
                     elif len_li in (8, 12, 14):
+                        i += 1
                         # YYYYMMDD
                         s = l[i-1]
                         ymd.append(s[:4])
@@ -754,9 +756,10 @@ class parser(object):
                             if len_li > 12:
                                 res.second = int(s[12:])
 
-                    elif ((i < len_l and info.hms(l[i]) is not None) or
-                          (i+1 < len_l and l[i] == ' ' and info.hms(l[i+1]) is not None)
-                          ):
+                    elif ((i+1 < len_l and info.hms(l[i+1]) is not None)
+                        or (i+2 < len_l and l[i+1] == ' ' and info.hms(l[i+2]) is not None)
+                            ):
+                        i += 1
 
                         # HH[ ]h or MM[ ]m or SS[.ss][ ]s
                         if l[i] == ' ':
@@ -797,7 +800,8 @@ class parser(object):
                                     if newidx is not None:
                                         idx = newidx
 
-                    elif (i == len_l and l[i-2] == ' ' and info.hms(l[i-3]) is not None):
+                    elif (i+1 == len_l and l[i-1] == ' ' and info.hms(l[i-2]) is not None):
+                        i += 1
                         # X h MM or X m SS
                         idx = info.hms(l[i-3])
 
@@ -810,7 +814,8 @@ class parser(object):
                         # i == len_l call indicates that we're looking at all
                         # the tokens already.
 
-                    elif i+1 < len_l and l[i] == ':':
+                    elif i+2 < len_l and l[i+1] == ':':
+                        i += 1
                         # HH:MM[:SS[.ss]]
                         res.hour = int(value)
                         i += 1
@@ -823,7 +828,8 @@ class parser(object):
                             res.second, res.microsecond = _parsems(l[i+1])
                             i += 2
 
-                    elif i < len_l and l[i] in ('-', '/', '.'):
+                    elif i+1 < len_l and l[i+1] in ('-', '/', '.'):
+                        i += 1
                         sep = l[i]
                         ymd.append(value_repr)
                         i += 1
@@ -855,7 +861,8 @@ class parser(object):
 
                                 i += 1
 
-                    elif i >= len_l or info.jump(l[i]):
+                    elif i+1 >= len_l or info.jump(l[i+1]):
+                        i += 1
                         if i+1 < len_l and info.ampm(l[i+1]) is not None:
                             # 12 am
                             hour = int(value)
@@ -866,8 +873,9 @@ class parser(object):
                             ymd.append(value)
                         i += 1
 
-                    elif info.ampm(l[i]) is not None:
+                    elif info.ampm(l[i+1]) is not None:
                         # 12am
+                        i += 1
                         hour = int(value)
                         res.hour = _adjust_ampm(hour, info.ampm(l[i]))
                         i += 1
@@ -936,9 +944,9 @@ class parser(object):
                     continue
 
                 # Check for a timezone name
-                if (res.hour is not None and len(l[i]) <= 5 and
-                        res.tzname is None and res.tzoffset is None and
-                        all(x in string.ascii_uppercase for x in l[i])):
+                if (res.hour is not None and len(l[i]) <= 5
+                    and res.tzname is None and res.tzoffset is None
+                    and all(x in string.ascii_uppercase for x in l[i])):
                     res.tzname = l[i]
                     res.tzoffset = info.tzoffset(res.tzname)
 

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -940,8 +940,7 @@ class parser(object):
                 # Check for a timezone name
                 if (res.hour is not None and len(l[i]) <= 5 and
                         res.tzname is None and res.tzoffset is None and
-                        not [x for x in l[i] if x not in
-                             string.ascii_uppercase]):
+                        all(x in string.ascii_uppercase for x in l[i])):
                     res.tzname = l[i]
                     res.tzoffset = info.tzoffset(res.tzname)
                     i += 1
@@ -987,8 +986,7 @@ class parser(object):
                     if (i+3 < len_l and
                         info.jump(l[i]) and l[i+1] == '(' and l[i+3] == ')' and
                         3 <= len(l[i+2]) <= 5 and
-                        not [x for x in l[i+2]
-                             if x not in string.ascii_uppercase]):
+                        all(x in string.ascii_uppercase for x in l[i+2])):
                         # -0300 (BRST)
                         res.tzname = l[i+2]
                         i += 4

--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -941,21 +941,21 @@ class parser(object):
                         all(x in string.ascii_uppercase for x in l[i])):
                     res.tzname = l[i]
                     res.tzoffset = info.tzoffset(res.tzname)
-                    i += 1
 
                     # Check for something like GMT+3, or BRST+3. Notice
                     # that it doesn't mean "I am 3 hours after GMT", but
                     # "my time +3 is GMT". If found, we reverse the
                     # logic so that timezone parsing code will get it
                     # right.
-                    if i < len_l and l[i] in ('+', '-'):
-                        l[i] = ('+', '-')[l[i] == '+']
+                    if i+1 < len_l and l[i+1] in ('+', '-'):
+                        l[i+1] = ('+', '-')[l[i+1] == '+']
                         res.tzoffset = None
                         if info.utczone(res.tzname):
                             # With something like GMT+3, the timezone
                             # is *not* GMT.
                             res.tzname = None
 
+                    i += 1
                     continue
 
                 # Check for a numbered timezone


### PR DESCRIPTION
I don't really expect/intend this to be merged, just want to show the places that I think make for easy refactoring wins.  These will be easiest to view commit-by-commit.

The heuristic for refactoring candidates was
- Can this be made a function without passing `res` or `ymd`?
- Is it obvious what this function would be named?"

[_build_tzinfo](https://github.com/jbrockmendel/dateutil/commit/ad1bff2157c5b4f12e9e3d0dfcdf0d08bb350f2a) and [_ampm_validity](https://github.com/jbrockmendel/dateutil/commit/9c107b9325a9438ae8cff4c8ca268ca915a9f287) just cut/paste a chunk of code from a method into a function.

[_adjust_ampm](https://github.com/jbrockmendel/dateutil/commit/ee75ff0a50e9fd73fc05941799f5af5464517558) and [_parse_min_sec](https://github.com/jbrockmendel/dateutil/commit/54deb3325d3aa28bf2822dad380ceb7b02015c07) are each only ~4 lines, but appear a several times each.

Commits 5 and 8 are just small cleanups.

The first commit [deprecates](https://github.com/jbrockmendel/dateutil/commit/3b22f0d9a4eef23ceabdc466691caa948ee259cc) `_skip_token`.  Instead of carrying around `skipped_tokens` and `last_skipped_index_i`, this is replaced with a set `skipped_idxs`, and at the end of the parsing `_recombine_skipped` is called to create `skipped_tokens`.

The second commit makes `mstridx` an attribute of `_ymd` and moves validation into `ymd.append`.  This was discussed briefly in #414.


Those were all of the candidates I saw that didn't alter any of the flow, i.e. should be fairly uncontroversial.  The next goals I'll suggest are

- Reducing the number of places where `i` is incremented (currently 51).
- Moving away from the `while True` block.
