### PR TITLE
Make zoneinfo tzfile superclass less confusing

### DIFF
--- a/dateutil/zoneinfo/__init__.py
+++ b/dateutil/zoneinfo/__init__.py
@@ -7,7 +7,7 @@ from pkgutil import get_data
 from io import BytesIO
 from contextlib import closing
 
-from dateutil.tz import tzfile
+from dateutil.tz import tzfile as _tzfile
 
 __all__ = ["get_zonefile_instance", "gettz", "gettz_db_metadata", "rebuild"]
 
@@ -15,7 +15,7 @@ ZONEFILENAME = "dateutil-zoneinfo.tar.gz"
 METADATA_FN = 'METADATA'
 
 
-class tzfile(tzfile):
+class tzfile(_tzfile):
     def __reduce__(self):
         return (gettz, (self._filename,))
 


### PR DESCRIPTION
Specifically, this was confusing to mypy.

The new code is slightly easier to understand if you don't know what's going
on, IMO, otherwise I wouldn't necessarily change valid upstream code to appease
a typechecker.

Specifically, before this change:

```
$ mypy dateutil/zoneinfo/__init__.py | grep zoneinfo
dateutil/zoneinfo/__init__.py:18: error: Name 'tzfile' already defined (possibly by an import)
dateutil/zoneinfo/__init__.py:18: error: Cycle in inheritance hierarchy
```

That Cycle inheritance one is bad enough to cause mypy to give an error even
with `--follow-imports=silent`, which might be a bug in mypy, but, like I said,
I think the new code is more obvious to humans.