### PR TITLE
Relicence my previous commits under Apache 2.0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,7 +17,7 @@ switch, and thus all their contributions are dual-licensed.
 - Alec Reiter <areiter@MASKED>
 - Alex Chamberlain (gh: @alexchamberlain) **D**
 - Alex Verdyan <verdyan@MASKED>
-- Alex Willmer <alex@MASKED> (gh: @moreati)
+- Alex Willmer <alex@moreati.org.uk> (gh: @moreati) **R**
 - Alexander Brugh <alexander.brugh@MASKED> (gh: @abrugh)
 - Andrew Murray <radarhere@MASKED>
 - Bernat Gabor <bgabor8@bloomberg.net> (gh: @gaborbernat) **D**

--- a/changelog.d/750.misc.txt
+++ b/changelog.d/750.misc.txt
@@ -1,0 +1,1 @@
+Relicensed Alex Willmer's commits (mainly those in pr #120) @moreati (gh pr #750)


### PR DESCRIPTION
## Summary of changes
Relicence commits I made prior to the move by the project to Apache 2.0 I declare that I hold the original copyright, and that they may be licensed under Apache 2.0 terms.

### Pull Request Checklist
- [ ] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
