### PR TITLE
pyproject.toml: add PEP 518 'build-system'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools", "wheel", "setuptools_scm"]
+
 [tool.towncrier]
     package = "dateutil"
     package_dir = "dateutil"


### PR DESCRIPTION
Fixes https://github.com/dateutil/dateutil/issues/736

setuptools and wheel are minimum requirements for build-system. I only added setuptools-scm
https://pip.pypa.io/en/stable/reference/pip/#pep-518-support


