### PR TITLE
Move parser

### DIFF
--- a/dateutil/parser/__init__.py
+++ b/dateutil/parser/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+from ._parser import parse, parser, parserinfo
+from ._parser import DEFAULTPARSER, DEFAULTTZPARSER
+from ._parser import InvalidDateError, InvalidDatetimeError, InvalidTimeError
+
+__all__ = ['parse', 'parser', 'parserinfo',
+           'InvalidDatetimeError', 'InvalidDateError', 'InvalidTimeError']

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -40,8 +40,8 @@ from io import StringIO
 
 from six import binary_type, integer_types, text_type
 
-from . import relativedelta
-from . import tz
+from .. import relativedelta
+from .. import tz
 
 __all__ = ["parse", "parserinfo"]
 

--- a/dateutil/test/test_imports.py
+++ b/dateutil/test/test_imports.py
@@ -45,6 +45,14 @@ class ImportParserTest(unittest.TestCase):
         for var in (parse, parserinfo, parser):
             self.assertIsNot(var, None)
 
+    def testParserErrors(self):
+        from dateutil.parser import InvalidDateError
+        from dateutil.parser import InvalidTimeError
+        from dateutil.parser import InvalidDatetimeError
+
+        for var in (InvalidDateError, InvalidTimeError, InvalidDatetimeError):
+            assert issubclass(var, ValueError)
+
 
 class ImportRelativeDeltaTest(unittest.TestCase):
     """ Test that dateutil.relativedelta-related imports work properly """

--- a/dateutil/test/test_internals.py
+++ b/dateutil/test/test_internals.py
@@ -9,7 +9,7 @@ code that may be difficult to reach through the standard API calls.
 
 import unittest
 
-from dateutil.parser import _ymd
+from dateutil.parser._parser import _ymd
 
 
 class TestYMD(unittest.TestCase):

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -958,7 +958,7 @@ class tzstr(tzrange):
     """
     def __init__(self, s, posix_offset=False):
         global parser
-        from dateutil import parser
+        from dateutil.parser import _parser as parser
 
         self._s = s
 


### PR DESCRIPTION
Porting the change from the `isoparser` branch into its own branch. Since `isoparser` no longer wants to build the tests and I'm in for a big complicated rebase, I might as well backport this change so that new changes don't continue causing problems.

@jbrockmendel 