### PR TITLE
661 tzinfos could be None in call to parse

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -59,6 +59,7 @@ switch, and thus all their contributions are dual-licensed.
 - Michael J. Schultz <mjschultz@MASKED>
 - Mike Gilbert <floppym@MASKED>
 - Nick Smith <nick.smith@MASKED>
+- Orson Adams <orson.network@MASKED> (gh: @parsethis)
 - Paul Ganssle <paul@ganssle.io> (gh: @pganssle) **R**
 - Pascal van Kooten <kootenpv@MASKED>
 - Pavel Ponomarev <comrad.awsum@MASKED>

--- a/changelog.d/681.bugfix.rst
+++ b/changelog.d/681.bugfix.rst
@@ -1,0 +1,4 @@
+**681.bugfix.rst**
+```
+Fixed a ValueError being thrown if tzinfos call explicity returns `None`. User should 
+be able to opt out of passing in tzinfos argment parse. Reported by @pganssle (gh issue #661) Fixed by @parsethis (gh pr #681)

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1125,16 +1125,14 @@ class parser(object):
             tzdata = tzinfos(tzname, tzoffset)
         else:
             tzdata = tzinfos.get(tzname)
-
-        if isinstance(tzdata, datetime.tzinfo):
+        # handle case where tzinfo is paased an options that returns None
+        # eg tzinfos = {'BRST' : None}
+        if isinstance(tzdata, datetime.tzinfo) or tzdata is None:
             tzinfo = tzdata
         elif isinstance(tzdata, text_type):
             tzinfo = tz.tzstr(tzdata)
         elif isinstance(tzdata, integer_types):
             tzinfo = tz.tzoffset(tzname, tzdata)
-        else:
-            raise ValueError("Offset must be tzinfo subclass, "
-                             "tz string, or int offset.")
         return tzinfo
 
     def _build_tzaware(self, naive, res, tzinfos):
@@ -1170,7 +1168,7 @@ class parser(object):
             warnings.warn("tzname {tzname} identified but not understood.  "
                           "Pass `tzinfos` argument in order to correctly "
                           "return a timezone-aware datetime.  In a future "
-                          "version, this raise an "
+                          "version, this will raise an "
                           "exception.".format(tzname=res.tzname),
                           category=UnknownTimezoneWarning)
             aware = naive

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -170,7 +170,6 @@ class ParserTest(unittest.TestCase):
                                    tzinfos={"BRST": long(-10800)}),
                              datetime(2003, 9, 25, 10, 36, 28,
                                       tzinfo=self.brsttz))
-
     def testDateCommandFormatIgnoreTz(self):
         self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
                                ignoretz=True),
@@ -747,6 +746,14 @@ class ParserTest(unittest.TestCase):
     def testUnspecifiedDayFallbackFebLeapYear(self):
         self.assertEqual(parse("Feb 2008", default=datetime(2010, 1, 31)),
                          datetime(2008, 2, 29))
+
+    def testTzinfoDictionaryCouldReturnNone(self):
+        self.assertEqual(parse('2017-02-03 12:40 BRST', tzinfos={"BRST": None}),
+                        datetime(2017, 2, 3, 12, 40))
+
+    def testTzinfosCallableCouldReturnNone(self):
+        self.assertEqual(parse('2017-02-03 12:40 BRST', tzinfos=lambda *args: None),
+                                    datetime(2017, 2, 3, 12, 40))
 
     def testErrorType01(self):
         self.assertRaises(ValueError,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Return `None` if the user would like to ignore the timezone in the date parse.
Fix typo in warning in `_build_tzaware` 

This is a WIP on #661.
 
Closes #661

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
