### PR TITLE
Add towncrier for changelog management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,32 @@ If you would like to fix something in `dateutil` -  improvements to documentatio
 
 The most important thing to include in your pull request are *tests* - please write one or more tests to cover the behavior you intend your patch to improve. Ideally, tests would use only the public interface - try to get 100% difference coverage using only supported behavior of the API.
 
+#### Changelog
+To keep users abreast of the changes to the module and to give proper credit, `dateutil` maintains a changelog, which is managed by [towncrier](https://github.com/hawkowl/towncrier). To add a changelog entry, make a new file called `<issue_no>.<type>.rst`, where `<issue_no>` is the number of the PR you've just made (it's easiest to add the changelog *after* you've created the PR so you'll have this number), and `<type>` is one of the following types:
+
+- `feature`: A new feature, (e.g. a new function, method, attribute, etc)
+- `bugfix`: A fix to a bug
+- `doc`: A change to the documentation
+- `deprecation`: Used if deprecating a feature or dropping support for a Python version.
+- `misc`: A change that has no interesting effect for end users, such as fixes to the test suite or CI.
+
+PRs that include a feature or bugfix *and* a deprecation should create a separate entry for the deprecation.
+
+
+
+> {description of changes}. Reported by @{reporter} (gh issue #{issue\_no}). Fixed by @{patch submitter} (gh pr #{pr\_no})
+
+An example changelog entry might be:
+
+**581.bugfix.rst**
+```
+Fixed issue where the tz.tzstr constructor would erroneously succeed if passed
+an invalid value for tzstr. Reported by @pganssle (gh issue #259). Fixed by
+@pablogsal (gh pr #581)
+```
+
+For bugs reported and fixed by the same person use "Reported and fixed by @{patch submitter}". It is not necessary to create a github issue just for the purpose of mentioning it in the changelog, if the PR *is* the report, mentioning the PR is enough.
+
 ## License
 
 Starting December 1, 2017, all contributions will be assumed to be released under a dual license - the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0) and the [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause) unless otherwise specified in the pull request.

--- a/changelog.d/template.rst
+++ b/changelog.d/template.rst
@@ -1,0 +1,33 @@
+{% for section, _ in sections.items() %}
+{% set underline = underlines[0] %}{% if section %}{{section}}
+{{ underline * section|length }}{% set underline = underlines[1] %}
+
+{% endif %}
+
+{% if sections[section] %}
+{% for category, val in definitions.items() if category in sections[section]%}
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
+
+{% if definitions[category]['showcontent'] %}
+{% for text, values in sections[section][category].items() %}
+- {{ text }}
+{% endfor %}
+
+{% else %}
+- {{ sections[section][category]['']|join(', ') }}
+
+{% endif %}
+{% if sections[section][category]|length == 0 %}
+No significant changes.
+
+{% else %}
+{% endif %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+
+{% endif %}
+{% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[tool.towncrier]
+    package = "dateutil"
+    package_dir = "dateutil"
+    filename = "NEWS"
+    directory = "changelog.d"
+    issue_format = "GH #{issue}"
+    template = "changelog.d/template.rst"
+
+    [[tool.towncrier.type]]
+        directory = "data"
+        name = "Data updates"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "deprecations"
+        name = "Deprecations"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "feature"
+        name = "Features"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "bugfix"
+        name = "Bugfixes"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "doc"
+        name = "Documentation changes"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "misc"
+        name = "Misc"
+        showcontent = false
+


### PR DESCRIPTION
Fixes #592.

At the moment town crier seems like the best option out there for changelog management. It does pretty much what I want, except I don't think the ticket-based workflow definitely works for this project.

Ideally we'd have something like town crier that allows additional metadata to be specified in the `.rst` so that I can add "reporter", "pr", "issue" and "patch submitter". Also, it would be nice to be able to specify an "issue template" so users could do something like `towncrier entry` and it would maybe ask a few questions then generate a basic template.

Still, this is waaaay better than what I've been doing, and seem better than anything else out there.