### PR TITLE
Improve fold backport compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,7 @@ python:
   - "pypy3"
 
 matrix:
-  # pypy3 latest version is not playing nice.
   allow_failures:
-    - python: "pypy3"
     - python: "nightly"
 
 before_install:

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -61,6 +61,36 @@ else:
         """
         __slots__ = ()
 
+        def replace(self, *args, **kwargs):
+            """
+            Return a datetime with the same attributes, except for those
+            attributes given new values by whichever keyword arguments are
+            specified. Note that tzinfo=None can be specified to create a naive
+            datetime from an aware datetime with no conversion of date and time
+            data.
+
+            This is reimplemented in ``_DatetimeWithFold`` because pypy3 will
+            return a ``datetime.datetime`` even if ``fold`` is unchanged.
+            """
+            argnames = (
+                'year', 'month', 'day', 'hour', 'minute', 'second',
+                'microsecond', 'tzinfo'
+            )
+
+            for arg, argname in zip(args, argnames):
+                if argname in kwargs:
+                    raise TypeError('Duplicate argument: {}'.format(argname))
+
+                kwargs[argname] = arg
+
+            for argname in argnames:
+                if argname not in kwargs:
+                    kwargs[argname] = getattr(self, argname)
+
+            dt_class = self.__class__ if kwargs.get('fold', 1) else datetime
+
+            return dt_class(**kwargs)
+
         @property
         def fold(self):
             return 1

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ envlist =
     py33,
     py34,
     py35,
-    py36
+    py36,
+    pypy,
+    pypy3
 
 [testenv]
 commands = python setup.py test -q {posargs}


### PR DESCRIPTION
Turns out that pypy3's implementation of `datetime.replace` doesn't return `self.__class__`, it always returns `datetime`. This fixes that issue and makes pypy3 a required pass.