### PR TITLE
Add test for repr of named fileobject in tzfile

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,6 +25,7 @@ switch, and thus all their contributions are dual-licensed.
 - Brock Mendel <jbrockmendel@MASKED> (gh: @jbrockmendel) **R**
 - Brook Li (gh: @absreim) **D**
 - Carlos <carlosxl@MASKED>
+- Chris van den Berg (gh: bergvca) **D**
 - Christopher Cordero <ccordero@pm.me> (gh: cs-cordero) **D**
 - Christopher Corley <cscorley@MASKED>
 - Claudio Canepa <ccanepacc@MASKED>

--- a/changelog.d/699.misc.rst
+++ b/changelog.d/699.misc.rst
@@ -1,0 +1,2 @@
+Added unittest to check if tz's objects repr contains the "name" attribute of an input fileobject.
+Added by @Bergvca (gh pr #699)

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1900,12 +1900,13 @@ class TZTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             tz.tzfile(BytesIO(b'BadFile'))
 
-    def testFilenameFromAttribute(self):
-        # Should set tz object's filename equal to a file "name" attribute
+    def testFilestreamWithNameRepr(self):
+        # If fileobj is a filestream with a "name" attribute this name should
+        # be reflected in the tz object's repr
         fileobj = BytesIO(base64.b64decode(TZFILE_EST5EDT))
         fileobj.name = 'foo'
         tzc = tz.tzfile(fileobj)
-        self.assertEqual(tzc._filename, 'foo')
+        self.assertEqual(repr(tzc), 'tzfile(' + repr('foo') + ')')
 
     def testRoundNonFullMinutes(self):
         # This timezone has an offset of 5992 seconds in 1900-01-01.

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1900,6 +1900,13 @@ class TZTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             tz.tzfile(BytesIO(b'BadFile'))
 
+    def testFilenameFromAttribute(self):
+        # Should set tz object's filename equal to a file "name" attribute
+        fileobj = BytesIO(base64.b64decode(TZFILE_EST5EDT))
+        fileobj.name = 'foo'
+        tzc = tz.tzfile(fileobj)
+        self.assertEqual(tzc._filename, 'foo')
+
     def testRoundNonFullMinutes(self):
         # This timezone has an offset of 5992 seconds in 1900-01-01.
         tzc = tz.tzfile(BytesIO(base64.b64decode(EUROPE_HELSINKI)))


### PR DESCRIPTION
## Summary of changes

Added unittest to check if tz's objects "_filename" attribute is equal to the "name" object of an input fileobject.

Closes <!-- issue number here -->
N/a - related to *Get coverage to 100%* (#521)
### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
