### PR TITLE
Define __all__ in the top level package

### DIFF
--- a/dateutil/__init__.py
+++ b/dateutil/__init__.py
@@ -1,2 +1,5 @@
 # -*- coding: utf-8 -*-
 from ._version import VERSION as __version__
+
+__all__ = ['easter', 'parser', 'relativedelta', 'rrule', 'tz',
+           'utils', 'zoneinfo']

--- a/dateutil/test/test_import_star.py
+++ b/dateutil/test/test_import_star.py
@@ -1,0 +1,33 @@
+"""Test for the "import *" functionality.
+
+As imort * can be only done at module level, it has been added in a separate file
+"""
+import unittest
+
+prev_locals = list(locals())
+from dateutil import *
+new_locals = {name:value for name,value in locals().items()
+              if name not in prev_locals}
+new_locals.pop('prev_locals')
+
+class ImportStarTest(unittest.TestCase):
+    """ Test that `from dateutil import *` adds the modules in __all__ locally"""
+
+    def testImportedModules(self):
+        import dateutil.easter
+        import dateutil.parser
+        import dateutil.relativedelta
+        import dateutil.rrule
+        import dateutil.tz
+        import dateutil.utils
+        import dateutil.zoneinfo
+
+        self.assertEquals(dateutil.easter, new_locals.pop("easter"))
+        self.assertEquals(dateutil.parser, new_locals.pop("parser"))
+        self.assertEquals(dateutil.relativedelta, new_locals.pop("relativedelta"))
+        self.assertEquals(dateutil.rrule, new_locals.pop("rrule"))
+        self.assertEquals(dateutil.tz, new_locals.pop("tz"))
+        self.assertEquals(dateutil.utils, new_locals.pop("utils"))
+        self.assertEquals(dateutil.zoneinfo, new_locals.pop("zoneinfo"))
+
+        self.assertFalse(new_locals)


### PR DESCRIPTION
Even if using import * is discouraged in general and considered a bad practice, it is considered by convention to define the public API of a module. That combined with some users asking for it lead to this commit.

Closes #406