### PR TITLE
Support for TZID= in rrulestr

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -20,6 +20,7 @@ from six.moves import _thread, range
 import heapq
 
 from ._common import weekday as weekdaybase
+from . import tz
 
 # For warning about deprecation of until and count
 from warnings import warn
@@ -1563,8 +1564,14 @@ class _rrulestr(object):
                     # RFC 5445 3.8.2.4: The VALUE parameter is optional, but
                     # may be found only once.
                     value_found = False
+                    TZID = None
                     valid_values = {"VALUE=DATE-TIME", "VALUE=DATE"}
                     for parm in parms:
+                        if parm.startswith("TZID="):
+                            tzkey = parm.split('TZID=')[-1]
+                            tzlookup = tzinfos.get if tzinfos else tz.gettz
+                            TZID = tzlookup(tzkey)
+                            continue
                         if parm not in valid_values:
                             raise ValueError("unsupported DTSTART parm: "+parm)
                         else:
@@ -1577,6 +1584,11 @@ class _rrulestr(object):
                         from dateutil import parser
                     dtstart = parser.parse(value, ignoretz=ignoretz,
                                            tzinfos=tzinfos)
+                    if TZID is not None:
+                        if dtstart.tzinfo is None:
+                            dtstart = dtstart.replace(tzinfo=TZID)
+                        else:
+                            raise ValueError('DTSTART specifies multiple timezones')
                 else:
                     raise ValueError("unsupported property: "+name)
             if (forceset or len(rrulevals) > 1 or rdatevals

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -2679,6 +2679,10 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                           datetime(1998, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York')),
                           datetime(1999, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York'))])
 
+    def testStrWithConflictingTZID(self):
+        with self.assertRaises(ValueError):
+            rrulestr("DTSTART;TZID=America/New_York:19970902T090000Z\nRRULE:FREQ=YEARLY;COUNT=3\n")
+
     def testStrType(self):
         self.assertEqual(isinstance(rrulestr(
                               "DTSTART:19970902T090000\n"

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -6,6 +6,7 @@ from datetime import datetime, date
 import unittest
 from six import PY3
 
+from dateutil import tz
 from dateutil.rrule import (
     rrule, rruleset, rrulestr,
     YEARLY, MONTHLY, WEEKLY, DAILY,
@@ -2668,6 +2669,15 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(1998, 9, 2, 9, 0),
                           datetime(1999, 9, 2, 9, 0)])
+
+    def testStrWithTZID(self):
+        self.assertEqual(list(rrulestr(
+                              "DTSTART;TZID=America/New_York:19970902T090000\n"
+                              "RRULE:FREQ=YEARLY;COUNT=3\n"
+                              )),
+                         [datetime(1997, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York')),
+                          datetime(1998, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York')),
+                          datetime(1999, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York'))])
 
     def testStrType(self):
         self.assertEqual(isinstance(rrulestr(

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -2671,17 +2671,68 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                           datetime(1999, 9, 2, 9, 0)])
 
     def testStrWithTZID(self):
+        NYC = tz.gettz('America/New_York')
         self.assertEqual(list(rrulestr(
                               "DTSTART;TZID=America/New_York:19970902T090000\n"
                               "RRULE:FREQ=YEARLY;COUNT=3\n"
                               )),
-                         [datetime(1997, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York')),
-                          datetime(1998, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York')),
-                          datetime(1999, 9, 2, 9, 0, tzinfo=tz.gettz('America/New_York'))])
+                         [datetime(1997, 9, 2, 9, 0, tzinfo=NYC),
+                          datetime(1998, 9, 2, 9, 0, tzinfo=NYC),
+                          datetime(1999, 9, 2, 9, 0, tzinfo=NYC)])
+
+    def testStrWithTZIDMapping(self):
+        rrstr = ("DTSTART;TZID=Eastern:19970902T090000\n" +
+                 "RRULE:FREQ=YEARLY;COUNT=3")
+
+        NYC = tz.gettz('America/New_York')
+        rr = rrulestr(rrstr, tzids={'Eastern': NYC})
+        exp = [datetime(1997, 9, 2, 9, 0, tzinfo=NYC),
+               datetime(1998, 9, 2, 9, 0, tzinfo=NYC),
+               datetime(1999, 9, 2, 9, 0, tzinfo=NYC)]
+
+        self.assertEqual(list(rr), exp)
+
+    def testStrWithTZIDCallable(self):
+        rrstr = ('DTSTART;TZID=UTC+04:19970902T090000\n' +
+                 'RRULE:FREQ=YEARLY;COUNT=3')
+
+        TZ = tz.tzstr('UTC+04')
+        def parse_tzstr(tzstr):
+            if tzstr is None:
+                raise ValueError('Invalid tzstr')
+
+            return tz.tzstr(tzstr)
+
+        rr = rrulestr(rrstr, tzids=parse_tzstr)
+
+        exp = [datetime(1997, 9, 2, 9, 0, tzinfo=TZ),
+               datetime(1998, 9, 2, 9, 0, tzinfo=TZ),
+               datetime(1999, 9, 2, 9, 0, tzinfo=TZ),]
+
+        self.assertEqual(list(rr), exp)
+
+    def testStrWithTZIDCallableFailure(self):
+        rrstr = ('DTSTART;TZID=America/New_York:19970902T090000\n' +
+                 'RRULE:FREQ=YEARLY;COUNT=3')
+
+        class TzInfoError(Exception):
+            pass
+
+        def tzinfos(tzstr):
+            if tzstr == 'America/New_York':
+                raise TzInfoError('Invalid!')
+            return None
+
+        with self.assertRaises(TzInfoError):
+            rrulestr(rrstr, tzids=tzinfos)
 
     def testStrWithConflictingTZID(self):
+        # RFC 5545 Section 3.3.5, FORM #2: DATE WITH UTC TIME
+        # https://tools.ietf.org/html/rfc5545#section-3.3.5
+        # The "TZID" property parameter MUST NOT be applied to DATE-TIME
         with self.assertRaises(ValueError):
-            rrulestr("DTSTART;TZID=America/New_York:19970902T090000Z\nRRULE:FREQ=YEARLY;COUNT=3\n")
+            rrulestr("DTSTART;TZID=America/New_York:19970902T090000Z\n"+
+                     "RRULE:FREQ=YEARLY;COUNT=3\n")
 
     def testStrType(self):
         self.assertEqual(isinstance(rrulestr(


### PR DESCRIPTION
This is a fixup PR for #619, see the discussion there for more details. It fixes #614. 

I realized that `tzinfos` in the parser and `tzid` want slightly different things in this scenario. Considering that the RFC is actually a lot stricter than `dateutil.parser.parse` about the format of the dates, in a future version I will try to deprecate the looser parser, possibly in favor of `dateutil.parser.isoparse`.

Either way I'll probably deprecate the use of `tzinfos`, since the RFC dictates that the time zone should go in the `TZID` parameter, not the datetime itself.