### PR TITLE
More caching and singletons in tz

### DIFF
--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -664,6 +664,7 @@ class TzUTCTest(unittest.TestCase):
         self.assertFalse(tz.datetime_ambiguous(dt))
 
 
+@pytest.mark.tzoffset
 class TzOffsetTest(unittest.TestCase):
     def testTimedeltaOffset(self):
         est = tz.tzoffset('EST', timedelta(hours=-5))
@@ -718,6 +719,30 @@ class TzOffsetTest(unittest.TestCase):
 
         self.assertFalse(tz.datetime_ambiguous(dt))
 
+    def testTzOffsetInstance(self):
+        tz1 = tz.tzoffset.instance('EST', timedelta(hours=-5))
+        tz2 = tz.tzoffset.instance('EST', timedelta(hours=-5))
+
+        assert tz1 is not tz2
+
+    def testTzOffsetSingletonDifferent(self):
+        tz1 = tz.tzoffset('EST', timedelta(hours=-5))
+        tz2 = tz.tzoffset('EST', -18000)
+
+        assert tz1 is tz2
+
+@pytest.mark.tzoffset
+@pytest.mark.parametrize('args', [
+    ('UTC', 0),
+    ('EST', -18000),
+    ('EST', timedelta(hours=-5)),
+    (None, timedelta(hours=3)),
+])
+def test_tzoffset_singleton(args):
+    tz1 = tz.tzoffset(*args)
+    tz2 = tz.tzoffset(*args)
+
+    assert tz1 is tz2
 
 @pytest.mark.tzlocal
 class TzLocalTest(unittest.TestCase):
@@ -1339,6 +1364,17 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
 
         self.assertIs(tz_f1, tz_f2)
 
+    def testTzStrInstance(self):
+        tz1 = tz.tzstr('EST5EDT')
+        tz2 = tz.tzstr.instance('EST5EDT')
+        tz3 = tz.tzstr.instance('EST5EDT')
+
+        assert tz1 is not tz2
+        assert tz2 is not tz3
+
+        # Ensure that these still are all the same zone
+        assert tz1 == tz2 == tz3
+
 @pytest.mark.tzstr
 @pytest.mark.parametrize('tz_str,expected', [
     # From https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
@@ -1429,7 +1465,7 @@ def test_valid_dateutil_format(tz_str, expected):
     # This tests the dateutil-specific format that is used widely in the tests
     # and examples. It is unclear where this format originated from.
     with pytest.warns(tz.DeprecatedTzFormatWarning):
-        tzi = tz.tzstr(tz_str)
+        tzi = tz.tzstr.instance(tz_str)
 
     assert tzi == expected
 

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1296,6 +1296,25 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         with self.assertRaises(ValueError):
             tz.tzstr('InvalidString;439999')
 
+    def testTzStrSingleton(self):
+        tz1 = tz.tzstr('EST5EDT')
+        tz2 = tz.tzstr('CST4CST')
+        tz3 = tz.tzstr('EST5EDT')
+
+        self.assertIsNot(tz1, tz2)
+        self.assertIs(tz1, tz3)
+
+    def testTzStrSingletonPosix(self):
+        tz_t1 = tz.tzstr('GMT+3', posix_offset=True)
+        tz_f1 = tz.tzstr('GMT+3', posix_offset=False)
+
+        tz_t2 = tz.tzstr('GMT+3', posix_offset=True)
+        tz_f2 = tz.tzstr('GMT+3', posix_offset=False)
+
+        self.assertIs(tz_t1, tz_t2)
+        self.assertIsNot(tz_t1, tz_f1)
+
+        self.assertIs(tz_f1, tz_f2)
 
 @pytest.mark.tzstr
 @pytest.mark.parametrize('tz_str,expected', [
@@ -1388,7 +1407,7 @@ def test_valid_dateutil_format(tz_str, expected):
     # and examples. It is unclear where this format originated from.
     with pytest.warns(tz.DeprecatedTzFormatWarning):
         tzi = tz.tzstr(tz_str)
-   
+
     assert tzi == expected
 
 

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -953,6 +953,7 @@ def test_tzlocal_offset_unequal(tzvar, tzoff):
         assert not (tz.tzlocal() == tzoff)
 
 
+@pytest.mark.gettz
 class GettzTest(unittest.TestCase, TzFoldMixin):
     gettz = staticmethod(tz.gettz)
 
@@ -998,6 +999,28 @@ class GettzTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(t_west.tzname(), 'WEST')
         self.assertEqual(t_west.utcoffset(), timedelta(hours=1))
         self.assertEqual(t_west.dst(), timedelta(hours=1))
+
+    def testGettzCacheTzFile(self):
+        NYC1 = tz.gettz('America/New_York')
+        NYC2 = tz.gettz('America/New_York')
+
+        assert NYC1 is NYC2
+
+    def testGettzCacheTzLocal(self):
+        local1 = tz.gettz()
+        local2 = tz.gettz()
+
+        assert local1 is not local2
+
+@pytest.mark.gettz
+@pytest.mark.xfail(IS_WIN, reason='zoneinfo separately cached')
+def test_gettz_cache_clear():
+    NYC1 = tz.gettz('America/New_York')
+    tz.gettz.cache_clear()
+
+    NYC2 = tz.gettz('America/New_York')
+
+    assert NYC1 is not NYC2
 
 
 class ZoneInfoGettzTest(GettzTest, WarningTestMixin):

--- a/dateutil/tz/_factories.py
+++ b/dateutil/tz/_factories.py
@@ -1,4 +1,4 @@
-from datetime import timedelta 
+from datetime import timedelta
 
 
 class _TzSingleton(type):
@@ -26,3 +26,18 @@ class _TzOffsetFactory(type):
         if instance is None:
             instance = cls.__instances.setdefault(key, type.__call__(cls, name, offset))
         return instance
+
+
+class _TzStrFactory(type):
+    def __init__(cls, *args, **kwargs):
+        cls.__instances = {}
+
+    def __call__(cls, s, posix_offset=False):
+        key = (s, posix_offset)
+        instance = cls.__instances.get(key, None)
+
+        if instance is None:
+            instance = cls.__instances.setdefault(key,
+                type.__call__(cls, s, posix_offset))
+        return instance
+

--- a/dateutil/tz/_factories.py
+++ b/dateutil/tz/_factories.py
@@ -11,8 +11,13 @@ class _TzSingleton(type):
             cls.__instance = super(_TzSingleton, cls).__call__()
         return cls.__instance
 
+class _TzFactory(type):
+    def instance(cls, *args, **kwargs):
+        """Alternate constructor that returns a fresh instance"""
+        return type.__call__(cls, *args, **kwargs)
 
-class _TzOffsetFactory(type):
+
+class _TzOffsetFactory(_TzFactory):
     def __init__(cls, *args, **kwargs):
         cls.__instances = {}
 
@@ -24,11 +29,12 @@ class _TzOffsetFactory(type):
 
         instance = cls.__instances.get(key, None)
         if instance is None:
-            instance = cls.__instances.setdefault(key, type.__call__(cls, name, offset))
+            instance = cls.__instances.setdefault(key,
+                                                  cls.instance(name, offset))
         return instance
 
 
-class _TzStrFactory(type):
+class _TzStrFactory(_TzFactory):
     def __init__(cls, *args, **kwargs):
         cls.__instances = {}
 
@@ -38,6 +44,6 @@ class _TzStrFactory(type):
 
         if instance is None:
             instance = cls.__instances.setdefault(key,
-                type.__call__(cls, s, posix_offset))
+                cls.instance(s, posix_offset))
         return instance
 

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -22,7 +22,7 @@ from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs
 
 from ._factories import _TzSingleton, _TzOffsetFactory
-
+from ._factories import _TzStrFactory
 try:
     from .win import tzwin, tzwinlocal
 except ImportError:
@@ -966,6 +966,7 @@ class tzrange(tzrangebase):
         return self._dst_base_offset_
 
 
+@six.add_metaclass(_TzStrFactory)
 class tzstr(tzrange):
     """
     ``tzstr`` objects are time zone objects specified by a time-zone string as

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1398,80 +1398,114 @@ else:
     TZFILES = []
     TZPATHS = []
 
+def __get_gettz():
+    tzlocal_classes = (tzlocal,)
+    if tzwinlocal is not None:
+        tzlocal_classes += (tzwinlocal,)
 
-def gettz(name=None):
-    tz = None
-    if not name:
-        try:
-            name = os.environ["TZ"]
-        except KeyError:
-            pass
-    if name is None or name == ":":
-        for filepath in TZFILES:
-            if not os.path.isabs(filepath):
-                filename = filepath
-                for path in TZPATHS:
-                    filepath = os.path.join(path, filename)
+    class GettzFunc(object):
+        def __init__(self):
+
+            self.__instances = {}
+            self._cache_lock = _thread.allocate_lock()
+
+        def __call__(self, name=None):
+            with self._cache_lock:
+                rv = self.__instances.get(name, None)
+
+                if rv is None:
+                    rv = self.nocache(name=name)
+                    if not (name is None or isinstance(rv, tzlocal_classes)):
+                        # tzlocal is slightly more complicated than the other
+                        # time zone providers because it depends on environment
+                        # at construction time, so don't cache that.
+                        self.__instances[name] = rv
+
+            return rv
+
+        def cache_clear(self):
+            with self._cache_lock:
+                self.__instances = {}
+
+        @staticmethod
+        def nocache(name=None):
+            """A non-cached version of gettz"""
+            tz = None
+            if not name:
+                try:
+                    name = os.environ["TZ"]
+                except KeyError:
+                    pass
+            if name is None or name == ":":
+                for filepath in TZFILES:
+                    if not os.path.isabs(filepath):
+                        filename = filepath
+                        for path in TZPATHS:
+                            filepath = os.path.join(path, filename)
+                            if os.path.isfile(filepath):
+                                break
+                        else:
+                            continue
                     if os.path.isfile(filepath):
-                        break
-                else:
-                    continue
-            if os.path.isfile(filepath):
-                try:
-                    tz = tzfile(filepath)
-                    break
-                except (IOError, OSError, ValueError):
-                    pass
-        else:
-            tz = tzlocal()
-    else:
-        if name.startswith(":"):
-            name = name[1:]
-        if os.path.isabs(name):
-            if os.path.isfile(name):
-                tz = tzfile(name)
-            else:
-                tz = None
-        else:
-            for path in TZPATHS:
-                filepath = os.path.join(path, name)
-                if not os.path.isfile(filepath):
-                    filepath = filepath.replace(' ', '_')
-                    if not os.path.isfile(filepath):
-                        continue
-                try:
-                    tz = tzfile(filepath)
-                    break
-                except (IOError, OSError, ValueError):
-                    pass
-            else:
-                tz = None
-                if tzwin is not None:
-                    try:
-                        tz = tzwin(name)
-                    except WindowsError:
-                        tz = None
-
-                if not tz:
-                    from dateutil.zoneinfo import get_zonefile_instance
-                    tz = get_zonefile_instance().get(name)
-
-                if not tz:
-                    for c in name:
-                        # name must have at least one offset to be a tzstr
-                        if c in "0123456789":
-                            try:
-                                tz = tzstr(name)
-                            except ValueError:
-                                pass
+                        try:
+                            tz = tzfile(filepath)
                             break
+                        except (IOError, OSError, ValueError):
+                            pass
+                else:
+                    tz = tzlocal()
+            else:
+                if name.startswith(":"):
+                    name = name[1:]
+                if os.path.isabs(name):
+                    if os.path.isfile(name):
+                        tz = tzfile(name)
                     else:
-                        if name in ("GMT", "UTC"):
-                            tz = tzutc()
-                        elif name in time.tzname:
-                            tz = tzlocal()
-    return tz
+                        tz = None
+                else:
+                    for path in TZPATHS:
+                        filepath = os.path.join(path, name)
+                        if not os.path.isfile(filepath):
+                            filepath = filepath.replace(' ', '_')
+                            if not os.path.isfile(filepath):
+                                continue
+                        try:
+                            tz = tzfile(filepath)
+                            break
+                        except (IOError, OSError, ValueError):
+                            pass
+                    else:
+                        tz = None
+                        if tzwin is not None:
+                            try:
+                                tz = tzwin(name)
+                            except WindowsError:
+                                tz = None
 
+                        if not tz:
+                            from dateutil.zoneinfo import get_zonefile_instance
+                            tz = get_zonefile_instance().get(name)
+
+                        if not tz:
+                            for c in name:
+                                # name must have at least one offset to be a tzstr
+                                if c in "0123456789":
+                                    try:
+                                        tz = tzstr(name)
+                                    except ValueError:
+                                        pass
+                                    break
+                            else:
+                                if name in ("GMT", "UTC"):
+                                    tz = tzutc()
+                                elif name in time.tzname:
+                                    tz = tzlocal()
+            return tz
+
+    return GettzFunc()
+
+gettz = __get_gettz()
+del __get_gettz
 
 def datetime_exists(dt, tz=None):
     """


### PR DESCRIPTION
For the upcoming 2.7.0 release, I think it's important for at least `tz.gettz` to return the same zone for the same inputs unless otherwise specified.

This PR makes `tzstr` a singleton, adds caching to `tz.gettz` and adds the `.instance` alternate constructor for `tzoffset` and `tzstr`.

I did not bother with a `.instance` alternate constructor for `tzutc`, because the semantics of `tzutc` are not affected by inter- and intra-zone comparisons (technically true of `tzoffset` as well, too).