### PR TITLE
Add default tzinfo

### DIFF
--- a/dateutil/test/test_utils.py
+++ b/dateutil/test/test_utils.py
@@ -5,7 +5,8 @@ from datetime import timedelta, datetime
 import unittest
 
 from dateutil import tz
-from dateutil.utils import within_delta, today
+from dateutil import utils
+from dateutil.utils import within_delta
 
 from freezegun import freeze_time
 
@@ -16,17 +17,27 @@ NYC = tz.gettz("America/New_York")
 class UtilsTest(unittest.TestCase):
     @freeze_time(datetime(2014, 12, 15, 1, 21, 33, 4003))
     def testToday(self):
-        self.assertEqual(today(), datetime(2014, 12, 15, 0, 0, 0))
+        self.assertEqual(utils.today(), datetime(2014, 12, 15, 0, 0, 0))
 
     @freeze_time(datetime(2014, 12, 15, 12), tz_offset=5)
     def testTodayTzInfo(self):
-        self.assertEqual(today(NYC),
+        self.assertEqual(utils.today(NYC),
                          datetime(2014, 12, 15, 0, 0, 0, tzinfo=NYC))
 
     @freeze_time(datetime(2014, 12, 15, 23), tz_offset=5)
     def testTodayTzInfoDifferentDay(self):
-        self.assertEqual(today(UTC),
+        self.assertEqual(utils.today(UTC),
                          datetime(2014, 12, 16, 0, 0, 0, tzinfo=UTC))
+
+    def testDefaultTZInfoNaive(self):
+        dt = datetime(2014, 9, 14, 9, 30)
+        self.assertIs(utils.default_tzinfo(dt, NYC).tzinfo,
+                      NYC)
+
+    def testDefaultTZInfoAware(self):
+        dt = datetime(2014, 9, 14, 9, 30, tzinfo=UTC)
+        self.assertIs(utils.default_tzinfo(dt, NYC).tzinfo,
+                      UTC)
 
     def testWithinDelta(self):
         d1 = datetime(2016, 1, 1, 12, 14, 1, 9)

--- a/dateutil/utils.py
+++ b/dateutil/utils.py
@@ -20,6 +20,26 @@ def today(tzinfo=None):
     return datetime.combine(dt.date(), time(0, tzinfo=tzinfo))
 
 
+def default_tzinfo(dt, tzinfo):
+    """
+    Sets the the ``tzinfo`` parameter on naive datetimes only
+
+    :param dt:
+        The datetime on which to replace the time zone
+
+    :param tzinfo:
+        The :py:class:`datetime.tzinfo` subclass instance to assign to
+        ``dt`` if (and only if) it is naive.
+
+    :return:
+        Returns an aware :py:class:`datetime.datetime`.
+    """
+    if dt.tzinfo is not None:
+        return dt
+    else:
+        return dt.replace(tzinfo=tzinfo)
+
+
 def within_delta(dt1, dt2, delta):
     """
     Useful for comparing two datetimes that may a negilible difference

--- a/dateutil/utils.py
+++ b/dateutil/utils.py
@@ -24,6 +24,21 @@ def default_tzinfo(dt, tzinfo):
     """
     Sets the the ``tzinfo`` parameter on naive datetimes only
 
+    This is useful for example when you are provided a datetime that may have
+    either an implicit or explicit time zone, such as when parsing a time zone
+    string.
+
+    .. doctest::
+
+        >>> from dateutil.tz import tzoffset
+        >>> from dateutil.parser import parse
+        >>> from dateutil.utils import default_tzinfo
+        >>> dflt_tz = tzoffset("EST", -18000)
+        >>> print(default_tzinfo(parse('2014-01-01 12:30 UTC'), dflt_tz))
+        2014-01-01 12:30:00+00:00
+        >>> print(default_tzinfo(parse('2014-01-01 12:30'), dflt_tz))
+        2014-01-01 12:30:00-05:00
+
     :param dt:
         The datetime on which to replace the time zone
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Contents:
    relativedelta
    rrule
    tz
+   utils
    zoneinfo
    examples
 

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -1,0 +1,6 @@
+=====
+utils
+=====
+.. automodule:: dateutil.utils
+   :members:
+   :undoc-members:


### PR DESCRIPTION
As a partial and possibly more general fix to #94, this adds a `tzinfo` to any `datetime` that doesn't have one, and otherwise leaves it alone.