### PR TITLE
Fixes handling of the GNU C Library default timezone value

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -69,6 +69,7 @@ switch, and thus all their contributions are dual-licensed.
 - Tomasz Kluczkowski (gh: @Tomasz-Kluczkowski) **D**
 - Tomi Pieviläinen <tomi.pievilainen@iki.fi>
 - Unrud <Unrud@MASKED> (gh: @unrud)
+- Xavier Lapointe <lapointe.xavier@MASKED> (gh: @lapointexavier) **D**
 - X O <xo@MASKED>
 - Yaron de Leeuw <me@jarondl.net> (gh: @jarondl)
 - Yoney <alper_yoney@hotmail.com> **D**

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -910,6 +910,12 @@ def test_tzlocal_utc_unequal(tzvar):
 
 
 @mark_tzlocal_nix
+def test_tzlocal_local_time_trim_colon():
+    with TZEnvContext(':/etc/localtime'):
+        assert tz.gettz() is not None
+
+
+@mark_tzlocal_nix
 @pytest.mark.parametrize('tzvar, tzoff', [
     ('EST5', tz.tzoffset('EST', -18000)),
     ('GMT', tz.tzoffset('GMT', 0)),

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1413,7 +1413,7 @@ def gettz(name=None):
             tz = tzlocal()
     else:
         if name.startswith(":"):
-            name = name[:-1]
+            name = name[1:]
         if os.path.isabs(name):
             if os.path.isfile(name):
                 tz = tzfile(name)


### PR DESCRIPTION
## Description

I just found an edge case (I believe) that was not handled properly. It seems like the slice on the `TZ` environment variable value was incorrect, using `name[:-1]` instead of `name[1:]`.

I would end up with the following:
```
(Pdb++) name
 ':/etc/localtim'
```

... instead of:

`/etc/localtime`

## Background

The default timezone value can be `TZ=:/etc/localtime`. It may vary, but usually starts with `:`.

Documentation: https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html

> If the TZ environment variable does not have a value, the operation chooses a time zone by default. In the GNU C Library, the default time zone is like the specification ‘TZ=:/etc/localtime’ (or ‘TZ=:/usr/local/etc/localtime’, depending on how the GNU C Library was configured; see Installation). Other C libraries use their own rule for choosing the default time zone, so there is little we can say about them. 
