### PR TITLE
Add time zone factories (tzutc, tzoffset)

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -19,6 +19,8 @@ from functools import partial
 
 IS_WIN = sys.platform.startswith('win')
 
+import pytest
+
 # dateutil imports
 from dateutil.relativedelta import relativedelta, SU
 from dateutil.parser import parse
@@ -746,6 +748,22 @@ class TzLocalTest(unittest.TestCase):
         tzl = tz.tzlocal()
 
         self.assertEqual(repr(tzl), 'tzlocal()')
+
+
+@pytest.mark.parametrize('args,kwargs', [
+    (('EST', -18000), {}),
+    (('EST', timedelta(hours=-5)), {}),
+    (('EST',), {'offset': -18000}),
+    (('EST',), {'offset': timedelta(hours=-5)}),
+    (tuple(), {'name': 'EST', 'offset': -18000})
+])
+def test_tzoffset_is(args, kwargs):
+    tz_ref = tz.tzoffset('EST', -18000)
+    assert tz.tzoffset(*args, **kwargs) is tz_ref
+
+
+def test_tzoffset_is_not():
+    assert tz.tzoffset('EDT', -14400) is not tz.tzoffset('EST', -18000)
 
 
 @unittest.skipIf(IS_WIN, "requires Unix")
@@ -1951,13 +1969,13 @@ class TzPickleTest(PicklableMixin, unittest.TestCase):
         self.assertPicklable(tz.tzutc(), singleton=True)
 
     def testPickleTzOffsetZero(self):
-        self.assertPicklable(tz.tzoffset('UTC', 0))
+        self.assertPicklable(tz.tzoffset('UTC', 0), singleton=True)
 
     def testPickleTzOffsetPos(self):
-        self.assertPicklable(tz.tzoffset('UTC+1', 3600))
+        self.assertPicklable(tz.tzoffset('UTC+1', 3600), singleton=True)
 
     def testPickleTzOffsetNeg(self):
-        self.assertPicklable(tz.tzoffset('UTC-1', -3600))
+        self.assertPicklable(tz.tzoffset('UTC-1', -3600), singleton=True)
 
     def testPickleTzLocal(self):
         self.assertPicklable(tz.tzlocal())

--- a/dateutil/tz/_factories.py
+++ b/dateutil/tz/_factories.py
@@ -1,0 +1,9 @@
+class _TzSingleton(type):
+    def __init__(cls, *args, **kwargs):
+        cls.__instance = None
+        super(_TzSingleton, cls).__init__(*args, **kwargs)
+
+    def __call__(cls):
+        if cls.__instance is None:
+            cls.__instance = super(_TzSingleton, cls).__call__()
+        return cls.__instance

--- a/dateutil/tz/_factories.py
+++ b/dateutil/tz/_factories.py
@@ -1,3 +1,6 @@
+from datetime import timedelta 
+
+
 class _TzSingleton(type):
     def __init__(cls, *args, **kwargs):
         cls.__instance = None
@@ -7,3 +10,19 @@ class _TzSingleton(type):
         if cls.__instance is None:
             cls.__instance = super(_TzSingleton, cls).__call__()
         return cls.__instance
+
+
+class _TzOffsetFactory(type):
+    def __init__(cls, *args, **kwargs):
+        cls.__instances = {}
+
+    def __call__(cls, name, offset):
+        if isinstance(offset, timedelta):
+            key = (name, offset.total_seconds())
+        else:
+            key = (name, offset)
+
+        instance = cls.__instances.get(key, None)
+        if instance is None:
+            instance = cls.__instances.setdefault(key, type.__call__(cls, name, offset))
+        return instance

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -14,11 +14,14 @@ import sys
 import os
 import bisect
 
+import six
 from six import string_types
 from six.moves import _thread
 from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs
+
+from ._factories import _TzSingleton
 
 try:
     from .win import tzwin, tzwinlocal
@@ -30,6 +33,7 @@ EPOCH = datetime.datetime.utcfromtimestamp(0)
 EPOCHORDINAL = EPOCH.toordinal()
 
 
+@six.add_metaclass(_TzSingleton)
 class tzutc(datetime.tzinfo):
     """
     This is a tzinfo object that represents the UTC time zone.
@@ -46,13 +50,6 @@ class tzutc(datetime.tzinfo):
             >>> tzutc() is UTC
             True
     """
-    __instance = None
-
-    def __new__(cls):
-        if tzutc.__instance is None:
-            tzutc.__instance = datetime.tzinfo.__new__(cls)
-        return tzutc.__instance
-
     def utcoffset(self, dt):
         return ZERO
 
@@ -108,10 +105,8 @@ class tzutc(datetime.tzinfo):
 class tzoffset(datetime.tzinfo):
     """
     A simple class for representing a fixed offset from UTC.
-
     :param name:
         The timezone name, to be returned when ``tzname()`` is called.
-
     :param offset:
         The time zone offset in seconds, or (since version 2.6.0, represented
         as a :py:class:`datetime.timedelta` object).
@@ -144,14 +139,10 @@ class tzoffset(datetime.tzinfo):
         """
         Whether or not the "wall time" of a given datetime is ambiguous in this
         zone.
-
         :param dt:
             A :py:class:`datetime.datetime`, naive or time zone aware.
-
-
         :return:
             Returns ``True`` if ambiguous, ``False`` otherwise.
-
         .. versionadded:: 2.6.0
         """
         return False

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -21,7 +21,7 @@ from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs
 
-from ._factories import _TzSingleton
+from ._factories import _TzSingleton, _TzOffsetFactory
 
 try:
     from .win import tzwin, tzwinlocal
@@ -102,6 +102,7 @@ class tzutc(datetime.tzinfo):
     __reduce__ = object.__reduce__
 
 
+@six.add_metaclass(_TzOffsetFactory)
 class tzoffset(datetime.tzinfo):
     """
     A simple class for representing a fixed offset from UTC.


### PR DESCRIPTION
This is more or less the strategy I've come up with for handling singleton zones. It's fairly efficient from my profiling with `tzoffset`.

The next obvious candidate is `tzlocal()`, but I think that one is slightly trickier to handle, I'll make an issue for discussion.