### PR TITLE
Warn on unidentified tz

### DIFF
--- a/dateutil/parser/__init__.py
+++ b/dateutil/parser/__init__.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 from ._parser import parse, parser, parserinfo
 from ._parser import DEFAULTPARSER, DEFAULTTZPARSER
+from ._parser import UnknownTimezoneWarning
 
 from ._parser import __doc__
 
 from .isoparser import isoparser, isoparse
 
 __all__ = ['parse', 'parser', 'parserinfo',
-           'isoparse', 'isoparser']
+           'isoparse', 'isoparser',
+           'UnknownTimezoneWarning']
 
 
 ###

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1157,7 +1157,8 @@ class parser(object):
                           "Pass `tzinfos` argument in order to correctly "
                           "return a timezone-aware datetime.  In a future "
                           "version, this raise an "
-                          "exception.".format(tzname=res.tzname))
+                          "exception.".format(tzname=res.tzname),
+                          category=UnknownTimezoneWarning)
             aware = naive
 
         return aware
@@ -1517,4 +1518,6 @@ DEFAULTTZPARSER = _tzparser()
 def _parsetz(tzstr):
     return DEFAULTTZPARSER.parse(tzstr)
 
+class UnknownTimezoneWarning(RuntimeWarning):
+    """Raised when the parser finds a timezone it cannot parse into a tzinfo"""
 # vim:ts=4:sw=4:et

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -613,6 +613,14 @@ class parser(object):
         if not ignoretz:
             ret = self._build_tzaware(ret, res, tzinfos)
 
+            elif not res.tzname and not res.tzoffset:
+                # i.e. no timezone information was found.
+                pass
+            else:
+                # tz-like string was parsed but we don't know what to do
+                # with it
+                raise ValueError(res.tzname)
+
         if kwargs.get('fuzzy_with_tokens', False):
             return ret, skipped_tokens
         else:

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -574,8 +574,9 @@ class ParserTest(unittest.TestCase):
 
     def testFuzzyIgnoreAMPM(self):
         s1 = "Jan 29, 1945 14:45 AM I going to see you there?"
-
-        self.assertEqual(parse(s1, fuzzy=True), datetime(1945, 1, 29, 14, 45))
+        with pytest.warns(UserWarning, match="identified but not understood"):
+            res = parse(s1, fuzzy=True)
+        self.assertEqual(res, datetime(1945, 1, 29, 14, 45))
 
     def testExtraSpace(self):
         self.assertEqual(parse("  July   4 ,  1976   12:01:02   am  "),
@@ -683,8 +684,10 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 12, 8))
 
     def testRandomFormat26(self):
-        self.assertEqual(parse("5:50 A.M. on June 13, 1990"),
-                         datetime(1990, 6, 13, 5, 50))
+        with pytest.warns(UserWarning, match="identified but not understood"):
+            res = parse("5:50 A.M. on June 13, 1990")
+
+        self.assertEqual(res, datetime(1990, 6, 13, 5, 50))
 
     def testRandomFormat27(self):
         self.assertEqual(parse("3rd of May 2001"), datetime(2001, 5, 3))

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -9,6 +9,7 @@ import sys
 from dateutil import tz
 from dateutil.tz import tzoffset
 from dateutil.parser import parse, parserinfo
+from dateutil.parser import UnknownTimezoneWarning
 
 from ._common import TZEnvContext
 
@@ -574,7 +575,7 @@ class ParserTest(unittest.TestCase):
 
     def testFuzzyIgnoreAMPM(self):
         s1 = "Jan 29, 1945 14:45 AM I going to see you there?"
-        with pytest.warns(UserWarning, match="identified but not understood"):
+        with pytest.warns(UnknownTimezoneWarning):
             res = parse(s1, fuzzy=True)
         self.assertEqual(res, datetime(1945, 1, 29, 14, 45))
 
@@ -684,7 +685,7 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 12, 8))
 
     def testRandomFormat26(self):
-        with pytest.warns(UserWarning, match="identified but not understood"):
+        with pytest.warns(UnknownTimezoneWarning):
             res = parse("5:50 A.M. on June 13, 1990")
 
         self.assertEqual(res, datetime(1990, 6, 13, 5, 50))


### PR DESCRIPTION
Current incorrect behavior:

```
>>> parser.parse('2017-12-05 08:38 EST')
datetime.datetime(2017, 12, 5, 8, 38)
```

This PR raises instead of silently dropping this timezone information.

This surfaces two test failures that look like false-positives slipped through and got assigned to res.tzname.  Thats the "WIP" part of the PR.

```
___________________________________________ ParserTest.testFuzzyIgnoreAMPM ___________________________________________
[...]
timestr = 'Jan 29, 1945 14:45 AM I going to see you there?'
res = _result(year=1945, month=1, day=29, hour=14, minute=45, tzname=u'I')

___________________________________________ ParserTest.testRandomFormat26 ____________________________________________
[...]
timestr = '5:50 A.M. on June 13, 1990'
_result(year=1990, month=6, day=13, hour=5, minute=50, tzname=u'M', ampm=0)
```
