### PR TITLE
make _timelex a parser class attribute

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -571,6 +571,10 @@ class _ymd(list):
 
 
 class parser(object):
+    # timelex_cls is a class attribute so it can be easily overriden in
+    # subclasses
+    _timelex_cls = _timelex
+
     def __init__(self, info=None):
         self.info = info or parserinfo()
 
@@ -718,7 +722,7 @@ class parser(object):
             yearfirst = info.yearfirst
 
         res = self._result()
-        l = _timelex.split(timestr)         # Splits the timestr into tokens
+        l = self._timelex_cls.split(timestr)  # Splits the timestr into tokens
 
         skipped_idxs = []
 


### PR DESCRIPTION
Makes `_timelex` (well, `_timelex_cls`) a parser class attribute to facilitate overriding in subclasses.  `_timelex.split` constitutes a fairly large chunk of parser runtime and can benefit from e.g. cythonizing.

Zero logic is affected.
