### PR TITLE
Remove support for end of life Python 3.2 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -30,4 +29,3 @@ script:
 
 after_success:
   - if [[ $TOXENV == "py" ]]; then tox -e coverage,codecov; fi
-

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 UNRELEASED
 ----------
-- **Dropped support for Python 2.6.**
+- **Dropped support for end of life Python 2.6, 3.2, and 3.3.**
 
 Version 2.6.1
 -------------

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ build: false
 environment:
   matrix:
     - PYTHON_VERSION: 27
-    - PYTHON_VERSION: 33
     - PYTHON_VERSION: 34
     - PYTHON_VERSION: 35
     - PYTHON_VERSION: 36
@@ -14,12 +13,10 @@ matrix:
   fast_finish: true
   exclude:
     - platform: x86
-      PYTHON_VERSION: 33
-    - platform: x86
       PYTHON_VERSION: 34
     - platform: x86
       PYTHON_VERSION: 35
-    
+
 install:
   # set env variables
   - set TOXENV=py%PYTHON_VERSION%

--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -13,6 +13,7 @@ import sys
 try:
     from math import gcd
 except ImportError:
+    # Python < 3.5
     from fractions import gcd
 
 from six import advance_iterator, integer_types

--- a/dateutil/test/test_internals.py
+++ b/dateutil/test/test_internals.py
@@ -15,8 +15,6 @@ import pytest
 from dateutil.parser._parser import _ymd
 from dateutil import tz
 
-IS_PY32 = sys.version_info[0:2] == (3, 2)
-
 
 class TestYMD(unittest.TestCase):
 
@@ -49,7 +47,6 @@ class TestYMD(unittest.TestCase):
 
 ###
 # Test that private interfaces in _parser are deprecated properly
-@pytest.mark.skipif(IS_PY32, reason='pytest.warns not supported on Python 3.2')
 def test_parser_private_warns():
     from dateutil.parser import _timelex, _tzparser
     from dateutil.parser import _parsetz
@@ -64,7 +61,6 @@ def test_parser_private_warns():
         _parsetz('+05:00')
 
 
-@pytest.mark.skipif(IS_PY32, reason='pytest.warns not supported on Python 3.2')
 def test_parser_parser_private_not_warns():
     from dateutil.parser._parser import _timelex, _tzparser
     from dateutil.parser._parser import _parsetz

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 six
-pytest >= 3.0; python_version != '3.3'
-pytest <  3.3; python_version == '3.3'
+pytest >= 3.0
 pytest-cov >= 2.0.0
 freezegun
 coverage

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ The dateutil module provides powerful extensions to the
 datetime module available in the Python standard library.
 """,
       packages=PACKAGES,
-      python_requires=">=2.7, !=3.0.*, !=3.1.*",
+      python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
       package_data={"dateutil.zoneinfo": ["dateutil-zoneinfo.tar.gz"]},
       zip_safe=True,
       requires=["six"],
@@ -55,8 +55,6 @@ datetime module available in the Python standard library.
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.2',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py27,
-          py33,
           py34,
           py35,
           py36,


### PR DESCRIPTION
Python 3.2 and 3.3 are end of life. They are no longer receiving bug fixes including for security issues. They have been EOL since 2016-02-20 and 2017-09-29 respectively. For additional details, see:

https://devguide.python.org/#status-of-python-branches

Reduces testing and maintenance resources.