### PR TITLE
Catch infinite decimal values in `_is_decimal` (fix #662)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -61,6 +61,7 @@ switch, and thus all their contributions are dual-licensed.
 - Pierre Gergondet <pierre.gergondet@MASKED> (gh: @gergondet)
 - Quentin Pradet <quentin@MASKED>
 - Roy Williams <rwilliams@MASKED>
+- Rustem Saiargaliev (gh: @amureki) **D**
 - Savraj <savraj@MASKED>
 - Sergey Vishnikin <armicron@MASKED>
 - Stefan Bonchev **D**

--- a/changelog.d/0679.bugfix.rst
+++ b/changelog.d/0679.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where decimal.Decimal would cast `NaN` or infinite value in a parser.parse, which will raise decimal.Decimal-specific errors. Reported and fixed by @amureki (gh issue #662, gh pr #679).

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1206,11 +1206,11 @@ class parser(object):
             # See GH 662, edge case, infinite value should not be converted via `_to_decimal`
             if not decimal_value.is_finite():
                 raise ValueError("Converted decimal value is infinite or NaN")
-
-            return decimal_value
         except Exception as e:
             msg = "Could not convert %s to decimal" % val
             six.raise_from(ValueError(msg), e)
+        else:
+            return decimal_value
 
 
 DEFAULTPARSER = parser()

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1202,7 +1202,12 @@ class parser(object):
 
     def _to_decimal(self, val):
         try:
-            return Decimal(val)
+            decimal_value = Decimal(val)
+            # See GH 662, edge case, infinite value should not be converted via `_to_decimal`
+            if not decimal_value.is_finite():
+                raise ValueError("Converted decimal value is infinite or NaN")
+
+            return decimal_value
         except Exception as e:
             msg = "Could not convert %s to decimal" % val
             six.raise_from(ValueError(msg), e)

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -1093,9 +1093,9 @@ def test_rounding_floatlike_strings(dtstr, dt):
     assert parse(dtstr, default=datetime(2003, 9, 25)) == dt
 
 
-def test_decimal_error():
-    # GH 632 - decimal.Decimal raises some non-ValueError exception when
+@pytest.mark.parametrize('value', ['1: test', 'Nan'])
+def test_decimal_error(value):
+    # GH 632, GH 662 - decimal.Decimal raises some non-ValueError exception when
     # constructed with an invalid value
     with pytest.raises(ValueError):
-        parse('1: test')
-
+        parse(value)


### PR DESCRIPTION
This fixes an edge case for decimal parsing.
When we are receiving `Nan` or infinite value in `_to_decimal` (which theoretically should not be possible), we are raising a `ValueError`, instead of continuing with it.

Thank you @pganssle for the suggestion, please, check if this solution fits well.