### PR TITLE
Add gitter badge, remove defunct pypi badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 dateutil - powerful extensions to datetime
 ==========================================
 
+.. image:: https://img.shields.io/pypi/v/python-dateutil.svg?style=flat-square
+    :target: https://pypi.python.org/pypi/python-dateutil/
+    :alt: pypi version
+
 .. image:: https://img.shields.io/travis/dateutil/dateutil/master.svg?style=flat-square
     :target: https://travis-ci.org/dateutil/dateutil
     :alt: travis build status
@@ -13,13 +17,9 @@ dateutil - powerful extensions to datetime
     :target: https://codecov.io/github/dateutil/dateutil?branch=master
     :alt: Code coverage
 
-.. image:: https://img.shields.io/pypi/dd/python-dateutil.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/python-dateutil/
-    :alt: pypi downloads per day
-
-.. image:: https://img.shields.io/pypi/v/python-dateutil.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/python-dateutil/
-    :alt: pypi version
+.. image:: https://badges.gitter.im/dateutil/dateutil.svg
+   :alt: Join the chat at https://gitter.im/dateutil/dateutil
+   :target: https://gitter.im/dateutil/dateutil
 
 
 The `dateutil` module provides powerful extensions to


### PR DESCRIPTION
Supplants #512.

This adds a gitter for the project, in case anyone wants that.

Also, the pypi downloads badge stopped working some time ago, so we can remove it until something better comes along.