### PR TITLE
Parametrize pytest

### DIFF
--- a/dateutil/test/test_easter.py
+++ b/dateutil/test/test_easter.py
@@ -2,94 +2,92 @@ from dateutil.easter import easter
 from dateutil.easter import EASTER_WESTERN, EASTER_ORTHODOX, EASTER_JULIAN
 
 from datetime import date
-import unittest
+import pytest
 
 # List of easters between 1990 and 2050
 western_easter_dates = [
     date(1990, 4, 15), date(1991, 3, 31), date(1992, 4, 19), date(1993, 4, 11),
-    date(1994, 4,  3), date(1995, 4, 16), date(1996, 4,  7), date(1997, 3, 30),
-    date(1998, 4, 12), date(1999, 4,  4),
+    date(1994, 4, 3), date(1995, 4, 16), date(1996, 4, 7), date(1997, 3, 30),
+    date(1998, 4, 12), date(1999, 4, 4),
 
     date(2000, 4, 23), date(2001, 4, 15), date(2002, 3, 31), date(2003, 4, 20),
-    date(2004, 4, 11), date(2005, 3, 27), date(2006, 4, 16), date(2007, 4,  8),
+    date(2004, 4, 11), date(2005, 3, 27), date(2006, 4, 16), date(2007, 4, 8),
     date(2008, 3, 23), date(2009, 4, 12),
 
-    date(2010, 4,  4), date(2011, 4, 24), date(2012, 4,  8), date(2013, 3, 31),
-    date(2014, 4, 20), date(2015, 4,  5), date(2016, 3, 27), date(2017, 4, 16),
-    date(2018, 4,  1), date(2019, 4, 21),
+    date(2010, 4, 4), date(2011, 4, 24), date(2012, 4, 8), date(2013, 3, 31),
+    date(2014, 4, 20), date(2015, 4, 5), date(2016, 3, 27), date(2017, 4, 16),
+    date(2018, 4, 1), date(2019, 4, 21),
 
-    date(2020, 4, 12), date(2021, 4,  4), date(2022, 4, 17), date(2023, 4,  9),
-    date(2024, 3, 31), date(2025, 4, 20), date(2026, 4,  5), date(2027, 3, 28),
-    date(2028, 4, 16), date(2029, 4,  1),
+    date(2020, 4, 12), date(2021, 4, 4), date(2022, 4, 17), date(2023, 4, 9),
+    date(2024, 3, 31), date(2025, 4, 20), date(2026, 4, 5), date(2027, 3, 28),
+    date(2028, 4, 16), date(2029, 4, 1),
 
     date(2030, 4, 21), date(2031, 4, 13), date(2032, 3, 28), date(2033, 4, 17),
-    date(2034, 4,  9), date(2035, 3, 25), date(2036, 4, 13), date(2037, 4,  5),
+    date(2034, 4, 9), date(2035, 3, 25), date(2036, 4, 13), date(2037, 4, 5),
     date(2038, 4, 25), date(2039, 4, 10),
 
-    date(2040, 4,  1), date(2041, 4, 21), date(2042, 4,  6), date(2043, 3, 29),
-    date(2044, 4, 17), date(2045, 4,  9), date(2046, 3, 25), date(2047, 4, 14),
-    date(2048, 4,  5), date(2049, 4, 18), date(2050, 4, 10)
-    ]
+    date(2040, 4, 1), date(2041, 4, 21), date(2042, 4, 6), date(2043, 3, 29),
+    date(2044, 4, 17), date(2045, 4, 9), date(2046, 3, 25), date(2047, 4, 14),
+    date(2048, 4, 5), date(2049, 4, 18), date(2050, 4, 10)
+]
 
 orthodox_easter_dates = [
-    date(1990, 4, 15), date(1991, 4,  7), date(1992, 4, 26), date(1993, 4, 18),
-    date(1994, 5,  1), date(1995, 4, 23), date(1996, 4, 14), date(1997, 4, 27),
+    date(1990, 4, 15), date(1991, 4, 7), date(1992, 4, 26), date(1993, 4, 18),
+    date(1994, 5, 1), date(1995, 4, 23), date(1996, 4, 14), date(1997, 4, 27),
     date(1998, 4, 19), date(1999, 4, 11),
 
-    date(2000, 4, 30), date(2001, 4, 15), date(2002, 5,  5), date(2003, 4, 27),
-    date(2004, 4, 11), date(2005, 5,  1), date(2006, 4, 23), date(2007, 4,  8),
+    date(2000, 4, 30), date(2001, 4, 15), date(2002, 5, 5), date(2003, 4, 27),
+    date(2004, 4, 11), date(2005, 5, 1), date(2006, 4, 23), date(2007, 4, 8),
     date(2008, 4, 27), date(2009, 4, 19),
 
-    date(2010, 4,  4), date(2011, 4, 24), date(2012, 4, 15), date(2013, 5,  5),
-    date(2014, 4, 20), date(2015, 4, 12), date(2016, 5,  1), date(2017, 4, 16),
-    date(2018, 4,  8), date(2019, 4, 28),
+    date(2010, 4, 4), date(2011, 4, 24), date(2012, 4, 15), date(2013, 5, 5),
+    date(2014, 4, 20), date(2015, 4, 12), date(2016, 5, 1), date(2017, 4, 16),
+    date(2018, 4, 8), date(2019, 4, 28),
 
-    date(2020, 4, 19), date(2021, 5,  2), date(2022, 4, 24), date(2023, 4, 16),
-    date(2024, 5,  5), date(2025, 4, 20), date(2026, 4, 12), date(2027, 5,  2),
-    date(2028, 4, 16), date(2029, 4,  8),
+    date(2020, 4, 19), date(2021, 5, 2), date(2022, 4, 24), date(2023, 4, 16),
+    date(2024, 5, 5), date(2025, 4, 20), date(2026, 4, 12), date(2027, 5, 2),
+    date(2028, 4, 16), date(2029, 4, 8),
 
-    date(2030, 4, 28), date(2031, 4, 13), date(2032, 5,  2), date(2033, 4, 24),
-    date(2034, 4,  9), date(2035, 4, 29), date(2036, 4, 20), date(2037, 4,  5),
+    date(2030, 4, 28), date(2031, 4, 13), date(2032, 5, 2), date(2033, 4, 24),
+    date(2034, 4, 9), date(2035, 4, 29), date(2036, 4, 20), date(2037, 4, 5),
     date(2038, 4, 25), date(2039, 4, 17),
 
-    date(2040, 5,  6), date(2041, 4, 21), date(2042, 4, 13), date(2043, 5,  3),
-    date(2044, 4, 24), date(2045, 4,  9), date(2046, 4, 29), date(2047, 4, 21),
-    date(2048, 4,  5), date(2049, 4, 25), date(2050, 4, 17)
+    date(2040, 5, 6), date(2041, 4, 21), date(2042, 4, 13), date(2043, 5, 3),
+    date(2044, 4, 24), date(2045, 4, 9), date(2046, 4, 29), date(2047, 4, 21),
+    date(2048, 4, 5), date(2049, 4, 25), date(2050, 4, 17)
 ]
 
 # A random smattering of Julian dates.
 # Pulled values from http://www.kevinlaughery.com/east4099.html
 julian_easter_dates = [
-    date( 326, 4,  3), date( 375, 4,  5), date( 492, 4,  5), date( 552, 3, 31),
-    date( 562, 4,  9), date( 569, 4, 21), date( 597, 4, 14), date( 621, 4, 19),
-    date( 636, 3, 31), date( 655, 3, 29), date( 700, 4, 11), date( 725, 4,  8),
-    date( 750, 3, 29), date( 782, 4,  7), date( 835, 4, 18), date( 849, 4, 14),
-    date( 867, 3, 30), date( 890, 4, 12), date( 922, 4, 21), date( 934, 4,  6),
-    date(1049, 3, 26), date(1058, 4, 19), date(1113, 4,  6), date(1119, 3, 30),
-    date(1242, 4, 20), date(1255, 3, 28), date(1257, 4,  8), date(1258, 3, 24),
-    date(1261, 4, 24), date(1278, 4, 17), date(1333, 4,  4), date(1351, 4, 17),
-    date(1371, 4,  6), date(1391, 3, 26), date(1402, 3, 26), date(1412, 4,  3),
-    date(1439, 4,  5), date(1445, 3, 28), date(1531, 4,  9), date(1555, 4, 14)
+    date(326, 4, 3), date(375, 4, 5), date(492, 4, 5), date(552, 3, 31),
+    date(562, 4, 9), date(569, 4, 21), date(597, 4, 14), date(621, 4, 19),
+    date(636, 3, 31), date(655, 3, 29), date(700, 4, 11), date(725, 4, 8),
+    date(750, 3, 29), date(782, 4, 7), date(835, 4, 18), date(849, 4, 14),
+    date(867, 3, 30), date(890, 4, 12), date(922, 4, 21), date(934, 4, 6),
+    date(1049, 3, 26), date(1058, 4, 19), date(1113, 4, 6), date(1119, 3, 30),
+    date(1242, 4, 20), date(1255, 3, 28), date(1257, 4, 8), date(1258, 3, 24),
+    date(1261, 4, 24), date(1278, 4, 17), date(1333, 4, 4), date(1351, 4, 17),
+    date(1371, 4, 6), date(1391, 3, 26), date(1402, 3, 26), date(1412, 4, 3),
+    date(1439, 4, 5), date(1445, 3, 28), date(1531, 4, 9), date(1555, 4, 14)
 ]
 
 
-class EasterTest(unittest.TestCase):
-    def testEasterWestern(self):
-        for easter_date in western_easter_dates:
-            self.assertEqual(easter_date,
-                             easter(easter_date.year, EASTER_WESTERN))
+@pytest.mark.parametrize("easter_date", western_easter_dates)
+def test_easter_western(easter_date):
+    assert easter_date == easter(easter_date.year, EASTER_WESTERN)
 
-    def testEasterOrthodox(self):
-        for easter_date in orthodox_easter_dates:
-            self.assertEqual(easter_date,
-                             easter(easter_date.year, EASTER_ORTHODOX))
 
-    def testEasterJulian(self):
-        for easter_date in julian_easter_dates:
-            self.assertEqual(easter_date,
-                             easter(easter_date.year, EASTER_JULIAN))
+@pytest.mark.parametrize("easter_date", orthodox_easter_dates)
+def test_easter_orthodox(easter_date):
+    assert easter_date == easter(easter_date.year, EASTER_ORTHODOX)
 
-    def testEasterBadMethod(self):
-        # Invalid methods raise ValueError
-        with self.assertRaises(ValueError):
-            easter(1975, 4)
+
+@pytest.mark.parametrize("easter_date", julian_easter_dates)
+def test_easter_julian(easter_date):
+    assert easter_date == easter(easter_date.year, EASTER_JULIAN)
+
+
+def test_easter_bad_method():
+    with pytest.raises(ValueError):
+        easter(1975, 4)

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -27,6 +27,72 @@ try:
 except ValueError:
     PLATFORM_HAS_DASH_D = False
 
+parser_test_cases = [
+    ("2003-09-25T10:49:41", datetime(2003, 9, 25, 10, 49, 41), "iso format strip"),
+    ("2003-09-25T10:49", datetime(2003, 9, 25, 10, 49), "iso format strip"),
+    ("2003-09-25T10", datetime(2003, 9, 25, 10), "iso format strip"),
+    ("2003-09-25", datetime(2003, 9, 25), "iso format strip"),
+    ("20030925T104941", datetime(2003, 9, 25, 10, 49, 41), "iso stripped format strip"),
+    ("20030925T1049", datetime(2003, 9, 25, 10, 49, 0), "iso stripped format strip"),
+    ("20030925T10", datetime(2003, 9, 25, 10), "iso stripped format strip"),
+    ("20030925", datetime(2003, 9, 25), "iso stripped format strip"),
+    ("2003-09-25 10:49:41,502", datetime(2003, 9, 25, 10, 49, 41, 502000), "python logger format"),
+    ("199709020908", datetime(1997, 9, 2, 9, 8), "no separator"),
+    ("19970902090807", datetime(1997, 9, 2, 9, 8, 7), "no separator"),
+    ("2003-09-25", datetime(2003, 9, 25), "date with dash"),
+    ("09-25-2003", datetime(2003, 9, 25), "date with dash"),
+    ("25-09-2003", datetime(2003, 9, 25), "date with dash"),
+    ("10-09-2003", datetime(2003, 10, 9), "date with dash"),
+    ("10-09-03", datetime(2003, 10, 9), "date with dash"),
+    ("2003.09.25", datetime(2003, 9, 25), "date with dot"),
+    ("09.25.2003", datetime(2003, 9, 25), "date with dot"),
+    ("25.09.2003", datetime(2003, 9, 25), "date with dot"),
+    ("10.09.2003", datetime(2003, 10, 9), "date with dot"),
+    ("10.09.03", datetime(2003, 10, 9), "date with dot"),
+    ("2003/09/25", datetime(2003, 9, 25), "date with slash"),
+    ("09/25/2003", datetime(2003, 9, 25), "date with slash"),
+    ("25/09/2003", datetime(2003, 9, 25), "date with slash"),
+    ("10/09/2003", datetime(2003, 10, 9), "date with slash"),
+    ("10/09/03", datetime(2003, 10, 9), "date with slash"),
+    ("2003 09 25", datetime(2003, 9, 25), "date with space"),
+    ("09 25 2003", datetime(2003, 9, 25), "date with space"),
+    ("25 09 2003", datetime(2003, 9, 25), "date with space"),
+    ("10 09 2003", datetime(2003, 10, 9), "date with space"),
+    ("10 09 03", datetime(2003, 10, 9), "date with space"),
+    ("25 09 03", datetime(2003, 9, 25), "date with space"),
+    ("03 25 Sep", datetime(2003, 9, 25), "strangely ordered date"),
+    ("25 03 Sep", datetime(2025, 9, 3), "strangely ordered date"),
+    ("  July   4 ,  1976   12:01:02   am  ", datetime(1976, 7, 4, 0, 1, 2), "extra space"),
+    ("Wed, July 10, '96", datetime(1996, 7, 10, 0, 0), "random format"),
+    ("1996.July.10 AD 12:08 PM", datetime(1996, 7, 10, 12, 8), "random format"),
+    ("July 4, 1976", datetime(1976, 7, 4), "random format"),
+    ("7 4 1976", datetime(1976, 7, 4), "random format"),
+    ("4 jul 1976", datetime(1976, 7, 4), "random format"),
+    ("7-4-76", datetime(1976, 7, 4), "random format"),
+    ("19760704", datetime(1976, 7, 4), "random format"),
+    ("0:01:02 on July 4, 1976", datetime(1976, 7, 4, 0, 1, 2), "random format"),
+    ("0:01:02 on July 4, 1976", datetime(1976, 7, 4, 0, 1, 2), "random format"),
+    ("July 4, 1976 12:01:02 am", datetime(1976, 7, 4, 0, 1, 2), "random format"),
+    ("Mon Jan  2 04:24:27 1995", datetime(1995, 1, 2, 4, 24, 27), "random format"),
+    ("04.04.95 00:22", datetime(1995, 4, 4, 0, 22), "random format"),
+    ("Jan 1 1999 11:23:34.578", datetime(1999, 1, 1, 11, 23, 34, 578000), "random format"),
+    ("950404 122212", datetime(1995, 4, 4, 12, 22, 12), "random format"),
+    ("3rd of May 2001", datetime(2001, 5, 3), "random format"),
+    ("5th of March 2001", datetime(2001, 3, 5), "random format"),
+    ("1st of May 2003", datetime(2003, 5, 1), "random format"),
+    ('0099-01-01T00:00:00', datetime(99, 1, 1, 0, 0), "99 ad"),
+    ('0031-01-01T00:00:00', datetime(31, 1, 1, 0, 0), "31 ad"),
+    ("20080227T21:26:01.123456789", datetime(2008, 2, 27, 21, 26, 1, 123456), "high precision seconds"),
+    ('13NOV2017', datetime(2017, 11, 13), "dBY (See GH360)"),
+    ('0003-03-04', datetime(3, 3, 4), "pre 12 year same month (See GH PR #293)"),
+    ('December.0031.30', datetime(31, 12, 30), "BYd corner case (GH#687)")
+]
+
+
+@pytest.mark.parametrize("parsable_text,expected_datetime,message", parser_test_cases)
+def test_parser(parsable_text, expected_datetime, message):
+    assert parse(parsable_text) == expected_datetime, message
+
 
 class TestFormat(unittest.TestCase):
 
@@ -234,22 +300,6 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 10, 49, 41,
                                   tzinfo=self.brsttz))
 
-    def testISOFormatStrip2(self):
-        self.assertEqual(parse("2003-09-25T10:49:41"),
-                         datetime(2003, 9, 25, 10, 49, 41))
-
-    def testISOFormatStrip3(self):
-        self.assertEqual(parse("2003-09-25T10:49"),
-                         datetime(2003, 9, 25, 10, 49))
-
-    def testISOFormatStrip4(self):
-        self.assertEqual(parse("2003-09-25T10"),
-                         datetime(2003, 9, 25, 10))
-
-    def testISOFormatStrip5(self):
-        self.assertEqual(parse("2003-09-25"),
-                         datetime(2003, 9, 25))
-
     def testISOStrippedFormat(self):
         self.assertEqual(parse("20030925T104941.5-0300"),
                          datetime(2003, 9, 25, 10, 49, 41, 500000,
@@ -260,157 +310,37 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 10, 49, 41,
                                   tzinfo=self.brsttz))
 
-    def testISOStrippedFormatStrip2(self):
-        self.assertEqual(parse("20030925T104941"),
-                         datetime(2003, 9, 25, 10, 49, 41))
-
-    def testISOStrippedFormatStrip3(self):
-        self.assertEqual(parse("20030925T1049"),
-                         datetime(2003, 9, 25, 10, 49, 0))
-
-    def testISOStrippedFormatStrip4(self):
-        self.assertEqual(parse("20030925T10"),
-                         datetime(2003, 9, 25, 10))
-
-    def testISOStrippedFormatStrip5(self):
-        self.assertEqual(parse("20030925"),
-                         datetime(2003, 9, 25))
-
-    def testPythonLoggerFormat(self):
-        self.assertEqual(parse("2003-09-25 10:49:41,502"),
-                         datetime(2003, 9, 25, 10, 49, 41, 502000))
-
-    def testNoSeparator1(self):
-        self.assertEqual(parse("199709020908"),
-                         datetime(1997, 9, 2, 9, 8))
-
-    def testNoSeparator2(self):
-        self.assertEqual(parse("19970902090807"),
-                         datetime(1997, 9, 2, 9, 8, 7))
-
-    def testDateWithDash1(self):
-        self.assertEqual(parse("2003-09-25"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithDash6(self):
-        self.assertEqual(parse("09-25-2003"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithDash7(self):
-        self.assertEqual(parse("25-09-2003"),
-                         datetime(2003, 9, 25))
-
     def testDateWithDash8(self):
         self.assertEqual(parse("10-09-2003", dayfirst=True),
                          datetime(2003, 9, 10))
-
-    def testDateWithDash9(self):
-        self.assertEqual(parse("10-09-2003"),
-                         datetime(2003, 10, 9))
-
-    def testDateWithDash10(self):
-        self.assertEqual(parse("10-09-03"),
-                         datetime(2003, 10, 9))
 
     def testDateWithDash11(self):
         self.assertEqual(parse("10-09-03", yearfirst=True),
                          datetime(2010, 9, 3))
 
-    def testDateWithDot1(self):
-        self.assertEqual(parse("2003.09.25"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithDot6(self):
-        self.assertEqual(parse("09.25.2003"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithDot7(self):
-        self.assertEqual(parse("25.09.2003"),
-                         datetime(2003, 9, 25))
-
     def testDateWithDot8(self):
         self.assertEqual(parse("10.09.2003", dayfirst=True),
                          datetime(2003, 9, 10))
-
-    def testDateWithDot9(self):
-        self.assertEqual(parse("10.09.2003"),
-                         datetime(2003, 10, 9))
-
-    def testDateWithDot10(self):
-        self.assertEqual(parse("10.09.03"),
-                         datetime(2003, 10, 9))
 
     def testDateWithDot11(self):
         self.assertEqual(parse("10.09.03", yearfirst=True),
                          datetime(2010, 9, 3))
 
-    def testDateWithSlash1(self):
-        self.assertEqual(parse("2003/09/25"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithSlash6(self):
-        self.assertEqual(parse("09/25/2003"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithSlash7(self):
-        self.assertEqual(parse("25/09/2003"),
-                         datetime(2003, 9, 25))
-
     def testDateWithSlash8(self):
         self.assertEqual(parse("10/09/2003", dayfirst=True),
                          datetime(2003, 9, 10))
-
-    def testDateWithSlash9(self):
-        self.assertEqual(parse("10/09/2003"),
-                         datetime(2003, 10, 9))
-
-    def testDateWithSlash10(self):
-        self.assertEqual(parse("10/09/03"),
-                         datetime(2003, 10, 9))
 
     def testDateWithSlash11(self):
         self.assertEqual(parse("10/09/03", yearfirst=True),
                          datetime(2010, 9, 3))
 
-    def testDateWithSpace1(self):
-        self.assertEqual(parse("2003 09 25"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithSpace6(self):
-        self.assertEqual(parse("09 25 2003"),
-                         datetime(2003, 9, 25))
-
-    def testDateWithSpace7(self):
-        self.assertEqual(parse("25 09 2003"),
-                         datetime(2003, 9, 25))
-
     def testDateWithSpace8(self):
         self.assertEqual(parse("10 09 2003", dayfirst=True),
                          datetime(2003, 9, 10))
 
-    def testDateWithSpace9(self):
-        self.assertEqual(parse("10 09 2003"),
-                         datetime(2003, 10, 9))
-
-    def testDateWithSpace10(self):
-        self.assertEqual(parse("10 09 03"),
-                         datetime(2003, 10, 9))
-
     def testDateWithSpace11(self):
         self.assertEqual(parse("10 09 03", yearfirst=True),
                          datetime(2010, 9, 3))
-
-    def testDateWithSpace12(self):
-        self.assertEqual(parse("25 09 03"),
-                         datetime(2003, 9, 25))
-
-    def testStrangelyOrderedDate1(self):
-        self.assertEqual(parse("03 25 Sep"),
-                         datetime(2003, 9, 25))
-
-    def testStrangelyOrderedDate3(self):
-        self.assertEqual(parse("25 03 Sep"),
-                         datetime(2025, 9, 3))
 
     def testHourWithLetters(self):
         self.assertEqual(parse("10h36m28.5s", default=self.default),
@@ -578,22 +508,10 @@ class ParserTest(unittest.TestCase):
             res = parse(s1, fuzzy=True)
         self.assertEqual(res, datetime(1945, 1, 29, 14, 45))
 
-    def testExtraSpace(self):
-        self.assertEqual(parse("  July   4 ,  1976   12:01:02   am  "),
-                         datetime(1976, 7, 4, 0, 1, 2))
-
-    def testRandomFormat1(self):
-        self.assertEqual(parse("Wed, July 10, '96"),
-                         datetime(1996, 7, 10, 0, 0))
-
     def testRandomFormat2(self):
         self.assertEqual(parse("1996.07.10 AD at 15:08:56 PDT",
                                ignoretz=True),
                          datetime(1996, 7, 10, 15, 8, 56))
-
-    def testRandomFormat3(self):
-        self.assertEqual(parse("1996.July.10 AD 12:08 PM"),
-                         datetime(1996, 7, 10, 12, 8))
 
     def testRandomFormat4(self):
         self.assertEqual(parse("Tuesday, April 12, 1952 AD 3:30:42pm PST",
@@ -615,21 +533,6 @@ class ParserTest(unittest.TestCase):
                                ignoretz=True),
                          datetime(1994, 11, 5, 8, 15, 30))
 
-    def testRandomFormat8(self):
-        self.assertEqual(parse("July 4, 1976"), datetime(1976, 7, 4))
-
-    def testRandomFormat9(self):
-        self.assertEqual(parse("7 4 1976"), datetime(1976, 7, 4))
-
-    def testRandomFormat10(self):
-        self.assertEqual(parse("4 jul 1976"), datetime(1976, 7, 4))
-
-    def testRandomFormat11(self):
-        self.assertEqual(parse("7-4-76"), datetime(1976, 7, 4))
-
-    def testRandomFormat12(self):
-        self.assertEqual(parse("19760704"), datetime(1976, 7, 4))
-
     def testRandomFormat13(self):
         self.assertEqual(parse("0:01:02", default=self.default),
                          datetime(2003, 9, 25, 0, 1, 2))
@@ -638,41 +541,13 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("12h 01m02s am", default=self.default),
                          datetime(2003, 9, 25, 0, 1, 2))
 
-    def testRandomFormat15(self):
-        self.assertEqual(parse("0:01:02 on July 4, 1976"),
-                         datetime(1976, 7, 4, 0, 1, 2))
-
-    def testRandomFormat16(self):
-        self.assertEqual(parse("0:01:02 on July 4, 1976"),
-                         datetime(1976, 7, 4, 0, 1, 2))
-
     def testRandomFormat17(self):
         self.assertEqual(parse("1976-07-04T00:01:02Z", ignoretz=True),
                          datetime(1976, 7, 4, 0, 1, 2))
 
-    def testRandomFormat18(self):
-        self.assertEqual(parse("July 4, 1976 12:01:02 am"),
-                         datetime(1976, 7, 4, 0, 1, 2))
-
-    def testRandomFormat19(self):
-        self.assertEqual(parse("Mon Jan  2 04:24:27 1995"),
-                         datetime(1995, 1, 2, 4, 24, 27))
-
     def testRandomFormat20(self):
         self.assertEqual(parse("Tue Apr 4 00:22:12 PDT 1995", ignoretz=True),
                          datetime(1995, 4, 4, 0, 22, 12))
-
-    def testRandomFormat21(self):
-        self.assertEqual(parse("04.04.95 00:22"),
-                         datetime(1995, 4, 4, 0, 22))
-
-    def testRandomFormat22(self):
-        self.assertEqual(parse("Jan 1 1999 11:23:34.578"),
-                         datetime(1999, 1, 1, 11, 23, 34, 578000))
-
-    def testRandomFormat23(self):
-        self.assertEqual(parse("950404 122212"),
-                         datetime(1995, 4, 4, 12, 22, 12))
 
     def testRandomFormat24(self):
         self.assertEqual(parse("0:00 PM, PST", default=self.default,
@@ -688,15 +563,6 @@ class ParserTest(unittest.TestCase):
             res = parse("5:50 A.M. on June 13, 1990")
 
         self.assertEqual(res, datetime(1990, 6, 13, 5, 50))
-
-    def testRandomFormat27(self):
-        self.assertEqual(parse("3rd of May 2001"), datetime(2001, 5, 3))
-
-    def testRandomFormat28(self):
-        self.assertEqual(parse("5th of March 2001"), datetime(2001, 3, 5))
-
-    def testRandomFormat29(self):
-        self.assertEqual(parse("1st of May 2003"), datetime(2003, 5, 1))
 
     def testRandomFormat30(self):
         self.assertEqual(parse("01h02m03", default=self.default),
@@ -721,14 +587,6 @@ class ParserTest(unittest.TestCase):
     def testRandomFormat35(self):
         self.assertEqual(parse("2004 10 Apr 11h30m", default=self.default),
                          datetime(2004, 4, 10, 11, 30))
-
-    def test_99_ad(self):
-        self.assertEqual(parse('0099-01-01T00:00:00'),
-                         datetime(99, 1, 1, 0, 0))
-
-    def test_31_ad(self):
-        self.assertEqual(parse('0031-01-01T00:00:00'),
-                         datetime(31, 1, 1, 0, 0))
 
     def testInvalidDay(self):
         with self.assertRaises(ValueError):
@@ -802,9 +660,9 @@ class ParserTest(unittest.TestCase):
             dt = datetime(2008, 2, 27, 21, 26, 1, ms)
             self.assertEqual(parse(dt.isoformat()), dt)
 
-    def testHighPrecisionSeconds(self):
-        self.assertEqual(parse("20080227T21:26:01.123456789"),
-                          datetime(2008, 2, 27, 21, 26, 1, 123456))
+    # def testHighPrecisionSeconds(self):
+    #     self.assertEqual(parse("20080227T21:26:01.123456789"),
+    #                       datetime(2008, 2, 27, 21, 26, 1, 123456))
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
@@ -900,12 +758,6 @@ class ParserTest(unittest.TestCase):
         res = parse(dtstr, fuzzy=True)
         self.assertEqual(res, datetime(2017, 7, 17, 6, 15))
 
-    def test_dBY(self):
-        # See GH360
-        dtstr = '13NOV2017'
-        res = parse(dtstr)
-        self.assertEqual(res, datetime(2017, 11, 13))
-
     def test_hmBY(self):
         # See GH#483
         dtstr = '02:17NOV2017'
@@ -922,11 +774,6 @@ class ParserTest(unittest.TestCase):
         dstr = 'AD2001'
         res = parse(dstr)
         assert res.year == 2001, res
-
-    def test_pre_12_year_same_month(self):
-        # See GH PR #293
-        dtstr = '0003-03-04'
-        assert parse(dtstr) == datetime(3, 3, 4)
 
 
 class TestParseUnimplementedCases(object):
@@ -1107,8 +954,3 @@ def test_decimal_error(value):
     with pytest.raises(ValueError):
         parse(value)
 
-
-def test_BYd_corner_case():
-    # GH#687
-    res = parse('December.0031.30')
-    assert res == datetime(31, 12, 30)

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -660,10 +660,6 @@ class ParserTest(unittest.TestCase):
             dt = datetime(2008, 2, 27, 21, 26, 1, ms)
             self.assertEqual(parse(dt.isoformat()), dt)
 
-    # def testHighPrecisionSeconds(self):
-    #     self.assertEqual(parse("20080227T21:26:01.123456789"),
-    #                       datetime(2008, 2, 27, 21, 26, 1, 123456))
-
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
         from dateutil.parser import parserinfo, parser


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->
@pganssle suggested that it would be good to migrate the tests to parameterized pytests. 

This is a possible partial conversion.
I've tried to keep the grouping and meaning of test cases the same. 

For the test cases in `test_parser.py` I've converted the old test function signatures to assertion messages. Where appropriate, I've integrated the comments from the test cases into the error messages as well. I've noticed that a large number of the test cases were` testSomeThing1, testSomeThing2, testSomeThing3,...` where the trailing number has appeard to be indexing the `i'th` test case I have dropped it. 

For test cases in `test_easter.py` I've dropped the `for easter_date in` to loop over cases. The problem with that is once an assertion fails, none of the following tests in the loop will be ran. Now, even if the first test case for each of the easter tests cases fails the following will still be ran. Also, since the refactor was for all of the test cases in the file I applied a `PEP8` format to the file. 

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
