### PR TITLE
Return a singleton from tzutc()

### DIFF
--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -75,7 +75,7 @@ class PicklableMixin(object):
 
         return nobj
 
-    def assertPicklable(self, obj, asfile=False,
+    def assertPicklable(self, obj, singleton=False, asfile=False,
                         dump_kwargs=None, load_kwargs=None):
         """
         Assert that an object can be pickled and unpickled. This assertion
@@ -87,7 +87,8 @@ class PicklableMixin(object):
         load_kwargs = load_kwargs or {}
 
         nobj = get_nobj(obj, dump_kwargs, load_kwargs)
-        self.assertIsNot(obj, nobj)
+        if not singleton:
+            self.assertIsNot(obj, nobj)
         self.assertEqual(obj, nobj)
 
 

--- a/dateutil/test/test_imports.py
+++ b/dateutil/test/test_imports.py
@@ -122,16 +122,16 @@ class ImportTZTest(unittest.TestCase):
         from dateutil.tz import gettz
         from dateutil.tz import tzwin
         from dateutil.tz import tzwinlocal
+        from dateutil.tz import UTC
 
         tz_all = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
-                  "tzstr", "tzical", "gettz"]
+                  "tzstr", "tzical", "gettz", "UTC"]
 
         tz_all += ["tzwin", "tzwinlocal"] if sys.platform.startswith("win") else []
         lvars = locals()
 
         for var in tz_all:
             self.assertIsNot(lvars[var], None)
-
 
 @unittest.skipUnless(sys.platform.startswith('win'), "Requires Windows")
 class ImportTZWinTest(unittest.TestCase):

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -596,6 +596,12 @@ class TzWinFoldMixin(object):
 ###
 # Test Cases
 class TzUTCTest(unittest.TestCase):
+    def testSingleton(self):
+        UTC_0 = tz.tzutc()
+        UTC_1 = tz.tzutc()
+
+        self.assertIs(UTC_0, UTC_1)
+
     def testOffset(self):
         ct = datetime(2009, 4, 1, 12, 11, 13, tzinfo=tz.tzutc())
 
@@ -614,7 +620,6 @@ class TzUTCTest(unittest.TestCase):
         UTC0 = tz.tzutc()
         UTC1 = tz.tzutc()
 
-        self.assertIsNot(UTC0, UTC1)
         self.assertEqual(UTC0, UTC1)
 
     def testInequality(self):
@@ -1943,7 +1948,7 @@ class TzPickleTest(PicklableMixin, unittest.TestCase):
                                        asfile=self._asfile)
 
     def testPickleTzUTC(self):
-        self.assertPicklable(tz.tzutc())
+        self.assertPicklable(tz.tzutc(), singleton=True)
 
     def testPickleTzOffsetZero(self):
         self.assertPicklable(tz.tzoffset('UTC', 0))

--- a/dateutil/tz/__init__.py
+++ b/dateutil/tz/__init__.py
@@ -1,5 +1,8 @@
 from .tz import *
 
+#: Convenience constant providing a :class:`tzutc()` instance
+#:
+#: .. versionadded:: 2.7.0
 UTC = tzutc()
 
 __all__ = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",

--- a/dateutil/tz/__init__.py
+++ b/dateutil/tz/__init__.py
@@ -1,5 +1,8 @@
 from .tz import *
 
+UTC = tzutc()
+
 __all__ = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
            "tzstr", "tzical", "tzwin", "tzwinlocal", "gettz",
-           "enfold", "datetime_ambiguous", "datetime_exists"]
+           "enfold", "datetime_ambiguous", "datetime_exists",
+           "UTC"]

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -34,6 +34,13 @@ class tzutc(datetime.tzinfo):
     """
     This is a tzinfo object that represents the UTC time zone.
     """
+    __instance = None
+
+    def __new__(cls):
+        if tzutc.__instance is None:
+            tzutc.__instance = datetime.tzinfo.__new__(cls)
+        return tzutc.__instance
+
     def utcoffset(self, dt):
         return ZERO
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -33,6 +33,18 @@ EPOCHORDINAL = EPOCH.toordinal()
 class tzutc(datetime.tzinfo):
     """
     This is a tzinfo object that represents the UTC time zone.
+
+    .. versionchanged:: 2.7.0
+        ``tzutc()`` is now a singleton, so the result of ``tzutc()`` will
+        always return the same object.
+
+        .. doctest::
+
+            >>> from dateutil.tz import tzutc, UTC
+            >>> tzutc() is tzutc()
+            True
+            >>> tzutc() is UTC
+            True
     """
     __instance = None
 


### PR DESCRIPTION
Python assumes that `tzinfo` objects representing the same zone are effectively singletons, which is why intra- vs inter-zone semantics apply based on `dt1.tzinfo is dt2.tzinfo`, not `dt1.tzinfo == dt2.tzinfo`.

`tzutc()` is the simplest case, since it only ever represents one zone. I've also added a convenience constant to the top level `tz/__init__.py`, so people can just use it as a constant.

Eventually the other classes will store their representations in caches (though this is more complicated and has more implications for the API long term).