### PR TITLE
[WiP] parse('19-9-42-14QBCD') should raise

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@ Apache 2.0 and BSD 3-clause. In the list below, anyone whose name is marked with
 - Adrien Cossa <cossa@MASKED>
 - Alec Nikolas Reiter <alecreiter@MASKED>
 - Alec Reiter <areiter@MASKED>
+- Alex Chamberlain (gh: @alexchamberlain)
 - Alex Verdyan <verdyan@MASKED>
 - Alex Willmer <alex@MASKED> (gh: @moreati)
 - Alexander Brugh <alexander.brugh@MASKED> (gh: @abrugh)
@@ -20,6 +21,7 @@ Apache 2.0 and BSD 3-clause. In the list below, anyone whose name is marked with
 - Brandon W Maister <quodlibetor@MASKED>
 - Brock Mendel <jbrockmendel@MASKED> (gh: @jbrockmendel) **R**
 - Carlos <carlosxl@MASKED>
+- Chanun Chirattikanon gh:chanunc
 - Christopher Corley <cscorley@MASKED>
 - Claudio Canepa <ccanepacc@MASKED>
 - Daniel Lepage <dplepage@MASKED>

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -531,7 +531,8 @@ class parser(object):
         self.info = info or parserinfo()
 
     def parse(self, timestr, default=None,
-              ignoretz=False, tzinfos=None, **kwargs):
+              ignoretz=False, tzinfos=None, 
+              ignore_bad_tzname=True, **kwargs):
         """
         Parse the date/time string into a :class:`datetime.datetime` object.
 
@@ -644,7 +645,8 @@ class parser(object):
                 if (ret.tzname() != res.tzname and
                         res.tzname in self.info.UTCZONE):
                     ret = ret.replace(tzinfo=tz.tzutc())
-
+            elif res.tzname and not ignore_bad_tzname:
+                raise ValueError('Unknown tzname: {}'.format(res.tzname))
             elif res.tzoffset == 0:
                 ret = ret.replace(tzinfo=tz.tzutc())
             elif res.tzoffset:

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -921,6 +921,10 @@ class ParserTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse('19-9-42-14QBCD', fuzzy=False, ignore_bad_tzname=False)
 
+    def test_QBCD_legacy(self):
+        dt = parse('19-9-42-14QBCD', fuzzy=False)
+        assert dt == datetime(2042, 9, 19, 14)
+
 
 class TestParseUnimplementedCases(object):
     @pytest.mark.xfail

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -8,7 +8,7 @@ import sys
 
 from dateutil import tz
 from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
+from dateutil.parser import parse, parserinfo, parser
 
 from ._common import TZEnvContext
 
@@ -916,6 +916,10 @@ class ParserTest(unittest.TestCase):
         # See GH PR #293
         dtstr = '0003-03-04'
         assert parse(dtstr) == datetime(3, 3, 4)
+
+    def test_QBCD(self):
+        with self.assertRaises(ValueError):
+            parse('19-9-42-14QBCD', fuzzy=False, ignore_bad_tzname=False)
 
 
 class TestParseUnimplementedCases(object):


### PR DESCRIPTION
Fixes #478 

- Add `ignore_bad_tzname=True` argument and validate if applicable

### TODO
- Update docs
- ~~Add a test when `ignore_bad_tzname=False`.~~

CC: @chanunc