### PR TITLE
Add linkcheck options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ previous release. A table of release signing keys can be found below:
 ===========  ============================
 Releases     Signing key fingerprint
 ===========  ============================
-2.4.1-       `6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB`_
+2.4.1-       `6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB`_ (|pgp_mirror|_)
 ===========  ============================
 
 
@@ -154,3 +154,5 @@ All contributions after December 1, 2017 released under dual license - either `A
 .. _6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB:
    https://pgp.mit.edu/pks/lookup?op=vindex&search=0xCD54FCE3D964BEFB
 
+.. |pgp_mirror| replace:: mirror
+.. _pgp_mirror: https://sks-keyservers.net/pks/lookup?op=vindex&search=0xCD54FCE3D964BEFB

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -264,3 +264,12 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+# -- Link checking options -------------------------------------------------
+linkcheck_ignore = [
+    # This has been spotty lately so we're adding a mirror
+    r'https://pgp.mit.edu',
+]
+
+# Reduce problems with ephemeral failures
+linkcheck_retries = 5


### PR DESCRIPTION
## Summary of changes
Rather than removing the pgp.mit.edu link, I've kept it as the primary link, but added a mirror to sks-keyservers.net. To avoid the intermittent failure problems, I've increased the number of retries for `linkcheck` and started ignoring the now-flaky pgp.mit.edu as part of the linkcheck.

The question of whether these linkchecks should be required for every PR review is still open, but I'll address that separately later if it continues to cause problems.

Fixes #694