### PR TITLE
Change license information in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name="python-dateutil",
       author="Paul Ganssle",
       author_email="dateutil@python.org",
       url="https://dateutil.readthedocs.io",
-      license="Simplified BSD",
+      license="BSD 3-Clause",
       long_description="""
 The dateutil module provides powerful extensions to the
 datetime module available in the Python standard library.


### PR DESCRIPTION
Fixes #464.

I'm not 100% on what the right thing to put in this `license` line here. Most people seem to use "BSD" to refer to either the 2-, 3- or 4- clause versions and there doesn't seem to be a single canonical name for the 3-clause license, [according to Wikipedia](https://en.wikipedia.org/wiki/BSD_licenses#3-clause_license_.28.22BSD_License_2.0.22.2C_.22Revised_BSD_License.22.2C_.22New_BSD_License.22.2C_or_.22Modified_BSD_License.22.29). I picked the most official-sounding one that seemed unambiguous, but maybe "BSD 3-clause" or "BSD (3-clause)" would be best?