### PR TITLE
Make tz.tzstr fail if an invalid GNU tz string is provided

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1315,7 +1315,7 @@ class _tzparser(object):
 
     def parse(self, tzstr):
         res = self._result()
-        l = [x for x in re.split(r'([,:.]|[a-zA-Z]+|[0-9]+)',tzstr) if x]
+        l = re.split(r'([,:.]|[a-zA-Z]+|[0-9]+)',tzstr)
         used_idxs = list()
         try:
 

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -144,7 +144,7 @@ class _timelex(object):
                 # numbers until we find something that doesn't fit.
                 if self.isnum(nextchar):
                     token += nextchar
-                elif nextchar == '.' or (nextchar == ',' and len(token) >= 2):
+                elif nextchar == '.':
                     token += nextchar
                     state = '0.'
                 else:
@@ -1387,10 +1387,11 @@ class _tzparser(object):
                 pass
             elif (8 <= l.count(',') <= 9 and
                   not [y for x in l[i:] if x != ','
-                       for y in x if y not in "0123456789"]):
+                       for y in x if y not in "0123456789+-"]):
                 # GMT0BST,3,0,30,3600,10,0,26,7200[,3600]
                 for x in (res.start, res.end):
                     x.month = int(l[i])
+                    used_tokens[i] = True
                     i += 2
                     if l[i] == '-':
                         value = int(l[i + 1]) * -1
@@ -1417,6 +1418,7 @@ class _tzparser(object):
                         i += 1
                     else:
                         signal = 1
+                    used_tokens[i] = True
                     res.dstoffset = (res.stdoffset + int(l[i])) * signal
             elif (l.count(',') == 2 and l[i:].count('/') <= 2 and
                   not [y for x in l[i:] if x not in (',', '/', 'J', 'M',

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1315,7 +1315,7 @@ class _tzparser(object):
 
     def parse(self, tzstr):
         res = self._result()
-        l = re.split(r'([,:.]|[a-zA-Z]+|[0-9]+)',tzstr)
+        l = [x for x in re.split(r'([,:.]|[a-zA-Z]+|[0-9]+)',tzstr) if x]
         used_idxs = list()
         try:
 

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1420,7 +1420,7 @@ class _tzparser(object):
                     else:
                         signal = 1
                     used_idxs.append(i)
-                    res.dstoffset = (res.stdoffset + int(l[i])) * signal
+                    res.dstoffset = (res.stdoffset + int(l[i]) * signal)
             elif (l.count(',') == 2 and l[i:].count('/') <= 2 and
                   not [y for x in l[i:] if x not in (',', '/', 'J', 'M',
                                                      '.', '-', ':')

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -22,7 +22,7 @@ IS_WIN = sys.platform.startswith('win')
 import pytest
 
 # dateutil imports
-from dateutil.relativedelta import relativedelta, SU
+from dateutil.relativedelta import relativedelta, SU, TH
 from dateutil.parser import parse
 from dateutil import tz as tz
 from dateutil import zoneinfo
@@ -1126,6 +1126,7 @@ class TZRangeTest(unittest.TestCase, TzFoldMixin):
         self.assertFalse(TZR != ComparesEqual)
 
 
+@pytest.mark.tzstr
 class TZStrTest(unittest.TestCase, TzFoldMixin):
     # POSIX string indicating change to summer time on the 2nd Sunday in March
     # at 2AM, and ending the 1st Sunday in November at 2AM. (valid >= 2007)
@@ -1146,44 +1147,6 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
 
         return tz.tzstr(tzname_map[tzname])
 
-    def test_valid_GNU_time_zone(self):
-        # From https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
-        # This test checks that tz.tzstr does not raise when parsing the strings.
-        tz.tzstr("EST+5EDT,M3.2.0/2,M11.1.0/2")
-        tz.tzstr("WART4WARST,J1,J365/25")
-        tz.tzstr("IST-2IDT,M3.4.4/26,M10.5.0")
-        tz.tzstr("WGT3WGST,M3.5.0/2,M10.5.0/1")
-
-        # Different offset
-        tz.tzstr("WGT3000WGST,M3.5.0/02:00,M10.5.0/01:00")
-        tz.tzstr("WGT30:00WGST,M3.5.0/02:00,M10.5.0/01:00")
-
-        # Different time formats
-        tz.tzstr("WGT3WGST,M3.5.0/02:00,M10.5.0/01:00")
-        tz.tzstr("WGT3WGST,M3.5.0/02:00,M10.5.0/01:00")
-
-    def test_invalid_GNU_time_zones(self):
-        with pytest.raises(ValueError):
-            tz.tzstr("hdfiughdfuig,dfughdfuigpu87ñ::")
-        with pytest.raises(ValueError):
-            tz.tzstr(",dfughdfuigpu87ñ::")
-        with pytest.raises(ValueError):
-            tz.tzstr("-1:WART4WARST,J1,J365/25")
-        with pytest.raises(ValueError):
-            tz.tzstr("WART4WARST,J1,J365/-25")
-        with pytest.raises(ValueError):
-            tz.tzstr("IST-2IDT,M3.4.-1/26,M10.5.0")
-        with pytest.raises(ValueError):
-            tz.tzstr("IST-2IDT,M3,2000,1/26,M10,5,0")
-
-    def test_valid_default_format(self):
-        tz.tzstr("EST5EDT,5,4,0,7200,11,3,0,7200")
-        tz.tzstr("EST5EDT,5,-4,0,7200,11,3,0,7200")
-        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200")
-        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,3600")
-        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,3600")
-        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,-3600")
-        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,+3600")
 
     def test_internal_timedeltas(self):
         self.assertNotEqual(tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200")._start_delta,
@@ -1203,7 +1166,7 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
                                   tzinfo=tz.tzstr("EST5EDT")).tzname(), "EDT")
 
         end = tz.enfold(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr("EST5EDT")), fold=1)
+                                 tzinfo=tz.tzstr("EST5EDT")), fold=1)
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart2(self):
@@ -1219,7 +1182,7 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
         end = tz.enfold(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)), fold=1)
+                                 tzinfo=tz.tzstr(s)), fold=1)
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart3(self):
@@ -1235,7 +1198,7 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
         end = tz.enfold(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)), fold=1)
+                                 tzinfo=tz.tzstr(s)), fold=1)
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart4(self):
@@ -1265,7 +1228,7 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
         end = tz.enfold(datetime(2003, 10, 26, 1, 00,
-                                  tzinfo=tz.tzstr(s)), fold=1)
+                                 tzinfo=tz.tzstr(s)), fold=1)
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart6(self):
@@ -1357,6 +1320,113 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
     def testTzStrFailure(self):
         with self.assertRaises(ValueError):
             tz.tzstr('InvalidString;439999')
+
+
+@pytest.mark.tzstr
+@pytest.mark.parametrize('tz_str,expected', [
+    # From https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
+    ('', tz.tzrange(None)),     # TODO: Should change this so tz.tzrange('') works
+    ('EST+5EDT,M3.2.0/2,M11.1.0/12',
+     tz.tzrange('EST', -18000, 'EDT', -14400,
+        start=relativedelta(month=3, day=1, weekday=SU(2), hours=2),
+        end=relativedelta(month=11, day=1, weekday=SU(1), hours=11))),
+    ('WART4WARST,J1/0,J365/25',  # This is DST all year, Western Argentina Summer Time
+     tz.tzrange('WART', timedelta(hours=-4), 'WARST',
+        start=relativedelta(month=1, day=1, hours=0),
+        end=relativedelta(month=12, day=31, days=1))),
+    ('IST-2IDT,M3.4.4/26,M10.5.0',      # Israel Standard / Daylight Time
+     tz.tzrange('IST', timedelta(hours=2), 'IDT',
+        start=relativedelta(month=3, day=1, weekday=TH(4), days=1, hours=2),
+        end=relativedelta(month=10, day=31, weekday=SU(-1), hours=1))),
+    ('WGT3WGST,M3.5.0/2,M10.5.0/1',
+     tz.tzrange('WGT', timedelta(hours=-3), 'WGST',
+        start=relativedelta(month=3, day=31, weekday=SU(-1), hours=2),
+        end=relativedelta(month=10, day=31, weekday=SU(-1), hours=0))),
+
+    # Different offset specifications
+    ('WGT0300WGST',
+     tz.tzrange('WGT', timedelta(hours=-3), 'WGST')),
+    ('WGT03:00WGST',
+     tz.tzrange('WGT', timedelta(hours=-3), 'WGST')),
+    ('AEST-1100AEDT',
+     tz.tzrange('AEST', timedelta(hours=11), 'AEDT')),
+    ('AEST-11:00AEDT',
+     tz.tzrange('AEST', timedelta(hours=11), 'AEDT')),
+
+    # Different time formats
+    ('EST5EDT,M3.2.0/4:00,M11.1.0/3:00',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(month=3, day=1, weekday=SU(2), hours=4),
+        end=relativedelta(month=11, day=1, weekday=SU(1), hours=2))),
+    ('EST5EDT,M3.2.0/04:00,M11.1.0/03:00',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(month=3, day=1, weekday=SU(2), hours=4),
+        end=relativedelta(month=11, day=1, weekday=SU(1), hours=2))),
+    ('EST5EDT,M3.2.0/0400,M11.1.0/0300',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(month=3, day=1, weekday=SU(2), hours=4),
+        end=relativedelta(month=11, day=1, weekday=SU(1), hours=2))),
+])
+def test_valid_GNU_tzstr(tz_str, expected):
+    tzi = tz.tzstr(tz_str)
+
+    assert tzi == expected
+
+
+@pytest.mark.tzstr
+@pytest.mark.parametrize('tz_str, expected', [
+    ('EST5EDT,5,4,0,7200,11,3,0,7200',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(month=5, day=1, weekday=SU(+4), hours=+2),
+        end=relativedelta(month=11, day=1, weekday=SU(+3), hours=+1))),
+    ('EST5EDT,5,-4,0,7200,11,3,0,7200',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(hours=+2, month=5, day=31, weekday=SU(-4)),
+        end=relativedelta(hours=+1, month=11, day=1, weekday=SU(+3)))),
+    ('EST5EDT,5,4,0,7200,11,-3,0,7200',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(hours=+2, month=5, day=1, weekday=SU(+4)),
+        end=relativedelta(hours=+1, month=11, day=31, weekday=SU(-3)))),
+    ('EST5EDT,5,4,0,7200,11,-3,0,7200,3600',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(hours=+2, month=5, day=1, weekday=SU(+4)),
+        end=relativedelta(hours=+1, month=11, day=31, weekday=SU(-3)))),
+    ('EST5EDT,5,4,0,7200,11,-3,0,7200,3600',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(hours=+2, month=5, day=1, weekday=SU(+4)),
+        end=relativedelta(hours=+1, month=11, day=31, weekday=SU(-3)))),
+    ('EST5EDT,5,4,0,7200,11,-3,0,7200,-3600',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT', timedelta(hours=-6),
+        start=relativedelta(hours=+2, month=5, day=1, weekday=SU(+4)),
+        end=relativedelta(hours=+3, month=11, day=31, weekday=SU(-3)))),
+    ('EST5EDT,5,4,0,7200,11,-3,0,7200,+7200',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT', timedelta(hours=-3),
+        start=relativedelta(hours=+2, month=5, day=1, weekday=SU(+4)),
+        end=relativedelta(hours=0, month=11, day=31, weekday=SU(-3)))),
+    ('EST5EDT,5,4,0,7200,11,-3,0,7200,+3600',
+     tz.tzrange('EST', timedelta(hours=-5), 'EDT',
+        start=relativedelta(hours=+2, month=5, day=1, weekday=SU(+4)),
+        end=relativedelta(hours=+1, month=11, day=31, weekday=SU(-3)))),
+])
+def test_valid_default_format(tz_str, expected):
+    # This tests the "default" format that is used widely in the tests and
+    # examples. It is unclear where this format originated from.
+    tzi = tz.tzstr(tz_str)
+    assert tzi == expected
+
+
+@pytest.mark.tzstr
+@pytest.mark.parametrize('tz_str', [
+    'hdfiughdfuig,dfughdfuigpu87ñ::',
+    ',dfughdfuigpu87ñ::',
+    '-1:WART4WARST,J1,J365/25',
+    'WART4WARST,J1,J365/-25',
+    'IST-2IDT,M3.4.-1/26,M10.5.0',
+    'IST-2IDT,M3,2000,1/26,M10,5,0'
+])
+def test_invalid_GNU_tzstr(tz_str):
+    with pytest.raises(ValueError):
+        tz.tzstr(tz_str)
 
 
 class TZICalTest(unittest.TestCase, TzFoldMixin):

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1154,9 +1154,15 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         tz.tzstr("IST-2IDT,M3.4.4/26,M10.5.0")
         tz.tzstr("WGT3WGST,M3.5.0/2,M10.5.0/1")
 
+        # Different offset
+        tz.tzstr("WGT3000WGST,M3.5.0/02:00,M10.5.0/01:00")
+        tz.tzstr("WGT30:00WGST,M3.5.0/02:00,M10.5.0/01:00")
+
+        # Different time formats
+        tz.tzstr("WGT3WGST,M3.5.0/02:00,M10.5.0/01:00")
+        tz.tzstr("WGT3WGST,M3.5.0/02:00,M10.5.0/01:00")
+
     def test_invalid_GNU_time_zones(self):
-        with pytest.raises(ValueError):
-            tz.tzstr("EST5EDT,4,1,0,7200,10,-1,0,7200,3600")
         with pytest.raises(ValueError):
             tz.tzstr("hdfiughdfuig,dfughdfuigpu87ñ::")
         with pytest.raises(ValueError):
@@ -1169,6 +1175,22 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
             tz.tzstr("IST-2IDT,M3.4.-1/26,M10.5.0")
         with pytest.raises(ValueError):
             tz.tzstr("IST-2IDT,M3,2000,1/26,M10,5,0")
+
+    def test_valid_default_format(self):
+        tz.tzstr("EST5EDT,5,4,0,7200,11,3,0,7200")
+        tz.tzstr("EST5EDT,5,-4,0,7200,11,3,0,7200")
+        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200")
+        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,3600")
+        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,3600")
+        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,-3600")
+        tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200,+3600")
+
+    def test_internal_timedeltas(self):
+        self.assertNotEqual(tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200")._start_delta,
+                            tz.tzstr("EST5EDT,4,1,0,7200,10,-1,0,7200")._start_delta)
+
+        self.assertNotEqual(tz.tzstr("EST5EDT,5,4,0,7200,11,-3,0,7200")._end_delta,
+                            tz.tzstr("EST5EDT,4,1,0,7200,10,-1,0,7200")._end_delta)
 
     def testStrStart1(self):
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
@@ -1185,14 +1207,14 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart2(self):
-        s = "EST5EDT,M4.1.0,M10.5.7"
+        s = "EST5EDT,4,0,6,7200,10,0,26,7200,3600"
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EST")
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
     def testStrEnd2(self):
-        s = "EST5EDT,M4.1.0,M10.5.7"
+        s = "EST5EDT,4,0,6,7200,10,0,26,7200,3600"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
@@ -1201,14 +1223,14 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart3(self):
-        s = "EST5EDT,M4.1.0,M10.5.7"
+        s = "EST5EDT,4,1,0,7200,10,-1,0,7200,3600"
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EST")
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
     def testStrEnd3(self):
-        s = "EST5EDT,M4.1.0,M10.5.7"
+        s = "EST5EDT,4,1,0,7200,10,-1,0,7200,3600"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
@@ -1232,14 +1254,14 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart5(self):
-        s = "EST5EDT,M4.1.0,M10.5.7"
+        s = "EST5EDT4,95/02:00:00,298/02:00"
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EST")
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
     def testStrEnd5(self):
-        s = "EST5EDT,M4.1.0,M10.5.7"
+        s = "EST5EDT4,95/02:00:00,298/02"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
         end = tz.enfold(datetime(2003, 10, 26, 1, 00,
@@ -1277,7 +1299,7 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
     def testStrCmp2(self):
         # TODO: This is parsing the default arguments.
         self.assertEqual(tz.tzstr("EST5EDT"),
-                         tz.tzstr("EST5EDT,M4.1.0,M10.5.7"))
+                         tz.tzstr("EST5EDT,4,1,0,7200,10,-1,0,7200,3600"))
 
     def testStrInequality(self):
         TZS1 = tz.tzstr('EST5EDT4')

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1146,6 +1146,30 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
 
         return tz.tzstr(tzname_map[tzname])
 
+    def test_valid_GNU_time_zone(self):
+        # From https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
+        # This test checks that tz.tzstr does not raise when parsing the strings.
+        tz.tzstr("EST+5EDT,M3.2.0/2,M11.1.0/2")
+        tz.tzstr("WART4WARST,J1,J365/25")
+        tz.tzstr("IST-2IDT,M3.4.4/26,M10.5.0")
+        tz.tzstr("WGT3WGST,M3.5.0/2,M10.5.0/1")
+
+    def test_invalid_GNU_time_zones(self):
+        with pytest.raises(ValueError):
+            tz.tzstr("EST5EDT,4,1,0,7200,10,-1,0,7200,3600")
+        with pytest.raises(ValueError):
+            tz.tzstr("hdfiughdfuig,dfughdfuigpu87ñ::")
+        with pytest.raises(ValueError):
+            tz.tzstr(",dfughdfuigpu87ñ::")
+        with pytest.raises(ValueError):
+            tz.tzstr("-1:WART4WARST,J1,J365/25")
+        with pytest.raises(ValueError):
+            tz.tzstr("WART4WARST,J1,J365/-25")
+        with pytest.raises(ValueError):
+            tz.tzstr("IST-2IDT,M3.4.-1/26,M10.5.0")
+        with pytest.raises(ValueError):
+            tz.tzstr("IST-2IDT,M3,2000,1/26,M10,5,0")
+
     def testStrStart1(self):
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr("EST5EDT")).tzname(), "EST")
@@ -1161,14 +1185,14 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart2(self):
-        s = "EST5EDT,4,0,6,7200,10,0,26,7200,3600"
+        s = "EST5EDT,M4.1.0,M10.5.7"
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EST")
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
     def testStrEnd2(self):
-        s = "EST5EDT,4,0,6,7200,10,0,26,7200,3600"
+        s = "EST5EDT,M4.1.0,M10.5.7"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
@@ -1177,14 +1201,14 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart3(self):
-        s = "EST5EDT,4,1,0,7200,10,-1,0,7200,3600"
+        s = "EST5EDT,M4.1.0,M10.5.7"
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EST")
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
     def testStrEnd3(self):
-        s = "EST5EDT,4,1,0,7200,10,-1,0,7200,3600"
+        s = "EST5EDT,M4.1.0,M10.5.7"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
@@ -1208,14 +1232,14 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(end.tzname(), "EST")
 
     def testStrStart5(self):
-        s = "EST5EDT4,95/02:00:00,298/02:00"
+        s = "EST5EDT,M4.1.0,M10.5.7"
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EST")
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
 
     def testStrEnd5(self):
-        s = "EST5EDT4,95/02:00:00,298/02"
+        s = "EST5EDT,M4.1.0,M10.5.7"
         self.assertEqual(datetime(2003, 10, 26, 0, 59,
                                   tzinfo=tz.tzstr(s)).tzname(), "EDT")
         end = tz.enfold(datetime(2003, 10, 26, 1, 00,
@@ -1253,7 +1277,7 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
     def testStrCmp2(self):
         # TODO: This is parsing the default arguments.
         self.assertEqual(tz.tzstr("EST5EDT"),
-                         tz.tzstr("EST5EDT,4,1,0,7200,10,-1,0,7200,3600"))
+                         tz.tzstr("EST5EDT,M4.1.0,M10.5.7"))
 
     def testStrInequality(self):
         TZS1 = tz.tzstr('EST5EDT4')

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -993,7 +993,7 @@ class tzstr(tzrange):
         self._s = s
 
         res = parser._parsetz(s)
-        if res is None:
+        if res is None or res.unused_tokens:
             raise ValueError("unknown string format")
 
         # Here we break the compatibility with the TZ variable handling.

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -993,7 +993,7 @@ class tzstr(tzrange):
         self._s = s
 
         res = parser._parsetz(s)
-        if res is None or res.unused_tokens:
+        if res is None or res.any_unused_tokens:
             raise ValueError("unknown string format")
 
         # Here we break the compatibility with the TZ variable handling.


### PR DESCRIPTION
This pr fixes #259. As discussed with @pganssle in the dateutil sprint in London, the fix consist in modifiying `dateutil.parser._parser._tzparser.parse` to check if all tokens generated from the input string have been consumed (except separators that are assumed to be "," and ":" as specified [here](https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html)). To have some control (and help future debugging) on the tokens that are not used, a mark of used_tokens is used internally to keep track of this. To avoid making the parser raise and therefore modifiying the current behaviour, a new slotted field was added to `dateutil.parser._parser._tzparser._result` that indicates if all tokens have been consumed or not. This is used in `dateutil.tz.tz.tzstr` to raise accordingly in the case that this check fails (so not all tokens have been consumed`.

8 test of the test suite for `tz.tz.tzstr` were failing because they were using invalid strings and now the call to  `tz.tz.tzstr` raises. These test were using "default" arguments, that were intented to use the default values that the parser, tzstr and tzrange constructs. To fix these test, the input string has been changed for a GNUtz-compatible equivalent.