### PR TITLE
Add test to parse 201712 (YYYYMM)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -61,6 +61,7 @@ Apache 2.0 and BSD 3-clause. In the list below, anyone whose name is marked with
 - Unrud <Unrud@MASKED> (gh: @unrud)
 - X O <xo@MASKED>
 - Yaron de Leeuw <me@jarondl.net> (gh: @jarondl)
+- Yoney <alper_yoney@hotmail.com>
 - Zbigniew Jędrzejewski-Szmek <zbyszek@MASKED>
 - bachmann <bachmann.matt@MASKED>
 - bjv <brandon.vanvaerenbergh@MASKED> (@bjamesvERT)

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -1016,6 +1016,14 @@ class TestParseUnimplementedCases(object):
         expected = datetime(1994, 12, 1)
         assert res == expected
 
+    @pytest.mark.xfail
+    def test_unambiguous_YYYYMM(self):
+        # 171206 can be parsed as YYMMDD. However, 201712 cannot be parsed
+        # as instance of YYMMDD and parser could fallback to YYYYMM format.
+        dstr = "201712"
+        res = parse(dstr)
+        expected = datetime(2017, 12, 1)
+        assert res == expected
 
 @pytest.mark.skipif(IS_WIN, reason='Windows does not use TZ var')
 def test_parse_unambiguous_nonexistent_local():


### PR DESCRIPTION
Test is marked as xfail becasue parser currently fails to parse
201712 since it considers it as YYMMDD. However 201712 can be
parsed as YYYYMM.