### PR TITLE
Revert weakref

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -26,7 +26,6 @@ switch, and thus all their contributions are dual-licensed.
 - Brook Li (gh: @absreim) **D**
 - Carlos <carlosxl@MASKED>
 - Chris van den Berg (gh: bergvca) **D**
-- Christopher Cordero <ccordero@pm.me> (gh: cs-cordero) **D**
 - Christopher Corley <cscorley@MASKED>
 - Claudio Canepa <ccanepacc@MASKED>
 - Corey Girard <corey.r.girard@gmail.com> (gh: @coreygirard)

--- a/changelog.d/672.bugfix.rst
+++ b/changelog.d/672.bugfix.rst
@@ -1,1 +1,0 @@
-Switched the ``tzoffset``, ``tzstr`` and ``gettz`` caches over to using weak references, so that the cache expires when no other references to the original ``tzinfo`` objects exist. This cache-expiry behavior is not considered part of the public interface and may change in the future. Requested by @pganssle (gh issue #635), implemented by @cs-cordero (gh pr #672).

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -14,7 +14,6 @@ import unittest
 import sys
 import base64
 import copy
-import gc
 
 from functools import partial
 
@@ -732,20 +731,6 @@ class TzOffsetTest(unittest.TestCase):
 
         assert tz1 is tz2
 
-    def testTzOffsetWeakRef(self):
-        UTC1 = tz.tzoffset('UTC', 0)
-        UTC2 = tz.tzoffset('UTC', 0)
-        assert id(UTC1) == id(UTC2)
-
-        weak_ref_id = id(UTC1)
-        del UTC1
-        del UTC2
-        gc.collect()
-
-        UTC3 = tz.tzoffset('UTC', 0)
-        assert not weak_ref_id == id(UTC3)
-
-
 @pytest.mark.tzoffset
 @pytest.mark.parametrize('args', [
     ('UTC', 0),
@@ -1051,21 +1036,6 @@ class GettzTest(unittest.TestCase, TzFoldMixin):
         local2 = tz.gettz()
 
         assert local1 is not local2
-
-    def testGettzWeakRef(self):
-        tz.gettz.cache_clear()
-        NYC1 = tz.gettz('America/New_York')
-        NYC2 = tz.gettz('America/New_York')
-        assert id(NYC1) == id(NYC2)
-
-        weak_ref_id = id(NYC1)
-        del NYC1
-        del NYC2
-        gc.collect()
-
-        NYC3 = tz.gettz('America/New_York')
-        assert not weak_ref_id == id(NYC3)
-
 
 @pytest.mark.gettz
 @pytest.mark.xfail(IS_WIN, reason='zoneinfo separately cached')
@@ -1404,20 +1374,6 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
 
         # Ensure that these still are all the same zone
         assert tz1 == tz2 == tz3
-
-    def testTzOffsetWeakRef(self):
-        tz_t1 = tz.tzstr('EST5EDT')
-        tz_t2 = tz.tzstr('EST5EDT')
-        assert id(tz_t1) == id(tz_t2)
-
-        weak_ref_id = id(tz_t1)
-        del tz_t1
-        del tz_t2
-        gc.collect()
-
-        tz_t3 = tz.tzstr('EST5EDT')
-        assert not weak_ref_id == id(tz_t3)
-
 
 @pytest.mark.tzstr
 @pytest.mark.parametrize('tz_str,expected', [

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -15,7 +15,6 @@ import sys
 import base64
 import copy
 import gc
-import weakref
 
 from functools import partial
 
@@ -733,18 +732,18 @@ class TzOffsetTest(unittest.TestCase):
 
         assert tz1 is tz2
 
+    def testTzOffsetWeakRef(self):
+        UTC1 = tz.tzoffset('UTC', 0)
+        UTC2 = tz.tzoffset('UTC', 0)
+        assert id(UTC1) == id(UTC2)
 
-@pytest.mark.smoke
-@pytest.mark.tzoffset
-def test_tzoffset_weakref():
-    UTC1 = tz.tzoffset('UTC', 0)
-    UTC_ref = weakref.ref(tz.tzoffset('UTC', 0))
-    UTC1 is UTC_ref()
-    del UTC1
-    gc.collect()
+        weak_ref_id = id(UTC1)
+        del UTC1
+        del UTC2
+        gc.collect()
 
-    assert UTC_ref() is None
-    assert UTC_ref() is not tz.tzoffset('UTC', 0)
+        UTC3 = tz.tzoffset('UTC', 0)
+        assert not weak_ref_id == id(UTC3)
 
 
 @pytest.mark.tzoffset
@@ -1066,20 +1065,20 @@ def test_gettz_cache_clear():
 
 
 @pytest.mark.xfail(IS_WIN, reason="Windows does not use system zoneinfo")
-@pytest.mark.smoke
 @pytest.mark.gettz
 def test_gettz_weakref():
     tz.gettz.cache_clear()
     NYC1 = tz.gettz('America/New_York')
-    NYC_ref = weakref.ref(tz.gettz('America/New_York'))
+    NYC2 = tz.gettz('America/New_York')
+    assert id(NYC1) == id(NYC2)
 
-    assert NYC1 is NYC_ref()
-
+    weak_ref_id = id(NYC1)
     del NYC1
+    del NYC2
     gc.collect()
 
-    assert NYC_ref() is None
-    assert tz.gettz('America/New_York') is not NYC_ref()
+    NYC3 = tz.gettz('America/New_York')
+    assert not weak_ref_id == id(NYC3)
 
 
 class ZoneInfoGettzTest(GettzTest, WarningTestMixin):
@@ -1409,19 +1408,18 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         # Ensure that these still are all the same zone
         assert tz1 == tz2 == tz3
 
+    def testTzOffsetWeakRef(self):
+        tz_t1 = tz.tzstr('EST5EDT')
+        tz_t2 = tz.tzstr('EST5EDT')
+        assert id(tz_t1) == id(tz_t2)
 
-@pytest.mark.smoke
-@pytest.mark.tzstr
-def test_tzstr_weakref():
-    tz_t1 = tz.tzstr('EST5EDT')
-    tz_t2_ref = weakref.ref(tz.tzstr('EST5EDT'))
-    assert tz_t1 is tz_t2_ref()
+        weak_ref_id = id(tz_t1)
+        del tz_t1
+        del tz_t2
+        gc.collect()
 
-    del tz_t1
-    gc.collect()
-
-    assert tz_t2_ref() is None
-    assert tz.tzstr('EST5EDT') is not tz_t2_ref()
+        tz_t3 = tz.tzstr('EST5EDT')
+        assert not weak_ref_id == id(tz_t3)
 
 
 @pytest.mark.tzstr

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1052,6 +1052,20 @@ class GettzTest(unittest.TestCase, TzFoldMixin):
 
         assert local1 is not local2
 
+    def testGettzWeakRef(self):
+        tz.gettz.cache_clear()
+        NYC1 = tz.gettz('America/New_York')
+        NYC2 = tz.gettz('America/New_York')
+        assert id(NYC1) == id(NYC2)
+
+        weak_ref_id = id(NYC1)
+        del NYC1
+        del NYC2
+        gc.collect()
+
+        NYC3 = tz.gettz('America/New_York')
+        assert not weak_ref_id == id(NYC3)
+
 
 @pytest.mark.gettz
 @pytest.mark.xfail(IS_WIN, reason='zoneinfo separately cached')
@@ -1062,23 +1076,6 @@ def test_gettz_cache_clear():
     NYC2 = tz.gettz('America/New_York')
 
     assert NYC1 is not NYC2
-
-
-@pytest.mark.xfail(IS_WIN, reason="Windows does not use system zoneinfo")
-@pytest.mark.gettz
-def test_gettz_weakref():
-    tz.gettz.cache_clear()
-    NYC1 = tz.gettz('America/New_York')
-    NYC2 = tz.gettz('America/New_York')
-    assert id(NYC1) == id(NYC2)
-
-    weak_ref_id = id(NYC1)
-    del NYC1
-    del NYC2
-    gc.collect()
-
-    NYC3 = tz.gettz('America/New_York')
-    assert not weak_ref_id == id(NYC3)
 
 
 class ZoneInfoGettzTest(GettzTest, WarningTestMixin):

--- a/dateutil/tz/_factories.py
+++ b/dateutil/tz/_factories.py
@@ -1,5 +1,5 @@
 from datetime import timedelta
-import weakref
+
 
 class _TzSingleton(type):
     def __init__(cls, *args, **kwargs):
@@ -19,7 +19,7 @@ class _TzFactory(type):
 
 class _TzOffsetFactory(_TzFactory):
     def __init__(cls, *args, **kwargs):
-        cls.__instances = weakref.WeakValueDictionary()
+        cls.__instances = {}
 
     def __call__(cls, name, offset):
         if isinstance(offset, timedelta):
@@ -36,7 +36,7 @@ class _TzOffsetFactory(_TzFactory):
 
 class _TzStrFactory(_TzFactory):
     def __init__(cls, *args, **kwargs):
-        cls.__instances = weakref.WeakValueDictionary()
+        cls.__instances = {}
 
     def __call__(cls, s, posix_offset=False):
         key = (s, posix_offset)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -13,7 +13,6 @@ import time
 import sys
 import os
 import bisect
-import weakref
 
 import six
 from six import string_types
@@ -1529,7 +1528,7 @@ def __get_gettz():
         """
         def __init__(self):
 
-            self.__instances = weakref.WeakValueDictionary()
+            self.__instances = {}
             self._cache_lock = _thread.allocate_lock()
 
         def __call__(self, name=None):

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1548,7 +1548,7 @@ def __get_gettz():
 
         def cache_clear(self):
             with self._cache_lock:
-                self.__instances = weakref.WeakValueDictionary()
+                self.__instances = {}
 
         @staticmethod
         def nocache(name=None):


### PR DESCRIPTION
This reverts #672 on the 2.7.x branch, since it's actually a somewhat big change, performance-wise, for a patch release.