### PR TITLE
Only raise ValueError in parser for now

### DIFF
--- a/dateutil/parser/__init__.py
+++ b/dateutil/parser/__init__.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 from ._parser import parse, parser, parserinfo
 from ._parser import DEFAULTPARSER, DEFAULTTZPARSER
-from ._parser import InvalidDateError, InvalidDatetimeError, InvalidTimeError
 
 from ._parser import __doc__
 
 from .isoparser import isoparser, isoparse
 
 __all__ = ['parse', 'parser', 'parserinfo',
-           'isoparse', 'isoparser',
-           'InvalidDatetimeError', 'InvalidDateError', 'InvalidTimeError']
+           'isoparse', 'isoparser']
 
 
 ###

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -788,7 +788,7 @@ class parser(object):
                         hour_offset = int(l[i + 1][:2])
                         min_offset = 0
                     else:
-                        raise InvalidDatetimeError(timestr)
+                        raise ValueError(timestr)
 
                     res.tzoffset = signal * (hour_offset * 3600 + min_offset * 60)
 
@@ -807,7 +807,7 @@ class parser(object):
 
                 # Check jumps
                 elif not (info.jump(l[i]) or fuzzy):
-                    raise InvalidDatetimeError(timestr)
+                    raise ValueError(timestr)
 
                 else:
                     skipped_idxs.append(i)
@@ -920,7 +920,7 @@ class parser(object):
                     if value is not None:
                         ymd.append(value, 'M')
                     else:
-                        raise InvalidDatetimeError()
+                        raise ValueError()
 
                 if idx + 3 < len_l and tokens[idx + 3] == sep:
                     # We have three members
@@ -956,7 +956,7 @@ class parser(object):
             ymd.append(value)
 
         elif not fuzzy:
-            raise InvalidDatetimeError()
+            raise ValueError()
 
         return idx
 
@@ -1508,17 +1508,5 @@ DEFAULTTZPARSER = _tzparser()
 
 def _parsetz(tzstr):
     return DEFAULTTZPARSER.parse(tzstr)
-
-
-class InvalidDatetimeError(ValueError):
-    pass
-
-
-class InvalidDateError(InvalidDatetimeError):
-    pass
-
-
-class InvalidTimeError(InvalidDatetimeError):
-    pass
 
 # vim:ts=4:sw=4:et

--- a/dateutil/test/test_imports.py
+++ b/dateutil/test/test_imports.py
@@ -45,14 +45,6 @@ class ImportParserTest(unittest.TestCase):
         for var in (parse, parserinfo, parser):
             self.assertIsNot(var, None)
 
-    def testParserErrors(self):
-        from dateutil.parser import InvalidDateError
-        from dateutil.parser import InvalidTimeError
-        from dateutil.parser import InvalidDatetimeError
-
-        for var in (InvalidDateError, InvalidTimeError, InvalidDatetimeError):
-            assert issubclass(var, ValueError)
-
 
 class ImportRelativeDeltaTest(unittest.TestCase):
     """ Test that dateutil.relativedelta-related imports work properly """


### PR DESCRIPTION
Preparing for the 2.7.0 release, I don't want to have a half-done implementation of #335. For now we'll go back to all `ValueError` and then implement the new subclasses strategy in one fell swoop.