### PR TITLE
Update tondering.dk link to use HTTPS

### DIFF
--- a/dateutil/easter.py
+++ b/dateutil/easter.py
@@ -45,7 +45,7 @@ def easter(year, method=EASTER_WESTERN):
 
     and
 
-    `The Calendar FAQ: Easter <http://www.tondering.dk/claus/cal/easter.php>`_
+    `The Calendar FAQ: Easter <https://www.tondering.dk/claus/cal/easter.php>`_
 
     """
 


### PR DESCRIPTION
This should unbreak the (possibly overzealous) CI, which is treating permanent redirects as errors.

That said, it's a good idea to link to HTTPS when possible.