### PR TITLE
fix bug with incorrectly picking out 1-character tznames

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1045,6 +1045,9 @@ class parser(object):
             (res.second, res.microsecond) = self._parsems(value_repr)
 
     def _could_be_tzname(self, hour, tzname, tzoffset, token):
+        if len(token) <= 1 and token != 'Z':
+            # see GH#540
+            return False
         return (hour is not None and
                 tzname is None and
                 tzoffset is None and

--- a/dateutil/test/test_internals.py
+++ b/dateutil/test/test_internals.py
@@ -12,9 +12,21 @@ import sys
 
 import pytest
 
-from dateutil.parser._parser import _ymd
+from dateutil.parser._parser import _ymd, parser
 
 IS_PY32 = sys.version_info[0:2] == (3, 2)
+
+
+class TestParserPrivate(object):
+    def test_single_character_tzname(self):
+        # See GH#540
+        dstr = '5:50 A.M. on June 13, 1990'
+        res = parser()._parse(dstr)[0]
+        assert res.tzname is None
+
+        dstr = 'Jan 29, 1945 14:45 AM I going to see you there?'
+        res = parser()._parse(dstr, fuzzy=True)[0]
+        assert res.tzname is None
 
 
 class TestYMD(unittest.TestCase):


### PR DESCRIPTION
I think with this fix, the errors exposed by #540 should be fixed.