### PR TITLE
isoparser strictness clarification and relaxation

### DIFF
--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -38,16 +38,21 @@ def _takes_ascii(f):
 
 
 class isoparser(object):
-    def __init__(self, sep='T'):
+    def __init__(self, sep=None):
         """
         :param sep:
-            A single character that separates date and time portions
+            A single character that separates date and time portions. If
+            ``None``, the parser will accept any single character.
+            For strict ISO-8601 adherence, pass ``'T'``.
         """
-        if (len(sep) != 1 or ord(sep) >= 128 or sep in '0123456789'):
-            raise ValueError('Separator must be a single, non-numeric '
-                             'ASCII character')
+        if sep is not None:
+            if (len(sep) != 1 or ord(sep) >= 128 or sep in '0123456789'):
+                raise ValueError('Separator must be a single, non-numeric ' +
+                                 'ASCII character')
 
-        self._sep = sep.encode('ascii')
+            sep = sep.encode('ascii')
+
+        self._sep = sep
 
     @_takes_ascii
     def isoparse(self, dt_str):
@@ -123,7 +128,7 @@ class isoparser(object):
         components, pos = self._parse_isodate(dt_str)
 
         if len(dt_str) > pos:
-            if dt_str[pos:pos + 1] == self._sep:
+            if self._sep is None or dt_str[pos:pos + 1] == self._sep:
                 components += self._parse_isotime(dt_str[pos + 1:])
             else:
                 raise ValueError('String contains unknown ISO components')

--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -57,7 +57,8 @@ class isoparser(object):
         An ISO-8601 datetime string consists of a date portion, followed
         optionally by a time portion - the date and time portions are separated
         by a single character separator, which is ``T`` in the official
-        standard.
+        standard. Incomplete date formats (such as ``YYYY-MM``) may *not* be
+        combined with a time portion.
 
         Supported date formats are:
 
@@ -108,6 +109,16 @@ class isoparser(object):
         :return:
             Returns a :class:`datetime.datetime` representing the string.
             Unspecified components default to their lowest value.
+
+        .. warning::
+
+            As of version 2.7.0, the strictness of the parser should not be
+            considered a stable part of the contract. Any valid ISO-8601 string
+            that parses correctly with the default settings will continue to
+            parse correctly in future versions, but invalid strings that
+            currently fail (e.g. ``2017-01-01T00:00+00:00:00``) are not
+            guaranteed to continue failing in future versions if they encode
+            a valid date.
         """
         components, pos = self._parse_isodate(dt_str)
 

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -152,6 +152,15 @@ def test_full_tzoffsets(tzoffset):
 def test_datetime_midnight(dt_str):
     assert isoparse(dt_str) == datetime(2014, 4, 11, 0, 0, 0, 0)
 
+@pytest.mark.parametrize('datestr', [
+    '2014-01-01',
+    '20140101',
+])
+@pytest.mark.parametrize('sep', [' ', 'a', 'T', '_', '-'])
+def test_isoparse_sep_none(datestr, sep):
+    isostr = datestr + sep + '14:33:09'
+    assert isoparse(isostr) == datetime(2014, 1, 1, 14, 33, 9)
+
 ##
 # Uncommon date formats
 TIME_ARGS = ('time_args',
@@ -224,7 +233,6 @@ def test_bytes(isostr, dt):
     ('201204-25', ValueError),                  # Inconsistent date separators
     ('20120425T0120:00', ValueError),           # Inconsistent time separators
     ('20120425T012500-334', ValueError),        # Wrong microsecond separator
-    ('20120425C012500', ValueError),            # Wrong time separator
     ('2001-1', ValueError),                     # YYYY-M not valid
     ('2012-04-9', ValueError),                  # YYYY-MM-D not valid
     ('201204', ValueError),                     # YYYYMM not valid
@@ -253,6 +261,14 @@ def test_bytes(isostr, dt):
 def test_iso_raises(isostr, exception):
     with pytest.raises(exception):
         isoparse(isostr)
+
+
+@pytest.mark.parametrize('sep_act,valid_sep', [
+    ('C', 'T'),
+    ('T', 'C')
+])
+def test_iso_raises_sep(sep_act, valid_sep):
+    isostr = '2012-04-25' + sep_act + '01:25:00'
 
 
 @pytest.mark.xfail()


### PR DESCRIPTION
My goal for the isoparser in the future is to allow more customization of the parse to allow the user to be more or less strict than the ISO 8601 standard, but I think it's time to get the 2.7.0 release out the door, so I've tweaked the documentation to indicate that the strictness of the default `isoparse` is not something to rely on (until the strictness can be specified).

Additionally, in a nod to pragmatism (since a huge number of people use ISO 8601 with a space separator rather than a `T` separator), I've relaxed the strictness of the parser to accept *any* single ASCII character by default, rather than just `T`. This brings the behavior more in line with the forthcoming [`datetime.fromisoformat`](https://docs.python.org/3.7/library/datetime.html#datetime.datetime.fromisoformat) alternate constructor - though there are things `fromisoformat` accepts that this function won't, and things this function accepts that `fromisoformat` won't, for the majority of people `dateutil.parser.isoparse` will work perfectly well as a substitute for `datetime.fromisoformat`.