### PR TITLE
Remove unnecessary pip download from Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,6 @@ install:
   - set pip_cmd=%PYTHON%/python.exe -m pip
 
   # Download scripts and dependencies
-  - ps: Start-FileDownload 'https://bootstrap.pypa.io/get-pip.py'
-  - "%PYTHON%/python.exe get-pip.py"
   - "%pip_cmd% install six"
   - "%pip_cmd% install coverage"
   - "%pip_cmd% install codecov"


### PR DESCRIPTION
It seems that Appveyor's Python versions come with pip installed already. Since we were having SSL/TLS problems causing failing builds, this should fix that.