### PR TITLE
Use the self.ystridx already found for unambiguous year < 99 dates

### DIFF
--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -897,6 +897,11 @@ class ParserTest(unittest.TestCase):
         res = parse(dstr)
         assert res.year == 2001, res
 
+    def test_pre_12_year_same_month(self):
+        # See GH PR #293
+        dtstr = '0003-03-04'
+        assert parse(dtstr) == datetime(3, 3, 4)
+
 
 class TestParseUnimplementedCases(object):
     @pytest.mark.xfail


### PR DESCRIPTION
Fixes #293.

@jbrockmendel Let me know if I missed something here, but it seems like all this checking for missed year tokens is unnecessary since `_ymd` is remembering which one is the year in the first place. This also allows us to drop the time string from `_ymd` (it didn't belong there anyway).