### PR TITLE
Add hypothesis tests for isoparse

### DIFF
--- a/changelog.d/688.misc.rst
+++ b/changelog.d/688.misc.rst
@@ -1,0 +1,1 @@
+Add a test for the property that ``dateutil.parser.parse`` will support inversion of ``datetime.isoformat()`` so long as ``sep`` is an ASCII character. Added by @pganssle (gh pr #688)

--- a/dateutil/test/property/test_isoparse_prop.py
+++ b/dateutil/test/property/test_isoparse_prop.py
@@ -1,0 +1,27 @@
+from hypothesis import given, assume
+from hypothesis import strategies as st
+
+from dateutil import tz
+from dateutil.parser import isoparse
+
+import pytest
+
+# Strategies
+TIME_ZONE_STRATEGY = st.sampled_from([None, tz.tzutc()] +
+    [tz.gettz(zname) for zname in ('US/Eastern', 'US/Pacific',
+                                   'Australia/Sydney', 'Europe/London')])
+ASCII_STRATEGY = st.characters(max_codepoint=127)
+
+
+@pytest.mark.isoparser
+@given(dt=st.datetimes(timezones=TIME_ZONE_STRATEGY), sep=ASCII_STRATEGY)
+def test_timespec_auto(dt, sep):
+    if dt.tzinfo is not None:
+        # Assume offset has no sub-second components
+        assume(dt.utcoffset().total_seconds() % 60 == 0)
+
+    sep = str(sep)          # Python 2.7 requires bytes
+    dtstr = dt.isoformat(sep=sep)
+    dt_rt = isoparse(dtstr)
+
+    assert dt_rt == dt


### PR DESCRIPTION
## Summary of changes
Tests the property that `dateutil.parser.parse` will support inversion of `dt.isoformat()` in the somewhat limiting case that `sep` is an ASCII character.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
