### PR TITLE
Fix incorrect index check, add test that fails pre-PR

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -821,7 +821,7 @@ class parser(object):
 
                         i += 1
 
-                        if i < len_l and l[i] == ':':
+                        if i+1 < len_l and l[i] == ':':
                             res.second, res.microsecond = _parsems(l[i+1])
                             i += 2
 

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -901,3 +901,11 @@ class ParserTest(unittest.TestCase):
         dtstr = '2015-15-May'
         self.assertEqual(parse(dtstr),
                          datetime(2015, 5, 15))
+
+    def test_idx_check(self):
+        dtstr = '2017-07-17 06:15:'
+        # Pre-PR, the trailing colon will cause an IndexError at 824-825
+        # when checking `i < len_l` and then accessing `l[i+1]`
+        res = parse(dtstr, fuzzy=True)
+        self.assertEqual(res, datetime(2017, 7, 17, 6, 15))
+


### PR DESCRIPTION
In the status-quo, [L824-825](https://github.com/dateutil/dateutil/blob/master/dateutil/parser.py#L824) checks:

```
                        if i < len_l and l[i] == ':':
                            res.second, res.microsecond = _parsems(l[i+1])
```

Avoiding an IndexError requires checking `i+1 < len_l`.  This is easy to miss because the try/except catches IndexError.  One way to trigger this is:

```
import dateutil.parser
dateutil.parser.IndexError = SyntaxError
dateutil.parser.parse('2017-07-17 06:21:', fuzzy=True)
```
