### PR TITLE
conversion of test_easter.py to use pytest

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -45,6 +45,7 @@ switch, and thus all their contributions are dual-licensed.
 - Jake Chorley (gh: @jakec-github) **D**
 - Jan Studený <jendas1@MASKED>
 - Jitesh <jitesh@MASKED>
+- John Purviance <jpurviance@MASKED> (gh @jpurviance) **D**
 - Jon Dufresne <jon.dufresne@MASKED> (gh: @jdufresne) **R**
 - Jonas Neubert <jonas@MASKED>
 - Kevin Nguyen <kvn219@MASKED>

--- a/changelog.d/726.misc.rst
+++ b/changelog.d/726.misc.rst
@@ -1,0 +1,1 @@
+Migrated easter tests to use parametrized pytest tests rather than a for loop within a single test. Implemented by @jpurviance (gh pr #726)

--- a/dateutil/test/test_easter.py
+++ b/dateutil/test/test_easter.py
@@ -2,7 +2,7 @@ from dateutil.easter import easter
 from dateutil.easter import EASTER_WESTERN, EASTER_ORTHODOX, EASTER_JULIAN
 
 from datetime import date
-import unittest
+import pytest
 
 # List of easters between 1990 and 2050
 western_easter_dates = [
@@ -73,23 +73,21 @@ julian_easter_dates = [
 ]
 
 
-class EasterTest(unittest.TestCase):
-    def testEasterWestern(self):
-        for easter_date in western_easter_dates:
-            self.assertEqual(easter_date,
-                             easter(easter_date.year, EASTER_WESTERN))
+@pytest.mark.parametrize("easter_date", western_easter_dates)
+def test_easter_western(easter_date):
+    assert easter_date == easter(easter_date.year, EASTER_WESTERN)
 
-    def testEasterOrthodox(self):
-        for easter_date in orthodox_easter_dates:
-            self.assertEqual(easter_date,
-                             easter(easter_date.year, EASTER_ORTHODOX))
 
-    def testEasterJulian(self):
-        for easter_date in julian_easter_dates:
-            self.assertEqual(easter_date,
-                             easter(easter_date.year, EASTER_JULIAN))
+@pytest.mark.parametrize("easter_date", orthodox_easter_dates)
+def test_easter_orthodox(easter_date):
+    assert easter_date == easter(easter_date.year, EASTER_ORTHODOX)
 
-    def testEasterBadMethod(self):
-        # Invalid methods raise ValueError
-        with self.assertRaises(ValueError):
-            easter(1975, 4)
+
+@pytest.mark.parametrize("easter_date", julian_easter_dates)
+def test_easter_julian(easter_date):
+    assert easter_date == easter(easter_date.year, EASTER_JULIAN)
+
+
+def test_easter_bad_method():
+    with pytest.raises(ValueError):
+        easter(1975, 4)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->
@pganssle suggested that it would be good to migrate the tests to parameterized pytests.

I've dropped the for easter_date in to loop over cases. The problem with that is once an assertion fails, none of the following tests in the loop will be ran. Now, even if the first test case for each of the easter tests cases fails the following will still be ran. Also, since the refactor was for all of the test cases in the file I applied a PEP8 format to the file.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details