### PR TITLE
Pin pytest dependency on 3.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 six
-pytest >= 3.0 ; python_version != '3.2'
+pytest >= 3.0 ; python_version != '3.2' and python_version != '3.3'
+pytest < 3.3; python_version == '3.3'
 pytest >= 2.0 ; python_version == '3.2'
 freezegun
 coverage==3.7.1 ; python_version == '3.2'


### PR DESCRIPTION
Trying to fix whatever new issues have been created by whatever's happening with py's support for Python 3.3 (see #526).