### PR TITLE
Open README.rst with utf-8 encoding

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -57,6 +57,7 @@ switch, and thus all their contributions are dual-licensed.
 - Pascal van Kooten <kootenpv@MASKED>
 - Pavel Ponomarev <comrad.awsum@MASKED>
 - Peter Bieringer <pb@MASKED>
+- Pierre Gergondet <pierre.gergondet@MASKED> (gh: @gergondet)
 - Quentin Pradet <quentin@MASKED>
 - Roy Williams <rwilliams@MASKED>
 - Savraj <savraj@MASKED>

--- a/changelog.d/651.misc.rst
+++ b/changelog.d/651.misc.rst
@@ -1,0 +1,1 @@
+Fixed an issue with the setup script running in non-UTF-8 environment. Reported and fixed by @gergondet (gh pr #651)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,8 @@ from setuptools.command.test import test as TestCommand
 from distutils.version import LooseVersion
 import warnings
 
+import io
+
 if isfile("MANIFEST"):
     os.unlink("MANIFEST")
 
@@ -27,7 +29,7 @@ class Unsupported(TestCommand):
 PACKAGES = find_packages(where='.', exclude=['dateutil.test'])
 
 def README():
-    with open('README.rst') as f:
+    with io.open('README.rst', encoding='utf-8') as f:
         readme_lines = f.readlines()
 
     # The .. doctest directive is not supported by PyPA


### PR DESCRIPTION
With the current setup script, the build fails (I only tested with Python 3.4) in a non-UTF-8 environment

e.g. `LC_ALL=C pip3 install .` fails prior to this patch

This fails because `open` uses the system encoding by default and the `README.rst` file contains non-ascii characters.

This PR enforces the opening of `README.rst` with the UTF-8 encoding. This fixes the build when running the setup script on non-UTF-8 setups.
