### PR TITLE
Implement intermediate representation ParseState

### DIFF
--- a/dateutil/parser/_construction.py
+++ b/dateutil/parser/_construction.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+"""
+
+Constructing datetime or other Parse results from an intermediate
+representation.
+
+"""
+from calendar import monthrange
+import collections  # py3.3 compat
+import datetime
+import time
+
+from six import text_type, integer_types
+
+from .. import tz
+from .. import relativedelta
+
+
+class _resultbase(object):
+
+    def __init__(self):
+        for attr in self.__slots__:
+            setattr(self, attr, None)
+
+    def _repr(self, classname):
+        l = []
+        for attr in self.__slots__:
+            value = getattr(self, attr)
+            if value is not None:
+                l.append("%s=%s" % (attr, repr(value)))
+        return "%s(%s)" % (classname, ", ".join(l))
+
+    def __len__(self):
+        return (sum(getattr(self, attr) is not None
+                    for attr in self.__slots__))
+
+    def __repr__(self):
+        return self._repr(self.__class__.__name__)
+
+
+class ParseState(_resultbase):
+    """
+    ParseState contains an unfinished parsing
+
+    Note: This is an internal class, is not considered part of the dateutil
+    public API.
+    """
+    __slots__ = ["year", "month", "day", "weekday",
+                 "hour", "minute", "second", "microsecond",
+                 "tzname", "tzoffset", "ampm"]
+
+    def _build_result(self, default, tzinfos, ignoretz):
+        ret = self._build_naive(default)
+        if not ignoretz:
+            ret = self._build_tzaware(tzinfos, ret)
+
+        return ret
+
+    def _build_naive(self, default):
+        replacement = {}
+        for attr in ("year", "month", "day", "hour",
+                     "minute", "second", "microsecond"):
+            value = getattr(self, attr)
+            if value is not None:
+                replacement[attr] = value
+
+        if 'day' not in replacement:
+            # If the default day exceeds the last day of the month, fall back
+            # to the end of the month.
+            cyear = default.year if self.year is None else self.year
+            cmonth = default.month if self.month is None else self.month
+            cday = default.day if self.day is None else self.day
+
+            if cday > monthrange(cyear, cmonth)[1]:
+                replacement['day'] = monthrange(cyear, cmonth)[1]
+
+        ret = default.replace(**replacement)
+
+        if self.weekday is not None and not self.day:
+            ret = ret + relativedelta.relativedelta(weekday=self.weekday)
+        return ret
+
+    def _build_tzaware(self, tzinfos, naive):
+        if callable(tzinfos) or (tzinfos and self.tzname in tzinfos):
+            tzinfo = self._build_tzinfo(tzinfos,
+                                        self.tzname, self.tzoffset)
+            aware = naive.replace(tzinfo=tzinfo)
+        elif self.tzname and self.tzname in time.tzname:
+            aware = naive.replace(tzinfo=tz.tzlocal())
+        elif self.tzoffset == 0:
+            aware = naive.replace(tzinfo=tz.tzutc())
+        elif self.tzoffset:
+            aware = naive.replace(tzinfo=tz.tzoffset(self.tzname,
+                                                     self.tzoffset))
+        else:
+            # TODO: Should we do something else in this case?
+            aware = naive
+        return aware
+
+    def _build_tzinfo(self, tzinfos, tzname, tzoffset):
+        if isinstance(tzinfos, collections.Callable):
+            tzdata = tzinfos(tzname, tzoffset)
+        else:
+            tzdata = tzinfos.get(tzname)
+
+        if isinstance(tzdata, datetime.tzinfo):
+            tzinfo = tzdata
+        elif isinstance(tzdata, text_type):
+            tzinfo = tz.tzstr(tzdata)
+        elif isinstance(tzdata, integer_types):
+            tzinfo = tz.tzoffset(tzname, tzdata)
+        else:
+            raise ValueError("Offset must be tzinfo subclass, "
+                             "tz string, or int offset.")
+        return tzinfo
+
+    def _recombine_skipped(self, tokens, skipped_idxs):
+        """
+        >>> tokens = ["foo", " ", "bar", " ", "19June2000", "baz"]
+        >>> skipped_idxs = [0, 1, 2, 5]
+        >>> _recombine_skipped(tokens, skipped_idxs)
+        ["foo bar", "baz"]
+        """
+        skipped_tokens = []
+        for i, idx in enumerate(sorted(skipped_idxs)):
+            if i > 0 and idx - 1 == skipped_idxs[i - 1]:
+                skipped_tokens[-1] = skipped_tokens[-1] + tokens[idx]
+            else:
+                skipped_tokens.append(tokens[idx])
+
+        return skipped_tokens

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -29,7 +29,6 @@ Additional resources about date/time string formats can be found below:
 """
 from __future__ import unicode_literals
 
-import collections
 import datetime
 import re
 import string
@@ -38,11 +37,9 @@ import time
 from calendar import monthrange
 from io import StringIO
 
-import six
-from six import binary_type, integer_types, text_type
+from six import binary_type, text_type
 
-from .. import relativedelta
-from .. import tz
+from ._construction import _resultbase, ParseState
 
 __all__ = ["parse", "parserinfo"]
 
@@ -210,28 +207,6 @@ class _timelex(object):
     def isspace(cls, nextchar):
         """ Whether the next character is whitespace """
         return nextchar.isspace()
-
-
-class _resultbase(object):
-
-    def __init__(self):
-        for attr in self.__slots__:
-            setattr(self, attr, None)
-
-    def _repr(self, classname):
-        l = []
-        for attr in self.__slots__:
-            value = getattr(self, attr)
-            if value is not None:
-                l.append("%s=%s" % (attr, repr(value)))
-        return "%s(%s)" % (classname, ", ".join(l))
-
-    def __len__(self):
-        return (sum(getattr(self, attr) is not None
-                    for attr in self.__slots__))
-
-    def __repr__(self):
-        return self._repr(self.__class__.__name__)
 
 
 class parserinfo(object):
@@ -520,6 +495,8 @@ class _ymd(list):
 
 
 class parser(object):
+    _result = ParseState  # this can be overridden by subclasses
+
     def __init__(self, info=None):
         self.info = info or parserinfo()
 
@@ -599,49 +576,12 @@ class parser(object):
         if len(res) == 0:
             raise ValueError("String does not contain a date:", timestr)
 
-        repl = {}
-        for attr in ("year", "month", "day", "hour",
-                     "minute", "second", "microsecond"):
-            value = getattr(res, attr)
-            if value is not None:
-                repl[attr] = value
-
-        if 'day' not in repl:
-            # If the default day exceeds the last day of the month, fall back
-            # to the end of the month.
-            cyear = default.year if res.year is None else res.year
-            cmonth = default.month if res.month is None else res.month
-            cday = default.day if res.day is None else res.day
-
-            if cday > monthrange(cyear, cmonth)[1]:
-                repl['day'] = monthrange(cyear, cmonth)[1]
-
-        ret = default.replace(**repl)
-
-        if res.weekday is not None and not res.day:
-            ret = ret + relativedelta.relativedelta(weekday=res.weekday)
-
-        if not ignoretz:
-            if (isinstance(tzinfos, collections.Callable) or
-                    tzinfos and res.tzname in tzinfos):
-                tzinfo = self._build_tzinfo(tzinfos, res.tzname, res.tzoffset)
-                ret = ret.replace(tzinfo=tzinfo)
-            elif res.tzname and res.tzname in time.tzname:
-                ret = ret.replace(tzinfo=tz.tzlocal())
-            elif res.tzoffset == 0:
-                ret = ret.replace(tzinfo=tz.tzutc())
-            elif res.tzoffset:
-                ret = ret.replace(tzinfo=tz.tzoffset(res.tzname, res.tzoffset))
+        ret = res._build_result(default, tzinfos, ignoretz)
 
         if kwargs.get('fuzzy_with_tokens', False):
             return ret, skipped_tokens
         else:
             return ret
-
-    class _result(_resultbase):
-        __slots__ = ["year", "month", "day", "weekday",
-                     "hour", "minute", "second", "microsecond",
-                     "tzname", "tzoffset", "ampm"]
 
     def _parse(self, timestr, dayfirst=None, yearfirst=None, fuzzy=False,
                fuzzy_with_tokens=False):
@@ -847,7 +787,7 @@ class parser(object):
             return None, None
 
         if fuzzy_with_tokens:
-            skipped_tokens = self._recombine_skipped(l, skipped_idxs)
+            skipped_tokens = res._recombine_skipped(l, skipped_idxs)
             return res, tuple(skipped_tokens)
         else:
             return res, None
@@ -1106,39 +1046,6 @@ class parser(object):
             new_idx = idx
 
         return (new_idx, hms)
-
-    def _recombine_skipped(self, tokens, skipped_idxs):
-        """
-        >>> tokens = ["foo", " ", "bar", " ", "19June2000", "baz"]
-        >>> skipped_idxs = [0, 1, 2, 5]
-        >>> _recombine_skipped(tokens, skipped_idxs)
-        ["foo bar", "baz"]
-        """
-        skipped_tokens = []
-        for i, idx in enumerate(sorted(skipped_idxs)):
-            if i > 0 and idx - 1 == skipped_idxs[i - 1]:
-                skipped_tokens[-1] = skipped_tokens[-1] + tokens[idx]
-            else:
-                skipped_tokens.append(tokens[idx])
-
-        return skipped_tokens
-
-    def _build_tzinfo(self, tzinfos, tzname, tzoffset):
-        if isinstance(tzinfos, collections.Callable):
-            tzdata = tzinfos(tzname, tzoffset)
-        else:
-            tzdata = tzinfos.get(tzname)
-
-        if isinstance(tzdata, datetime.tzinfo):
-            tzinfo = tzdata
-        elif isinstance(tzdata, text_type):
-            tzinfo = tz.tzstr(tzdata)
-        elif isinstance(tzdata, integer_types):
-            tzinfo = tz.tzoffset(tzname, tzdata)
-        else:
-            raise ValueError("Offset must be tzinfo subclass, "
-                             "tz string, or int offset.")
-        return tzinfo
 
 
 DEFAULTPARSER = parser()


### PR DESCRIPTION
Implement the intermediate representation as a full-fledged (easily-subclassable) class.

A subset of `parser` methods are focused on taking this intermediate representation and building the final representation.  These methods are moved into the new class.  As a result, they actually use `self`!  (Well a couple don't, but I kept them as-is as a token of goodwill).

Note: `tokens` could pretty reasonably be an attribute of the intermediate representation.
