### PR TITLE
Add changelog entries for changes since 2.7.0

### DIFF
--- a/changelog.d/0633.bugfix.rst
+++ b/changelog.d/0633.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue where parser.parse would occasionally raise decimal.Decimal-specific error types rather than ValueError. Reported by @amureki (gh issue #632). Fixed by @pganssle (gh pr #636).

--- a/changelog.d/0634.bugfix.rst
+++ b/changelog.d/0634.bugfix.rst
@@ -1,0 +1,1 @@
+Improve error message when rrule's dtstart and until are not both naive or both aware. Reported and fixed by @ryanpetrello (gh issue #633, gh pr #634)

--- a/changelog.d/0643.data.rst
+++ b/changelog.d/0643.data.rst
@@ -1,0 +1,1 @@
+Updated tzdata version to 2018d.

--- a/changelog.d/0644.misc.rst
+++ b/changelog.d/0644.misc.rst
@@ -1,0 +1,1 @@
+Updated license metadata and trove classifiers (gh prs #630 and #644).


### PR DESCRIPTION
Backfill of the town crier log now that #645 is merged.