### PR TITLE
Make xfails strict

### DIFF
--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -274,10 +274,11 @@ def test_isoparser_invalid_sep(sep):
         isoparser(sep=sep)
 
 
-@pytest.mark.xfail
+# This only fails on Python 3
+@pytest.mark.xfail(six.PY3, reason="Fails on Python 3 only")
 def test_isoparser_byte_sep():
     dt = datetime(2017, 12, 6, 12, 30, 45)
-    dt_str = dt.isoformat(sep='T')
+    dt_str = dt.isoformat(sep=str('T'))
 
     dt_rt = isoparser(sep=b'T').isoparse(dt_str)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
+
+[tool:pytest]
+xfail_strict = true


### PR DESCRIPTION
This makes an `xpass` a failure unless otherwise specified.

Also we had one xpass on `pypy` that *should have* been an `xpass` on Python 2.7, so I fixed that and made it conditional.