### PR TITLE
London Sprint - imaginaryDateTest

### DIFF
--- a/.cache/v/cache/lastfailed
+++ b/.cache/v/cache/lastfailed
@@ -1,0 +1,6 @@
+{
+  "dateutil/test/test_tz.py::TzWinTest::testTzResNameFromString": true,
+  "dateutil/test/test_tz.py::TzWinTest::testTzwinName": true,
+  "dateutil/test/test_tz.py::imaginaryDateTest::testMonroviaForward": true,
+  "dateutil/test/test_utils.py": true
+}

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -2283,8 +2283,7 @@ class imaginaryDateTest(unittest.TestCase):
         self.assertEqual(dt,datetime(1995, 1, 2, 2, 30, tzinfo=timezone))
         
     def testMonroviaForward(self):
-        #import pdb; pdb.set_trace()
         timezone = tz.gettz('Africa/Monrovia')
-        dt = datetime(1972, 1, 7, 0, 30, 0, tzinfo=timezone)
+        dt = datetime(1972, 1, 7, hour = 0, minute = 30, second = 0, tzinfo=timezone)
         dt = tz.resolve_imaginary(dt)
-        self.assertEqual(dt,datetime(1972, 1, 7, 1, 14, 30, tzinfo=timezone))
+        self.assertEqual(dt,datetime(1972, 1, 7, hour = 1, minute =  14,  second = 30, tzinfo=timezone))

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -2262,3 +2262,29 @@ class EnfoldTest(unittest.TestCase):
 
         # Before Python 3.6, dt.fold won't exist if fold is 0.
         self.assertEqual(getattr(dt, 'fold', 0), 0)
+
+class imaginaryDateTest(unittest.TestCase):
+    def testCanberraForward(self):
+        timezone = tz.gettz('Australia/Canberra')
+        dt = datetime(2018, 10, 7, 2, 30, tzinfo=timezone)
+        dt = tz.resolve_imaginary(dt)
+        self.assertEqual(dt,datetime(2018, 10, 7, 3, 30, tzinfo=timezone))
+        
+    def testSydneyBack(self):
+        timezone = tz.gettz('Australia/Sydney')
+        dt = datetime(2018, 4, 1, 3, 30, tzinfo=timezone)
+        dtnew = tz.resolve_imaginary(dt)
+        self.assertEqual(dt,dtnew)
+        
+    def testKiritimatiForward(self):
+        timezone = tz.gettz('Pacific/Kiritimati')
+        dt = datetime(1995, 1, 1, 2, 30, tzinfo=timezone)
+        dt = tz.resolve_imaginary(dt)
+        self.assertEqual(dt,datetime(1995, 1, 2, 2, 30, tzinfo=timezone))
+        
+    def testMonroviaForward(self):
+        #import pdb; pdb.set_trace()
+        timezone = tz.gettz('Africa/Monrovia')
+        dt = datetime(1972, 1, 7, 0, 30, 0, tzinfo=timezone)
+        dt = tz.resolve_imaginary(dt)
+        self.assertEqual(dt,datetime(1972, 1, 7, 1, 14, 30, tzinfo=timezone))

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1531,4 +1531,21 @@ class _ContextWrapper(object):
     def __exit__(*args, **kwargs):
         pass
 
+def resolve_imaginary(dt):
+    import pdb;pdb.set_trace()
+    if dt.tzinfo is not None and not datetime_exists(dt):
+        # You need to shift this by the difference between the current offset
+        # and the previous one. Historically, there has never been a time zone
+        # shift of more than 24 hours, nor has there been two changes to a time
+        # zone within 24 hours, so if we take the "wall time" - 24 hours, we
+        # should be OK, barring any insane time zone behavior in the future.
+        curr_offset = (dt + datetime.timedelta(hours=24)).utcoffset()
+        old_offset = (dt - datetime.timedelta(hours=24)).utcoffset()
+
+        dt += curr_offset - old_offset
+        
+
+    return dt
+
 # vim:ts=4:sw=4:et
+

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1532,19 +1532,13 @@ class _ContextWrapper(object):
         pass
 
 def resolve_imaginary(dt):
-    import pdb;pdb.set_trace()
     if dt.tzinfo is not None and not datetime_exists(dt):
-        # You need to shift this by the difference between the current offset
-        # and the previous one. Historically, there has never been a time zone
-        # shift of more than 24 hours, nor has there been two changes to a time
-        # zone within 24 hours, so if we take the "wall time" - 24 hours, we
-        # should be OK, barring any insane time zone behavior in the future.
+
         curr_offset = (dt + datetime.timedelta(hours=24)).utcoffset()
         old_offset = (dt - datetime.timedelta(hours=24)).utcoffset()
 
         dt += curr_offset - old_offset
         
-
     return dt
 
 # vim:ts=4:sw=4:et


### PR DESCRIPTION
London Sprint #339 

Pushing function resolve_imaginary in tz, created 4 test cases which 3 of them pass. the only one that fail is testMonroviaForward which is dealing with + 44mins 30seconds time zone changes. Further testing suggest that utcoffset ignore the 30seconds so it 0:30 on 7 Jan 1972 will become 1:14, not 1:14:30 on the same day.