### PR TITLE
Expand equality for tzlocal

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -877,11 +877,20 @@ class TzLocalNixTest(unittest.TestCase, TzFoldMixin):
         with TZEnvContext(self.UTC):
             assert tz.tzlocal() == tz.tzutc()
 
+
 # TODO: Maybe a better hack than this?
-mark_tzlocal_nix = pytest.mark.tzlocal(
-    pytest.mark.skipif(IS_WIN, reason='requires Unix')(
-    pytest.mark.skipif(not TZEnvContext.tz_change_allowed,
-                       reason=TZEnvContext.tz_change_disallowed_message())))
+def mark_tzlocal_nix(f):
+    marks = [
+        pytest.mark.tzlocal,
+        pytest.mark.skipif(IS_WIN, reason='requires Unix'),
+        pytest.mark.skipif(not TZEnvContext.tz_change_allowed,
+                           reason=TZEnvContext.tz_change_disallowed_message())
+    ]
+
+    for mark in reversed(marks):
+        f = mark(f)
+
+    return f
 
 
 @mark_tzlocal_nix
@@ -1653,7 +1662,6 @@ class TZICalTest(unittest.TestCase, TzFoldMixin):
                                                  'FOO=BAR')
         with self.assertRaises(ValueError):
             tz.tzical(StringIO(tz_str))
-
 
     # Test Parsing
     def testGap(self):

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -201,6 +201,7 @@ class tzlocal(_tzinfo):
 
         self._dst_saved = self._dst_offset - self._std_offset
         self._hasdst = bool(self._dst_saved)
+        self._tznames = tuple(time.tzname)
 
     def utcoffset(self, dt):
         if dt is None and self._hasdst:
@@ -222,7 +223,7 @@ class tzlocal(_tzinfo):
 
     @tzname_in_python2
     def tzname(self, dt):
-        return time.tzname[self._isdst(dt)]
+        return self._tznames[self._isdst(dt)]
 
     def is_ambiguous(self, dt):
         """
@@ -287,11 +288,15 @@ class tzlocal(_tzinfo):
         return dstval
 
     def __eq__(self, other):
-        if not isinstance(other, tzlocal):
+        if isinstance(other, tzlocal):
+            return (self._std_offset == other._std_offset and
+                    self._dst_offset == other._dst_offset)
+        elif isinstance(other, tzutc):
+            return (not self._hasdst and
+                    self._tznames[0] in {'UTC', 'GMT'} and
+                    self._std_offset == ZERO)
+        else:
             return NotImplemented
-
-        return (self._std_offset == other._std_offset and
-                self._dst_offset == other._dst_offset)
 
     __hash__ = None
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -295,6 +295,10 @@ class tzlocal(_tzinfo):
             return (not self._hasdst and
                     self._tznames[0] in {'UTC', 'GMT'} and
                     self._std_offset == ZERO)
+        elif isinstance(other, tzoffset):
+            return (not self._hasdst and
+                    self._tznames[0] == other._name and
+                    self._std_offset == other._offset)
         else:
             return NotImplemented
 


### PR DESCRIPTION
Should fix the `tzlocal() == tzutc()` question in #64.