### PR TITLE
Improve RFC5545 support in tzical, tweak tests.

### DIFF
--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1287,6 +1287,13 @@ class tzical(object):
                         raise ValueError("invalid component end: "+value)
                 elif comptype:
                     if name == "DTSTART":
+                        # DTSTART in VTIMEZONE takes a subset of valid RRULE
+                        # values under RFC 5545.
+                        for parm in parms:
+                            if parm != 'VALUE=DATE-TIME':
+                                msg = ('Unsupported DTSTART param in ' +
+                                       'VTIMEZONE: ' + parm)
+                                raise ValueError(msg)
                         rrulelines.append(line)
                         founddtstart = True
                     elif name in ("RRULE", "RDATE", "EXRULE", "EXDATE"):


### PR DESCRIPTION
Per [these comments on #429](https://github.com/dateutil/dateutil/pull/429#issuecomment-320507666) according to [RFC 5544 3.6.5](https://tools.ietf.org/html/rfc5545#section-3.6.5), `VTIMEZONE` only supports the optional `VALUE=DATE-TIME` parameter,  so anything else is filtered out.