### PR TITLE
Implement utils.within_delta

### DIFF
--- a/dateutil/test/test_utils.py
+++ b/dateutil/test/test_utils.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from datetime import timedelta, datetime
+from dateutil.utils import within_delta
+import unittest
+
+class UtilsTest(unittest.TestCase):
+
+    def testWithinDelta(self):
+        d1 = datetime(2016, 1, 1, 12, 14, 1, 9)
+        d2 = d1.replace(microsecond=15)
+
+        self.assertTrue(within_delta(d1, d2, timedelta(seconds=1)))
+        self.assertFalse(within_delta(d1, d2, timedelta(microseconds=1)))
+
+    def testWithinDeltaWithNegativeDelta(self):
+        d1 = datetime(2016, 1, 1)
+        d2 = datetime(2015, 12, 31)
+
+        self.assertTrue(within_delta(d2, d1, timedelta(days=-1)))

--- a/dateutil/utils.py
+++ b/dateutil/utils.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+
+def within_delta(dt1, dt2, delta):
+    """
+    Useful for comparing two datetimes that may a negilible difference
+    to be considered equal.
+    """
+    delta = abs(delta)
+    difference = dt1 - dt2
+    return -delta <= difference <= delta


### PR DESCRIPTION
Per the discussion in #431 and #432 this is the (fixed) `within_delta` from justanr/datestuff. I ended up finding a bug that a negative timedelta would return False, so using `abs` on it before doing the negative/positive comparison fixes that.


