### PR TITLE
Fix license trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ datetime module available in the Python standard library.
           'Development Status :: 5 - Production/Stable',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: BSD License',
+          'License :: OSI Approved :: Apache Software License',
           'Programming Language :: Python',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
Missed this in the switchover from BSD to Apache.