### PR TITLE
Add changelog to documentation

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -162,7 +162,7 @@ Version 2.7.0
 - Style improvement to zoneinfo.tzfile that was confusing to static type
   checkers. Reported and fixed by @quodlibetor (gh pr #485)
 - Several unused imports were removed by @jdufresne. (gh pr #486)
-- Switched isinstance(*, collections.Callable) to callable, which is available
+- Switched ``isinstance(*, collections.Callable)`` to callable, which is available
   on all supported Python versions. Implemented by @jdufresne (gh pr #612)
 - Added CONTRIBUTING.md (gh pr #533)
 - Added AUTHORS.md (gh pr #542)
@@ -609,7 +609,7 @@ Version 0.9
   Andreas Köhler.
 
 - Implemented internal timezone information with binary
-  timezone files [1]. datautil.tz.gettz() function will now
+  timezone files. datautil.tz.gettz() function will now
   try to use the system timezone files, and fallback to
   the internal versions. It's also possible to ask for
   the internal versions directly by using
@@ -628,13 +628,11 @@ Version 0.9
 
 - Fixed other reported bugs.
 
-[1] http://www.twinsun.com/tz/tz-link.htm
-
 
 Version 0.5
 ===========
 
-- Removed FREQ_ prefix from rrule frequency constants
+- Removed ``FREQ_`` prefix from rrule frequency constants
   WARNING: this breaks compatibility with previous versions.
 
 - Fixed rrule.between() for cases where "after" is achieved

--- a/changelog.d/692.doc.rst
+++ b/changelog.d/692.doc.rst
@@ -1,0 +1,1 @@
+Added changelog to documentation. (gh issue #692, gh pr #707)

--- a/changelog.d/707.doc.rst
+++ b/changelog.d/707.doc.rst
@@ -1,0 +1,1 @@
+Changed the default theme to sphinx_rtd_theme, and changed the sphinx configuration to go along with that. (gh pr #707)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,7 @@
+.. Changelog transcluded from the NEWS file
+
+=========
+Changelog
+=========
+
+.. include:: ../NEWS

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,7 +106,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,9 +11,14 @@ Documentation
 Contents:
 
 .. toctree::
+   :maxdepth: 1
+
+   Overview <self>
+   Changelog <changelog>
+
+.. toctree::
    :maxdepth: 2
 
-   self
    easter
    parser
    relativedelta

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,0 +1,2 @@
+Sphinx>=1.7.3,<2
+sphinx_rtd_theme>=0.3.0

--- a/tox.ini
+++ b/tox.ini
@@ -53,7 +53,7 @@ show_missing = True
 [testenv:docs]
 description = invoke sphinx-build to build the HTML docs, check that URIs are valid
 basepython = python3.6
-deps = sphinx >= 1.6.3, < 2
+deps = -r docs/requirements-docs.txt
        {[testenv]deps}
 commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" {posargs:-W --color -bhtml}
            sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" {posargs:-W --color -blinkcheck}


### PR DESCRIPTION
## Summary of changes
Adds the changelog to the documentation.

While I was in there I also changed the default documentation build to use the sphinx_rtd_theme, and some configuration changes to go with that.

Closes #692

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
