### PR TITLE
Catch non-ValueError exceptions in decimal

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -836,7 +836,11 @@ class parser(object):
     def _parse_numeric_token(self, tokens, idx, info, ymd, res, fuzzy):
         # Token is a number
         value_repr = tokens[idx]
-        value = Decimal(value_repr)
+        try:
+            value = self._to_decimal(value_repr)
+        except Exception as e:
+            six.raise_from(ValueError('Unknown numeric token'), e)
+
         len_li = len(value_repr)
 
         len_l = len(tokens)
@@ -895,7 +899,7 @@ class parser(object):
         elif idx + 2 < len_l and tokens[idx + 1] == ':':
             # HH:MM[:SS[.ss]]
             res.hour = int(value)
-            value = Decimal(tokens[idx + 2])  # TODO: try/except for this?
+            value = self._to_decimal(tokens[idx + 2])  # TODO: try/except for this?
             (res.minute, res.second) = self._parse_min_sec(value)
 
             if idx + 4 < len_l and tokens[idx + 3] == ':':
@@ -996,7 +1000,7 @@ class parser(object):
 
     def _assign_hms(self, res, value_repr, hms):
         # See GH issue #427, fixing float rounding
-        value = Decimal(value_repr)
+        value = self._to_decimal(value_repr)
 
         if hms == 0:
             # Hour
@@ -1195,6 +1199,13 @@ class parser(object):
                 return new_dt
 
         return dt
+
+    def _to_decimal(self, val):
+        try:
+            return Decimal(val)
+        except Exception as e:
+            msg = "Could not convert %s to decimal" % val
+            six.raise_from(ValueError(msg), e)
 
 
 DEFAULTPARSER = parser()

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -1091,3 +1091,11 @@ def test_parse_tzinfos_fold():
 ])
 def test_rounding_floatlike_strings(dtstr, dt):
     assert parse(dtstr, default=datetime(2003, 9, 25)) == dt
+
+
+def test_decimal_error():
+    # GH 632 - decimal.Decimal raises some non-ValueError exception when
+    # constructed with an invalid value
+    with pytest.raises(ValueError):
+        parse('1: test')
+


### PR DESCRIPTION
Fixes #632.

This adds both function call overhead and exception catching overhead to the function. Based on running `%timeit` on a few strings, the cost is on the order of a few microseconds out of 60-100 microseconds. If we can come up with a version that doesn't have to re-raise, that might be preferable.

Also, we could theoretically add whatever errors `Decimal` is raising into the huge try-except loop and handle it that way, but the documentation doesn't seem to clearly enumerate an exception hierarchy for `decimal.Decimal`, so I'm not confident that we could catch the "root" exception easily. 