### PR TITLE
Add LRU caching to tzoffset, tzstr and gettz

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -44,6 +44,7 @@ switch, and thus all their contributions are dual-licensed.
 - Florian Rathgeber (gh: @kynan) **D**
 - Gabriel Bianconi <gabriel@MASKED> (gh: @GabrielBianconi) **D**
 - Gabriel Poesia <gabriel.poesia@MASKED>
+- Gökçen Nurlu <gnurlu1@bloomberg.net> (gh: @gokcennurlu) **D**
 - Gustavo Niemeyer <gustavo@niemeyer.net> (gh: @niemeyer)
 - Holger Joukl <holger.joukl@MASKED> (gh: @hjoukl)
 - Igor <mrigor83@MASKED>

--- a/changelog.d/761.feature.rst
+++ b/changelog.d/761.feature.rst
@@ -1,0 +1,1 @@
+Added a small "strong value" cache into ``tz.gettz``, ``tz.tzoffset`` and ``tz.tzstr`` to improve performance in the situation where transient references are repeatedly created to the same time zones, but no strong reference is continuously held. Patch by Gökçen Nurlu (gh issue #691, gh pr #761)

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -746,12 +746,12 @@ def test_tzoffset_weakref():
     del UTC1
     gc.collect()
 
-    assert UTC_ref() is not None # Because strong cache should keep it
+    assert UTC_ref() is not None    # Should be in the strong cache
     assert UTC_ref() is tz.tzoffset('UTC', 0)
 
     # Fill the strong cache with other items
     for offset in range(5,15):
-        tz.tzoffset('UTC', offset)
+        tz.tzoffset('RandomZone', offset)
 
     gc.collect()
     assert UTC_ref() is  None
@@ -1149,7 +1149,7 @@ def test_gettz_weakref():
     del NYC1
     gc.collect()
 
-    assert NYC_ref() is not None # Because strong cache should keep it
+    assert NYC_ref() is not None        # Should still be in the strong cache
     assert tz.gettz('America/New_York') is NYC_ref()
 
     # Populate strong cache with other timezones
@@ -1158,7 +1158,7 @@ def test_gettz_weakref():
     tz.gettz('Australia/Currie')
 
     gc.collect()
-    assert NYC_ref() is None # Because strong cache should keep it
+    assert NYC_ref() is None    # Should have been pushed out
     assert tz.gettz('America/New_York') is not NYC_ref()
 
 class ZoneInfoGettzTest(GettzTest, WarningTestMixin):

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -746,7 +746,15 @@ def test_tzoffset_weakref():
     del UTC1
     gc.collect()
 
-    assert UTC_ref() is None
+    assert UTC_ref() is not None # Because strong cache should keep it
+    assert UTC_ref() is tz.tzoffset('UTC', 0)
+
+    # Fill the strong cache with other items
+    for offset in range(5,15):
+        tz.tzoffset('UTC', offset)
+
+    gc.collect()
+    assert UTC_ref() is  None
     assert UTC_ref() is not tz.tzoffset('UTC', 0)
 
 
@@ -1106,12 +1114,33 @@ def test_gettz_cache_clear():
 
     assert NYC1 is not NYC2
 
+@pytest.mark.gettz
+@pytest.mark.xfail(IS_WIN, reason='zoneinfo separately cached')
+def test_gettz_set_cache_size():
+    tz.gettz.cache_clear()
+    tz.gettz.set_cache_size(3)
+
+    MONACO_ref = weakref.ref(tz.gettz('Europe/Monaco'))
+    EASTER_ref = weakref.ref(tz.gettz('Pacific/Easter'))
+    CURRIE_ref = weakref.ref(tz.gettz('Australia/Currie'))
+
+    gc.collect()
+
+    assert MONACO_ref() is not None
+    assert EASTER_ref() is not None
+    assert CURRIE_ref() is not None
+
+    tz.gettz.set_cache_size(2)
+    gc.collect()
+
+    assert MONACO_ref() is None
 
 @pytest.mark.xfail(IS_WIN, reason="Windows does not use system zoneinfo")
 @pytest.mark.smoke
 @pytest.mark.gettz
 def test_gettz_weakref():
     tz.gettz.cache_clear()
+    tz.gettz.set_cache_size(2)
     NYC1 = tz.gettz('America/New_York')
     NYC_ref = weakref.ref(tz.gettz('America/New_York'))
 
@@ -1120,9 +1149,17 @@ def test_gettz_weakref():
     del NYC1
     gc.collect()
 
-    assert NYC_ref() is None
-    assert tz.gettz('America/New_York') is not NYC_ref()
+    assert NYC_ref() is not None # Because strong cache should keep it
+    assert tz.gettz('America/New_York') is NYC_ref()
 
+    # Populate strong cache with other timezones
+    tz.gettz('Europe/Monaco')
+    tz.gettz('Pacific/Easter')
+    tz.gettz('Australia/Currie')
+
+    gc.collect()
+    assert NYC_ref() is None # Because strong cache should keep it
+    assert tz.gettz('America/New_York') is not NYC_ref()
 
 class ZoneInfoGettzTest(GettzTest, WarningTestMixin):
     def gettz(self, name):
@@ -1460,6 +1497,13 @@ def test_tzstr_weakref():
     assert tz_t1 is tz_t2_ref()
 
     del tz_t1
+    gc.collect()
+
+    assert tz_t2_ref() is not None
+    assert tz.tzstr('EST5EDT') is tz_t2_ref()
+
+    for offset in range(5,15):
+        tz.tzstr('GMT+{}'.format(offset))
     gc.collect()
 
     assert tz_t2_ref() is None

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -14,6 +14,7 @@ import sys
 import os
 import bisect
 import weakref
+from collections import OrderedDict
 
 import six
 from six import string_types
@@ -1538,6 +1539,8 @@ def __get_gettz():
         def __init__(self):
 
             self.__instances = weakref.WeakValueDictionary()
+            self.__strong_cache_size = 8
+            self.__strong_cache = OrderedDict()
             self._cache_lock = _thread.allocate_lock()
 
         def __call__(self, name=None):
@@ -1556,12 +1559,27 @@ def __get_gettz():
                         # We also cannot store weak references to None, so we
                         # will also not store that.
                         self.__instances[name] = rv
+                    else:
+                        # No need for strong caching, return immediately
+                        return rv
+
+                self.__strong_cache[name] = self.__strong_cache.pop(name, rv)
+
+                if len(self.__strong_cache) == (self.__strong_cache_size + 1):
+                    self.__strong_cache.popitem(last=False)
 
             return rv
+
+        def set_cache_size(self, size):
+            with self._cache_lock:
+                self.__strong_cache_size = size
+                while len(self.__strong_cache) > size:
+                    self.__strong_cache.popitem(last=False)
 
         def cache_clear(self):
             with self._cache_lock:
                 self.__instances = weakref.WeakValueDictionary()
+                self.__strong_cache.clear()
 
         @staticmethod
         def nocache(name=None):

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1565,7 +1565,7 @@ def __get_gettz():
 
                 self.__strong_cache[name] = self.__strong_cache.pop(name, rv)
 
-                if len(self.__strong_cache) == (self.__strong_cache_size + 1):
+                if len(self.__strong_cache) > self.__strong_cache_size:
                     self.__strong_cache.popitem(last=False)
 
             return rv


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

I prepared a benchmark script and here are the results without the patch:

Benchmark:
https://gist.github.com/gokcennurlu/2b4e9d82e255c73e920c00ca5d26dcec

Results without patch:
```bash
3951.2012898921967 μs (tz.gettz() calls without storing values)
12.26398441940546 μs (tz.gettz() calls with storing values)


58.90091247856617 μs (tz.tzoffset() calls without storing values)
9.584207087755203 μs (tz.tzoffset() calls with storing values)


284.80793107300997 μs (tz.tzstr() calls without storing values)
7.534163072705269 μs (tz.tzstr() calls with storing values)
```

Results without patch:
```bash
27.99563854932785 μs (tz.gettz() calls without storing values)
28.635493479669094 μs (tz.gettz() calls with storing values)


22.882843017578125 μs (tz.tzoffset() calls without storing values)
25.380311533808708 μs (tz.tzoffset() calls with storing values)


24.550598114728928 μs (tz.tzstr() calls without storing values)
22.043749690055847 μs (tz.tzstr() calls with storing values)
```

'with storing values' means that a strong reference is kept in the scope (by doing `a = func(..)`) and lower values there explains the optimizing effect of currently used `WeakValueDictionary` based. caching.



<!-- Summary goes here -->

Closes #691 

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
