### PR TITLE
Update version added documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tzdata*.tar.gz
 
 .idea
 .cache
+.mypy_cache

--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -4,6 +4,8 @@ This module offers a parser for ISO-8601 strings
 
 It is intended to support all valid date, time and datetime formats per the
 ISO-8601 specification.
+
+..versionadded:: 2.7.0
 """
 from datetime import datetime, timedelta, time, date
 import calendar
@@ -124,6 +126,8 @@ class isoparser(object):
             currently fail (e.g. ``2017-01-01T00:00+00:00:00``) are not
             guaranteed to continue failing in future versions if they encode
             a valid date.
+
+        .. versionadded:: 2.7.0
         """
         components, pos = self._parse_isodate(dt_str)
 

--- a/dateutil/utils.py
+++ b/dateutil/utils.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+This module offers general convenience and utility functions for dealing with
+datetimes.
+
+.. versionadded:: 2.7.0
+"""
 from __future__ import unicode_literals
 
 from datetime import datetime, time


### PR DESCRIPTION
## Summary of changes
Neither isoparse nor the utils module were documented as being added in 2.7.0 before this.

Closes #625

I also piggy-backed adding `.mypy_cache` into the gitignore on this PR.