### PR TITLE
#426: Added a parser example for overriding parserinfo

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1190,6 +1190,18 @@ Other random formats:
     datetime.datetime(1990, 6, 13, 5, 50)
 
 
+Override parserinfo with a custom parserinfo
+
+.. doctest:: tz
+
+   >>> from dateutil.parser import parse, parserinfo
+   >>> parserinfo = parserinfo()
+   >>> # e.g. edit a property of parserinfo to allow a custom 12 hour format identification
+   >>> parserinfo.AMPM[0] = (u'am', u'xm', u'a')
+   >>> parse('2018-06-08 12:06:58 XM', parserinfo=parserinfo)
+   datetime.datetime(2018, 6, 8, 0, 6, 58)
+
+
 tzutc examples
 --------------
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Added a doctest to describe how to achieve required behaviour.  Parsing of XM doesn't appear to be a mainstream behaviour so we should probably not implement this in the default parser. 

Closes #426 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
