### PR TITLE
Release 2.7.3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,58 @@
+Version 2.7.3 (2018-05-09)
+==========================
+
+Data updates
+------------
+
+- Update tzdata to 2018e. (gh pr #710)
+
+
+Bugfixes
+--------
+
+- Fixed an issue where decimal.Decimal would cast `NaN` or infinite value in a
+  parser.parse, which will raise decimal.Decimal-specific errors. Reported and
+  fixed by @amureki (gh issue #662, gh pr #679).
+- Fixed a ValueError being thrown if tzinfos call explicity returns ``None``.
+  Reported by @pganssle (gh issue #661) Fixed by @parsethis (gh pr #681)
+- Fixed incorrect parsing of certain dates earlier than 100 AD when repesented
+  in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)
+- Fixed a bug where automatically generated DTSTART was naive even if a
+  specified UNTIL had a time zone. Automatically generated DTSTART will now
+  take on the timezone of an UNTIL date, if provided. Reported by @href (gh
+  issue #652). Fixed by @absreim (gh pr #693).
+
+
+Documentation changes
+---------------------
+
+- Corrected link syntax and updated URL to https for ISO year week number
+  notation in relativedelta examples. (gh issue #670, pr #711)
+- Add doctest examples to tzfile documentation. Done by @weatherpattern and
+  @pganssle (gh pr #671)
+- Updated the documentation for relativedelta. Removed references to tuple
+  arguments for weekday, explained effect of weekday(_, 1) and better explained
+  the order of operations that relativedelta applies. Fixed by @kvn219
+  @huangy22 and @ElliotJH (gh pr #673)
+- Added changelog to documentation. (gh issue #692, gh pr #707)
+- Changed order of keywords in rrule docstring. Reported and fixed by
+  @rmahajan14 (gh issue #686, gh pr #695).
+- Added documentation for ``dateutil.tz.gettz``. Reported by @pganssle (gh
+  issue #647). Fixed by @weatherpattern (gh pr #704)
+- Cleaned up malformed RST in the ``tz`` documentation. (gh issue #702, gh pr
+  #706)
+- Changed the default theme to sphinx_rtd_theme, and changed the sphinx
+  configuration to go along with that. (gh pr #707)
+- Reorganized ``dateutil.tz`` documentation and fixed issue with the
+  ``dateutil.tz`` docstring. (gh pr #714)
+
+
+Misc
+----
+
+- GH #674, GH #688, GH #699
+
+
 Version 2.7.2 (2018-03-26)
 ==========================
 

--- a/changelog.d/670.doc.rst
+++ b/changelog.d/670.doc.rst
@@ -1,1 +1,0 @@
-Corrected link syntax and updated URL to https for ISO year week number notation in relativedelta examples. (gh issue #670, pr #711)

--- a/changelog.d/671.doc.rst
+++ b/changelog.d/671.doc.rst
@@ -1,1 +1,0 @@
-Add doctest examples to tzfile documentation. Done by @weatherpattern and @pganssle (gh pr #671)

--- a/changelog.d/673.doc.rst
+++ b/changelog.d/673.doc.rst
@@ -1,4 +1,0 @@
-Updated the documentation for relativedelta. Removed references to
-tuple arguments for weekday, explained effect of weekday(_, 1) and
-better explained the order of operations that relativedelta
-applies. Fixed by @kvn219 @huangy22 and @ElliotJH (gh pr #673)

--- a/changelog.d/674.misc.rst
+++ b/changelog.d/674.misc.rst
@@ -1,1 +1,0 @@
-Add property testing with hypothesis with property tests for parserinfo.convertyear. Implemented by @coreygirard and @loldja (gh pr #674)

--- a/changelog.d/679.bugfix.rst
+++ b/changelog.d/679.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed an issue where decimal.Decimal would cast `NaN` or infinite value in a parser.parse, which will raise decimal.Decimal-specific errors. Reported and fixed by @amureki (gh issue #662, gh pr #679).

--- a/changelog.d/681.bugfix.rst
+++ b/changelog.d/681.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a ValueError being thrown if tzinfos call explicity returns ``None``.  Reported by @pganssle (gh issue #661) Fixed by @parsethis (gh pr #681)

--- a/changelog.d/687.bugfix.rst
+++ b/changelog.d/687.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed incorrect parsing of certain dates earlier than 100 AD when repesented in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)

--- a/changelog.d/688.misc.rst
+++ b/changelog.d/688.misc.rst
@@ -1,1 +1,0 @@
-Add a test for the property that ``dateutil.parser.parse`` will support inversion of ``datetime.isoformat()`` so long as ``sep`` is an ASCII character. Added by @pganssle (gh pr #688)

--- a/changelog.d/692.doc.rst
+++ b/changelog.d/692.doc.rst
@@ -1,1 +1,0 @@
-Added changelog to documentation. (gh issue #692, gh pr #707)

--- a/changelog.d/693.feature.rst
+++ b/changelog.d/693.feature.rst
@@ -1,1 +1,0 @@
-Fixed a bug where automatically generated DTSTART was naive even if a specified UNTIL had a time zone. Automatically generated DTSTART will now take on the timezone of an UNTIL date, if provided. Reported by @href (gh issue #652). Fixed by @absreim (gh pr #693).

--- a/changelog.d/693.feature.rst
+++ b/changelog.d/693.feature.rst
@@ -1,1 +1,1 @@
-Adds a feature when initializing an rrule with a specified UNTIL but without an explicitly specified DTSTART so that the generated DTSTART takes on the time zone of the UNTIL. Reported by @href (gh issue #652). Fixed by @absreim (gh pr #693).
+Fixed a bug where automatically generated DTSTART was naive even if a specified UNTIL had a time zone. Automatically generated DTSTART will now take on the timezone of an UNTIL date, if provided. Reported by @href (gh issue #652). Fixed by @absreim (gh pr #693).

--- a/changelog.d/695.doc.rst
+++ b/changelog.d/695.doc.rst
@@ -1,1 +1,0 @@
-Changed order of keywords in rrule docstring. Reported and fixed by @rmahajan14 (gh issue #686, gh pr #695).

--- a/changelog.d/699.misc.rst
+++ b/changelog.d/699.misc.rst
@@ -1,2 +1,0 @@
-Added unittest to check if tz's objects repr contains the "name" attribute of an input fileobject.
-Added by @Bergvca (gh pr #699)

--- a/changelog.d/704.doc.rst
+++ b/changelog.d/704.doc.rst
@@ -1,1 +1,0 @@
-Added documentation for ``dateutil.tz.gettz``. Reported by @pganssle (gh issue #647). Fixed by @weatherpattern (gh pr #704)

--- a/changelog.d/706.doc.rst
+++ b/changelog.d/706.doc.rst
@@ -1,1 +1,0 @@
-Cleaned up malformed RST in the ``tz`` documentation. (gh issue #702, gh pr #706)

--- a/changelog.d/707.doc.rst
+++ b/changelog.d/707.doc.rst
@@ -1,1 +1,0 @@
-Changed the default theme to sphinx_rtd_theme, and changed the sphinx configuration to go along with that. (gh pr #707)

--- a/changelog.d/710.data.rst
+++ b/changelog.d/710.data.rst
@@ -1,1 +1,0 @@
-Update tzdata to 2018e. (gh pr #710)

--- a/changelog.d/714.doc.rst
+++ b/changelog.d/714.doc.rst
@@ -1,1 +1,0 @@
-Reorganized ``dateutil.tz`` documentation and fixed issue with the ``dateutil.tz`` docstring. (gh pr #714)


### PR DESCRIPTION
Prepare a release of 2.7.3.

Changelog entry:

Version 2.7.3 (2018-05-09)
==========================

Data updates
------------

- Update tzdata to 2018e. (gh pr #710)


Bugfixes
--------

- Fixed an issue where decimal.Decimal would cast `NaN` or infinite value in a
  parser.parse, which will raise decimal.Decimal-specific errors. Reported and
  fixed by @amureki (gh issue #662, gh pr #679).
- Fixed a ValueError being thrown if tzinfos call explicity returns ``None``.
  Reported by @pganssle (gh issue #661) Fixed by @parsethis (gh pr #681)
- Fixed incorrect parsing of certain dates earlier than 100 AD when repesented
  in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)
- Fixed a bug where automatically generated DTSTART was naive even if a
  specified UNTIL had a time zone. Automatically generated DTSTART will now
  take on the timezone of an UNTIL date, if provided. Reported by @href (gh
  issue #652). Fixed by @absreim (gh pr #693).


Documentation changes
---------------------

- Corrected link syntax and updated URL to https for ISO year week number
  notation in relativedelta examples. (gh issue #670, pr #711)
- Add doctest examples to tzfile documentation. Done by @weatherpattern and
  @pganssle (gh pr #671)
- Updated the documentation for relativedelta. Removed references to tuple
  arguments for weekday, explained effect of weekday(_, 1) and better explained
  the order of operations that relativedelta applies. Fixed by @kvn219
  @huangy22 and @ElliotJH (gh pr #673)
- Added changelog to documentation. (gh issue #692, gh pr #707)
- Changed order of keywords in rrule docstring. Reported and fixed by
  @rmahajan14 (gh issue #686, gh pr #695).
- Added documentation for ``dateutil.tz.gettz``. Reported by @pganssle (gh
  issue #647). Fixed by @weatherpattern (gh pr #704)
- Cleaned up malformed RST in the ``tz`` documentation. (gh issue #702, gh pr
  #706)
- Changed the default theme to sphinx_rtd_theme, and changed the sphinx
  configuration to go along with that. (gh pr #707)
- Reorganized ``dateutil.tz`` documentation and fixed issue with the
  ``dateutil.tz`` docstring. (gh pr #714)


Misc
----

- GH #674, GH #688, GH #699