### PR TITLE
implement _defaults field

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -238,7 +238,7 @@ class _resultbase(object):
 
     def __len__(self):
         return (sum(getattr(self, attr) is not None
-                    for attr in self.__slots__))
+                    for attr in self.__slots__ if attr != "_defaults"))
 
     def __repr__(self):
         return self._repr(self.__class__.__name__)

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -244,6 +244,20 @@ class _resultbase(object):
         return self._repr(self.__class__.__name__)
 
 
+class ParseResult(_resultbase):
+    __slots__ = ["year", "month", "day", "weekday",
+                 "hour", "minute", "second", "microsecond",
+                 "tzname", "tzoffset", "ampm", "any_unused_tokens",
+                 "_defaults"]
+
+    def __init__(self):
+        super(ParseResult, self).__init__()
+        # _defaults describe which fields were filled with default values
+        # as opposed to found in the parsed string.
+        self._defaults = set(["year", "month", "day",
+                              "hour", "minute", "second", "microsecond"])
+
+
 class parserinfo(object):
     """
     Class which handles what inputs are accepted. Subclass this to customize
@@ -571,6 +585,9 @@ class _ymd(list):
 
 
 class parser(object):
+    # _result is a class attribute to facilitate overriding in subclasses
+    _result = ParseResult
+
     def __init__(self, info=None):
         self.info = info or parserinfo()
 
@@ -659,11 +676,6 @@ class parser(object):
             return ret, skipped_tokens
         else:
             return ret
-
-    class _result(_resultbase):
-        __slots__ = ["year", "month", "day", "weekday",
-                     "hour", "minute", "second", "microsecond",
-                     "tzname", "tzoffset", "ampm","any_unused_tokens"]
 
     def _parse(self, timestr, dayfirst=None, yearfirst=None, fuzzy=False,
                fuzzy_with_tokens=False):
@@ -1213,6 +1225,8 @@ class parser(object):
             value = getattr(res, attr)
             if value is not None:
                 repl[attr] = value
+                # TODO: is this the best place to remove these from _defaults?
+                res._defaults.remove(attr)
 
         if 'day' not in repl:
             # If the default day exceeds the last day of the month, fall back


### PR DESCRIPTION
Last one for today; is a bit more step-in-a-process than the others.

Moves the definition of `_result` class to outside of the `parser` class, adds a comment explaining why `_result` is a `parser` attribute.  This does not affect any logic, but does improve readability.

The more important thing here is the introduction of `res._defaults`.  This holds the fields that were used instead of parsed.  (we could just as easily hold the complementary set, I'm more or less indifferent).

An example:
```
self = dateutil.parser.parser()
res = self._parse("July 4, 4:05 PM")[0]
default = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
ret = self._build_naive(res, default)

>>> ret
datetime.datetime(2018, 7, 4, 16, 0)
>>> res._defaults
set([u'second', u'microsecond', u'year'])
```

Two nice things we can do with this are:
a) infer the resolution of the datetime-like string
b) do validation on our results, e.g. it is pretty sketchy to have [year, day, minute, microsecond] but not [month, hour, second].
