### PR TITLE
Bytesarray parse

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -55,13 +55,18 @@ class _timelex(object):
     _split_decimal = re.compile("([.,])")
 
     def __init__(self, instream):
-        if isinstance(instream, binary_type):
-            instream = instream.decode()
+        if six.PY2:
+            # In Python 2, we can't duck type properly because unicode has
+            # a 'decode' function, and we'd be double-decoding
+            if isinstance(instream, (binary_type, bytearray)):
+                instream = instream.decode()
+        else:
+            if getattr(instream, 'decode', None) is not None:
+                instream = instream.decode()
 
         if isinstance(instream, text_type):
             instream = StringIO(instream)
-
-        if getattr(instream, 'read', None) is None:
+        elif getattr(instream, 'read', None) is None:
             raise TypeError('Parser must be a string or character stream, not '
                             '{itype}'.format(itype=instream.__class__.__name__))
 

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -95,6 +95,14 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse(self.str_str),
                          parse(self.uni_str))
 
+    def testParseBytes(self):
+        self.assertEqual(parse(b'2014 January 19'), datetime(2014, 1, 19))
+
+    def testParseBytearray(self):
+        # GH #417
+        self.assertEqual(parse(bytearray(b'2014 January 19')),
+                         datetime(2014, 1, 19))
+
     def testParserParseStr(self):
         from dateutil.parser import parser
 


### PR DESCRIPTION
Fixes #417 in favor of #418 (with rebase and adding limited support for Python 2).