### PR TITLE
Deprecate private interfaces

### DIFF
--- a/dateutil/parser/__init__.py
+++ b/dateutil/parser/__init__.py
@@ -5,3 +5,51 @@ from ._parser import InvalidDateError, InvalidDatetimeError, InvalidTimeError
 
 __all__ = ['parse', 'parser', 'parserinfo',
            'InvalidDatetimeError', 'InvalidDateError', 'InvalidTimeError']
+
+
+###
+# Deprecate portions of the private interface so that downstream code that
+# is improperly relying on it is given *some* notice.
+
+
+def __deprecated_private_func(f):
+    from functools import wraps
+    import warnings
+
+    msg = ('{name} is a private function and may break without warning, '
+           'it will be moved and or renamed in future versions.')
+    msg = msg.format(name=f.__name__)
+
+    @wraps(f)
+    def deprecated_func(*args, **kwargs):
+        warnings.warn(msg, DeprecationWarning)
+        return f(*args, **kwargs)
+
+    return deprecated_func
+
+def __deprecate_private_class(c):
+    import warnings
+
+    msg = ('{name} is a private class and may break without warning, '
+           'it will be moved and or renamed in future versions.')
+    msg = msg.format(name=c.__name__)
+
+    class private_class(c):
+        __doc__ = c.__doc__
+
+        def __init__(self, *args, **kwargs):
+            warnings.warn(msg, DeprecationWarning)
+            super(private_class, self).__init__(*args, **kwargs)
+
+    private_class.__name__ = c.__name__
+
+    return private_class
+
+
+from ._parser import _timelex, _resultbase
+from ._parser import _tzparser, _parsetz
+
+_timelex = __deprecate_private_class(_timelex)
+_tzparser = __deprecate_private_class(_tzparser)
+_resultbase = __deprecate_private_class(_resultbase)
+_parsetz = __deprecated_private_func(_parsetz)

--- a/dateutil/test/test_internals.py
+++ b/dateutil/test/test_internals.py
@@ -8,34 +8,75 @@ code that may be difficult to reach through the standard API calls.
 """
 
 import unittest
+import sys
+
+import pytest
 
 from dateutil.parser._parser import _ymd
+
+IS_PY32 = sys.version_info[0:2] == (3, 2)
 
 
 class TestYMD(unittest.TestCase):
 
-	# @pytest.mark.smoke
-	def test_could_be_day(self):
-		ymd = _ymd('foo bar 124 baz')
+    # @pytest.mark.smoke
+    def test_could_be_day(self):
+        ymd = _ymd('foo bar 124 baz')
 
-		ymd.append(2, 'M')
-		assert ymd.has_month
-		assert not ymd.has_year
-		assert ymd.could_be_day(4)
-		assert not ymd.could_be_day(-6)
-		assert not ymd.could_be_day(32)
+        ymd.append(2, 'M')
+        assert ymd.has_month
+        assert not ymd.has_year
+        assert ymd.could_be_day(4)
+        assert not ymd.could_be_day(-6)
+        assert not ymd.could_be_day(32)
 
-		# Assumes leapyear
-		assert ymd.could_be_day(29)
+        # Assumes leapyear
+        assert ymd.could_be_day(29)
 
-		ymd.append(1999)
-		assert ymd.has_year
-		assert not ymd.could_be_day(29)
+        ymd.append(1999)
+        assert ymd.has_year
+        assert not ymd.could_be_day(29)
 
-		ymd.append(16, 'D')
-		assert ymd.has_day
-		assert not ymd.could_be_day(1)
+        ymd.append(16, 'D')
+        assert ymd.has_day
+        assert not ymd.could_be_day(1)
 
-		ymd = _ymd('foo bar 124 baz')
-		ymd.append(1999)
-		assert ymd.could_be_day(31)
+        ymd = _ymd('foo bar 124 baz')
+        ymd.append(1999)
+        assert ymd.could_be_day(31)
+
+
+###
+# Test that private interfaces in _parser are deprecated properly
+@pytest.mark.skipif(IS_PY32, reason='pytest.warns not supported on Python 3.2')
+def test_parser_private_warns():
+    from dateutil.parser import _timelex, _tzparser
+    from dateutil.parser import _parsetz
+
+    with pytest.warns(DeprecationWarning):
+        _tzparser()
+
+    with pytest.warns(DeprecationWarning):
+        _timelex('2014-03-03')
+
+    with pytest.warns(DeprecationWarning):
+        _parsetz('+05:00')
+
+
+@pytest.mark.skipif(IS_PY32, reason='pytest.warns not supported on Python 3.2')
+def test_parser_parser_private_not_warns():
+    from dateutil.parser._parser import _timelex, _tzparser
+    from dateutil.parser._parser import _parsetz
+
+    with pytest.warns(None) as recorder:
+        _tzparser()
+        assert len(recorder) == 0
+
+    with pytest.warns(None) as recorder:
+        _timelex('2014-03-03')
+
+        assert len(recorder) == 0
+
+    with pytest.warns(None) as recorder:
+        _parsetz('+05:00')
+        assert len(recorder) == 0


### PR DESCRIPTION
Per my comments in pandas-dev/pandas#18141, I think that it is not particularly expensive to preserve some of the private interface, with an explicit deprecation warning.

The main question I have here is whether we should use `DeprecationWarning`, which is not visible by default in Python 2.7+, or if we should use something more visible, like our own custom warning class that *is* visible, or possibly make some sort of context manager that temporarily enables `DeprecationWarning`.

Kinda unfortunate that `DeprecationWarning` was disabled by default, since that encourages libraries to do shit like what I just described, but it is what it is.