### PR TITLE
Proof of concept _constructor property

### DIFF
--- a/dateutil/parser.py
+++ b/dateutil/parser.py
@@ -547,18 +547,39 @@ class ParseResult(_resultbase):
                  "hour", "minute", "second", "microsecond",
                  "tzname", "tzoffset", "ampm"]
 
-    def _build_tzaware(self, tzinfos, result, naive):
-        if callable(tzinfos) or (tzinfos and result.tzname in tzinfos):
+    def _build_naive(self, default):
+        repl = {}
+        for attr in ("year", "month", "day", "hour",
+                     "minute", "second", "microsecond"):
+            value = getattr(self, attr)
+            if value is not None:
+                repl[attr] = value
+
+        if 'day' not in repl:
+            # If the default day exceeds the last day of the month, fall back
+            # to the end of the month.
+            cyear = default.year if self.year is None else self.year
+            cmonth = default.month if self.month is None else self.month
+            cday = default.day if self.day is None else self.day
+
+            if cday > monthrange(cyear, cmonth)[1]:
+                repl['day'] = monthrange(cyear, cmonth)[1]
+
+        ret = default.replace(**repl)
+        return ret
+
+    def _build_tzaware(self, tzinfos, naive):
+        if callable(tzinfos) or (tzinfos and self.tzname in tzinfos):
             tzinfo = self._build_tzinfo(tzinfos,
-                                        result.tzname, result.tzoffset)
+                                        self.tzname, self.tzoffset)
             aware = naive.replace(tzinfo=tzinfo)
-        elif result.tzname and result.tzname in time.tzname:
+        elif self.tzname and self.tzname in time.tzname:
             aware = naive.replace(tzinfo=tz.tzlocal())
-        elif result.tzoffset == 0:
+        elif self.tzoffset == 0:
             aware = naive.replace(tzinfo=tz.tzutc())
-        elif result.tzoffset:
-            aware = naive.replace(tzinfo=tz.tzoffset(result.tzname,
-                                                     result.tzoffset))
+        elif self.tzoffset:
+            aware = naive.replace(tzinfo=tz.tzoffset(self.tzname,
+                                                     self.tzoffset))
         else:
             # TODO: Should we do something else in this case?
             aware = naive
@@ -666,30 +687,13 @@ class parser(object):
         if len(res) == 0:
             raise ValueError("String does not contain a date:", timestr)
 
-        repl = {}
-        for attr in ("year", "month", "day", "hour",
-                     "minute", "second", "microsecond"):
-            value = getattr(res, attr)
-            if value is not None:
-                repl[attr] = value
-
-        if 'day' not in repl:
-            # If the default day exceeds the last day of the month, fall back
-            # to the end of the month.
-            cyear = default.year if res.year is None else res.year
-            cmonth = default.month if res.month is None else res.month
-            cday = default.day if res.day is None else res.day
-
-            if cday > monthrange(cyear, cmonth)[1]:
-                repl['day'] = monthrange(cyear, cmonth)[1]
-
-        ret = default.replace(**repl)
+        ret = res._build_naive(default)
 
         if res.weekday is not None and not res.day:
             ret = ret + relativedelta.relativedelta(weekday=res.weekday)
 
         if not ignoretz:
-            ret = res._build_tzaware(tzinfos, res, ret)
+            ret = res._build_tzaware(tzinfos, ret)
 
         if kwargs.get('fuzzy_with_tokens', False):
             return ret, skipped_tokens


### PR DESCRIPTION
This is meant as a demonstration more than anything else.

There are some attributes/methods of the `parser` class that thematically don't really belong there.  In particular I'm thinking of `_result` and `_build_tzinfo`.  They are currently part of `parser` for subclassing reasons.

The demonstration here is to separate these out into a post-parsing class here called `ParseResult`.  The most important thing here is the `_res_class` property.  It provides a hook for subclassing.  So if downstream someone wants to post-process results differently, they implement a different _resultbase subclass and change the _res_class property.

The pattern could also be applied to allow hooks for `_ymd`, `_timelex`or `parserinfo` (though parserinfo already has a mechanism for passing a custom object).