### PR TITLE
Restructure tz docs

### DIFF
--- a/changelog.d/714.doc.rst
+++ b/changelog.d/714.doc.rst
@@ -1,0 +1,1 @@
+Reorganized ``dateutil.tz`` documentation and fixed issue with the ``dateutil.tz`` docstring. (gh pr #714)

--- a/dateutil/tz/__init__.py
+++ b/dateutil/tz/__init__.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from .tz import *
+from .tz import __doc__
 
 #: Convenience constant providing a :class:`tzutc()` instance
 #:

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
 This module offers timezone implementations subclassing the abstract
-:py:`datetime.tzinfo` type. There are classes to handle tzfile format files
-(usually are in :file:`/etc/localtime`, :file:`/usr/share/zoneinfo`, etc), TZ
-environment string (in all known formats), given ranges (with help from
-relative deltas), local machine timezone, fixed offset timezone, and UTC
+:py:class:`datetime.tzinfo` type. There are classes to handle tzfile format
+files (usually are in :file:`/etc/localtime`, :file:`/usr/share/zoneinfo`,
+etc), TZ environment string (in all known formats), given ranges (with help
+from relative deltas), local machine timezone, fixed offset timezone, and UTC
 timezone.
 """
 import datetime

--- a/docs/tz.rst
+++ b/docs/tz.rst
@@ -1,8 +1,44 @@
 ==
 tz
 ==
-.. autofunction:: dateutil.tz.gettz
+.. py:currentmodule:: dateutil.tz
 
 .. automodule:: dateutil.tz
-   :members:
-   :undoc-members:
+
+Objects
+-------
+.. py:data:: dateutil.tz.UTC
+
+    A convenience instance of :class:`dateutil.tz.tzutc`.
+
+Functions
+---------
+
+.. autofunction:: gettz
+
+    .. automethod:: gettz.nocache
+    .. automethod:: gettz.cache_clear
+
+.. autofunction:: enfold
+
+.. autofunction:: datetime_ambiguous
+.. autofunction:: datetime_exists
+
+.. autofunction:: resolve_imaginary
+
+
+Classes
+-------
+
+.. autoclass:: tzutc
+
+.. autoclass:: tzoffset
+
+.. autoclass:: tzlocal
+
+.. autoclass:: tzrange
+
+.. autoclass:: tzstr
+
+.. autoclass:: tzical
+    :members:


### PR DESCRIPTION
This is a light restructuring of the tz documentation because the automodule-generated stuff was not great to read.

The downside of using all these explicit directives is that if we forget to add something to `tz.rst` it won't get added to the documentation, but given how much stuff we've forgotten to document *anyway* we should probably be improving discipline on that anyway. At least this way we don't have to wait until the build is done to figure out if something is missing.