### PR TITLE
#426 parse xm times

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -68,6 +68,7 @@ switch, and thus all their contributions are dual-licensed.
 - Nicholas Herrriot <Nicholas.Herriot@gmail.com> **D**
 - Nick Smith <nick.smith@MASKED>
 - Orson Adams <orson.network@MASKED> (gh: @parsethis)
+- Paul Dickson (gh @prdickson) **D**
 - Paul Ganssle <paul@ganssle.io> (gh: @pganssle) **R**
 - Pascal van Kooten <kootenpv@MASKED>
 - Pavel Ponomarev <comrad.awsum@MASKED>

--- a/changelog.d/753.doc.rst
+++ b/changelog.d/753.doc.rst
@@ -1,0 +1,1 @@
+Added an example of how to customize the parser with a parserinfo subclass. Added by @prdickson (gh #753)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1190,6 +1190,19 @@ Other random formats:
     datetime.datetime(1990, 6, 13, 5, 50)
 
 
+Override parserinfo with a custom parserinfo
+
+.. doctest:: tz
+
+   >>> from dateutil.parser import parse, parserinfo
+   >>> class CustomParserInfo(parserinfo):
+   ...     # e.g. edit a property of parserinfo to allow a custom 12 hour format
+   ...     AMPM = [("am", "a", "xm"), ("pm", "p")]
+   >>> parse('2018-06-08 12:06:58 XM', parserinfo=CustomParserInfo())
+   datetime.datetime(2018, 6, 8, 0, 6, 58)
+
+
+
 tzutc examples
 --------------
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Added a doctest example to demonstrate how to override parserinfo.  XM does not appear to be common with 12 hour date format so we should probably not include in default parserinfo.

Closes #426 

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
