### PR TITLE
Fix up isoparse documentation.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,6 +13,7 @@ Apache 2.0 and BSD 3-clause. In the list below, anyone whose name is marked with
 - Adrien Cossa <cossa@MASKED>
 - Alec Nikolas Reiter <alecreiter@MASKED>
 - Alec Reiter <areiter@MASKED>
+- Alex Chamberlain (gh: @alexchamberlain)
 - Alex Verdyan <verdyan@MASKED>
 - Alex Willmer <alex@MASKED> (gh: @moreati)
 - Alexander Brugh <alexander.brugh@MASKED> (gh: @abrugh)

--- a/dateutil/parser/__init__.py
+++ b/dateutil/parser/__init__.py
@@ -3,6 +3,8 @@ from ._parser import parse, parser, parserinfo
 from ._parser import DEFAULTPARSER, DEFAULTTZPARSER
 from ._parser import InvalidDateError, InvalidDatetimeError, InvalidTimeError
 
+from ._parser import __doc__
+
 from .isoparser import isoparser, isoparse
 
 __all__ = ['parse', 'parser', 'parserinfo',

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -572,7 +572,7 @@ class parser(object):
 
             This parameter is ignored if ``ignoretz`` is set.
 
-        :param **kwargs:
+        :param \\*\\*kwargs:
             Keyword arguments as passed to ``_parse()``.
 
         :return:

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -6,6 +6,7 @@ most known formats to represent a date and/or time.
 This module attempts to be forgiving with regards to unlikely input formats,
 returning a datetime object even for dates which are ambiguous. If an element
 of a date/time stamp is omitted, the following rules are applied:
+
 - If AM or PM is left unspecified, a 24-hour clock is assumed, however, an hour
   on a 12-hour clock (``0 <= hour <= 12``) *must* be specified if AM or PM is
   specified.

--- a/docs/parser.rst
+++ b/docs/parser.rst
@@ -2,5 +2,11 @@
 parser
 ======
 .. automodule:: dateutil.parser
-   :members:
-   :undoc-members:
+
+   .. automethod:: dateutil.parser.parse
+
+   .. autoclass:: dateutil.parser.parserinfo
+      :members:
+      :undoc-members:
+
+   .. automethod:: dateutil.parser.isoparse


### PR DESCRIPTION
Note as implemented, this puts the docs for `isoparse` at the top, which feels a bit odd. Let me know what you think.