### PR TITLE
Remove old news fragments

### DIFF
--- a/changelog.d/0633.bugfix.rst
+++ b/changelog.d/0633.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed issue where parser.parse would occasionally raise decimal.Decimal-specific error types rather than ValueError. Reported by @amureki (gh issue #632). Fixed by @pganssle (gh pr #636).

--- a/changelog.d/0634.bugfix.rst
+++ b/changelog.d/0634.bugfix.rst
@@ -1,1 +1,0 @@
-Improve error message when rrule's dtstart and until are not both naive or both aware. Reported and fixed by @ryanpetrello (gh issue #633, gh pr #634)

--- a/changelog.d/0643.data.rst
+++ b/changelog.d/0643.data.rst
@@ -1,1 +1,0 @@
-Updated tzdata version to 2018d.

--- a/changelog.d/0644.misc.rst
+++ b/changelog.d/0644.misc.rst
@@ -1,1 +1,0 @@
-Updated license metadata and trove classifiers (gh prs #630 and #644).

--- a/changelog.d/648.misc
+++ b/changelog.d/648.misc
@@ -1,1 +1,0 @@
-Added README contents to the setup.py metadata. (gh pr #648)


### PR DESCRIPTION
There was some bug and towncrier did not remove these, and I forgot to do it manually.