### PR TITLE
Update readme links to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ dateutil - powerful extensions to datetime
 ==========================================
 
 .. image:: https://img.shields.io/pypi/v/python-dateutil.svg?style=flat-square
-    :target: https://pypi.python.org/pypi/python-dateutil/
+    :target: https://pypi.org/project/python-dateutil/
     :alt: pypi version
 
 .. image:: https://img.shields.io/travis/dateutil/dateutil/master.svg?style=flat-square
@@ -29,13 +29,14 @@ the standard `datetime` module, available in Python.
 Download
 ========
 dateutil is available on PyPI
-https://pypi.python.org/pypi/python-dateutil/
+https://pypi.org/project/python-dateutil/
 
 The documentation is hosted at:
 https://dateutil.readthedocs.io/en/stable/
 
 Code
 ====
+The code and issue tracker are hosted on Github:
 https://github.com/dateutil/dateutil/
 
 Features

--- a/changelog.d/655.misc
+++ b/changelog.d/655.misc
@@ -1,0 +1,1 @@
+Update PyPI links to point to pypi.org.


### PR DESCRIPTION
Warehouse seems definitely mature enough that we should be linking to it rather than the old PyPI.

Correct me if I'm wrong @ewdurbin, but I think it's time for this.