### PR TITLE
add support for DTSTART;TZID= in rrules

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -20,6 +20,7 @@ from six.moves import _thread, range
 import heapq
 
 from ._common import weekday as weekdaybase
+from . import tz
 
 # For warning about deprecation of until and count
 from warnings import warn
@@ -1565,6 +1566,13 @@ class _rrulestr(object):
                     value_found = False
                     valid_values = {"VALUE=DATE-TIME", "VALUE=DATE"}
                     for parm in parms:
+                        if parm.startswith("TZID="):
+                            tzid = parm.split('TZID=')[-1]
+                            if tzinfos is None:
+                                tzinfos = {}
+                            tzinfos['TZID'] = tz.gettz(tzid)
+                            value = value+'TZID'
+                            continue
                         if parm not in valid_values:
                             raise ValueError("unsupported DTSTART parm: "+parm)
                         else:

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -6,6 +6,7 @@ from datetime import datetime, date
 import unittest
 from six import PY3
 
+from dateutil import tz
 from dateutil.rrule import (
     rrule, rruleset, rrulestr,
     YEARLY, MONTHLY, WEEKLY, DAILY,
@@ -2668,6 +2669,15 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1998, 9, 2, 9, 0),
                           datetime(1999, 9, 2, 9, 0)])
+
+    def testStrWithTZID(self):
+        self.assertEqual(list(rrulestr(
+                              "DTSTART;TZID=America/New_York:19970902T090000\n"
+                              "RRULE:FREQ=YEARLY;COUNT=3\n"
+                              )),
+                         [datetime(1997, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York')),
+                          datetime(1998, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York')),
+                          datetime(1999, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York'))])
 
     def testStrType(self):
         self.assertEqual(isinstance(rrulestr(


### PR DESCRIPTION
see: https://github.com/dateutil/dateutil/issues/614