### PR TITLE
Update test to not fail after 2027

### DIFF
--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -624,7 +624,7 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("4 jul 1976"), datetime(1976, 7, 4))
 
     def testRandomFormat11(self):
-        self.assertEqual(parse("7-4-76"), datetime(1976, 7, 4))
+        self.assertEqual(parse("7-4-36"), datetime(2036, 7, 4))
 
     def testRandomFormat12(self):
         self.assertEqual(parse("19760704"), datetime(1976, 7, 4))


### PR DESCRIPTION
because then 2076 is closer than 1976


The more general fix would be to add something like
```python
        time.localtime = mock.Mock()
        time.localtime.return_value = time.struct_time(
            [2017, 11, 28, 1, 1, 1, 1, 332, 0]
        )
```