### PR TITLE
Fix for B.Y.d format corner case #687

### DIFF
--- a/changelog.d/687.bugfix.rst
+++ b/changelog.d/687.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed incorrect parsing of dates of the form "%B.%Y.%d", e.g. "December.0031.30".

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -458,9 +458,35 @@ class _ymd(list):
                 raise ValueError('Year is already set')
             self.ystridx = len(self) - 1
 
+    def _resolve_from_stridxs(self):
+        """
+        Try to resolve the identities of year/month/day elements using
+        ystridx, mstridx, and dstridx, if enough of these are specified.
+        """
+        strids = {'y': self.ystridx, 'm': self.mstridx, 'd': self.dstridx}
+        strids = {key: strids[key] for key in strids if strids[key] is not None}
+
+        if len(self) == 3 and len(strids) == 2:
+            # we can back out the remaining stridx value
+            missing = [x for x in range(3) if x not in strids.values()]
+            key = [x for x in ['y', 'm', 'd'] if x not in strids]
+            assert len(missing) == len(key) == 1
+            key = key[0]
+            val = missing[0]
+            strids[key] = val
+
+        assert len(self) == len(strids)  # otherwise this should not be called
+        return tuple([self[strids[key]] for key in ['y', 'm', 'd']
+                      if key in strids])
+
     def resolve_ymd(self, yearfirst, dayfirst):
         len_ymd = len(self)
         year, month, day = (None, None, None)
+
+        strids = {'y': self.ystridx, 'm': self.mstridx, 'd': self.dstridx}
+        strids = {key: strids[key] for key in strids if strids[key] is not None}
+        if len(self) == len(strids) or (len(self) == 3 and len(strids) == 2):
+            return self._resolve_from_stridxs()
 
         mstridx = self.mstridx
 

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -1106,3 +1106,9 @@ def test_decimal_error(value):
     # constructed with an invalid value
     with pytest.raises(ValueError):
         parse(value)
+
+
+def test_BYd_corner_case():
+    # GH#687
+    res = parse('December.0031.30')
+    assert res == datetime(31, 12, 30)


### PR DESCRIPTION
## Summary of changes

<!-- Summary goes here -->
At the moment `_ymd.resolve_ymd` can ignore `ystridx` and `dstridx` in some corner cases.  This PR has resolve_ymd check if enough of [ystridx, mstridx, dstridx] have been specified to uniquely pin down (year, month, day), and if so, use those instead of other heuristics.

Closes #687

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
