### PR TITLE
Fix Python 3.3 tests, make setup.py PEP 8 compliant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
 
 install:
   - pip install -U six && pip install -U tox
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
   - ./ci_tools/retry.sh python updatezinfo.py
 
 script:

--- a/changelog.d/723.misc.rst
+++ b/changelog.d/723.misc.rst
@@ -1,0 +1,1 @@
+Brought setup.py into compliance with PEP8. (gh pr #723)

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,11 @@ class Unsupported(TestCommand):
         print("Running 'test' with setup.py is not supported. "
               "Use 'pytest' or 'tox' to run the tests.")
 
+
 ###
 # Load metadata
 PACKAGES = find_packages(where='.', exclude=['dateutil.test'])
+
 
 def README():
     with io.open('README.rst', encoding='utf-8') as f:
@@ -34,16 +36,15 @@ def README():
 
     # The .. doctest directive is not supported by PyPA
     lines_out = []
-    doctest_line_found = False
     for line in readme_lines:
         if line.startswith('.. doctest'):
-            doctest_line_found = True
             lines_out.append('.. code-block:: python3\n')
         else:
             lines_out.append(line)
 
     return ''.join(lines_out)
-README = README()
+README = README()  # NOQA
+
 
 setup(name="python-dateutil",
       use_scm_version={


### PR DESCRIPTION
New version of #722 because Travis was acting up.

Fixes #724