### PR TITLE
Adds python_require

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,6 +31,7 @@ Apache 2.0 and BSD 3-clause. In the list below, anyone whose name is marked with
 - Holger Joukl <holger.joukl@MASKED> (gh: @hjoukl)
 - Igor <mrigor83@MASKED>
 - Ionuț Ciocîrlan <jdxlark@MASKED>
+- Jake Chorley (gh: @jakec-github)
 - Jan Studený <jendas1@MASKED>
 - Jitesh <jitesh@MASKED>
 - Jon Dufresne <jon.dufresne@MASKED> (gh: @jdufresne) **R**
@@ -53,6 +54,7 @@ Apache 2.0 and BSD 3-clause. In the list below, anyone whose name is marked with
 - Roy Williams <rwilliams@MASKED>
 - Savraj <savraj@MASKED>
 - Sergey Vishnikin <armicron@MASKED>
+- Stefan Bonchev
 - Thierry Bastian <thierryb@MASKED>
 - Thomas A Caswell <tcaswell@MASKED> (gh: @tacaswell)
 - Thomas Achtemichuk <tom@MASKED>

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,23 @@
 from os.path import isfile
 import os
 
+import setuptools
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
 from dateutil._version import VERSION
 
+from distutils.version import LooseVersion
+import warnings
+
 if isfile("MANIFEST"):
     os.unlink("MANIFEST")
 
 PACKAGES = find_packages(where='.', exclude=['dateutil.test'])
+
+if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
+    warnings.warn("python_requires requires setuptools version > 24.3",
+                  UserWarning)
 
 
 class Unsupported(TestCommand):
@@ -33,6 +41,7 @@ The dateutil module provides powerful extensions to the
 datetime module available in the Python standard library.
 """,
       packages=PACKAGES,
+      python_requires=">=2.7, !=3.0.*, !=3.1.*",
       package_data={"dateutil.zoneinfo": ["dateutil-zoneinfo.tar.gz"]},
       zip_safe=True,
       requires=["six"],


### PR DESCRIPTION
This closes #537 

Adds python_require to setup() in setup.py. Only works for users installing with pip 9 or above. Will warn if setuptools version is <=24.3.

Also help from Stefan Bonchev