### PR TITLE
pin py to <1.5 on py33 (1.5 onward dropped support for py26 and py33)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 six
+py < 1.5 ; python_version == '3.3'
 pytest >= 3.0 ; python_version != '3.2'
 pytest >= 2.0 ; python_version == '3.2'
 freezegun


### PR DESCRIPTION
Ref: pytest-dev/py#169