### PR TITLE
Closes #582: Allow partial minutes for python 3.6 or newer

### DIFF
--- a/changelog.d/582.bug.rst
+++ b/changelog.d/582.bug.rst
@@ -1,0 +1,1 @@
+Added support for sub-minute offsets in Python 3.6+. Fixed by @cssherry (gh issue #582, pr #763)


### PR DESCRIPTION
## Summary of changes

As described in python bug tracker (https://bugs.python.org/issue5288), datetime now allows offsets that are not an integer number of minutes. Dateutil now accounts for this when running in newer versions of python

- Add "Africa/Monrovia" to test_resolve_imaginary test for python 3.6 or newer
- Test that partial minutes is supported in python 3.6 or newer for tz.tzfile and datetime.utcoffset
- Enable partial minutes in both tz.tzoffset and tz.tzfile
- For now, don't warn user when rounding to nearest minute for python pre-3.6

Closes #582

### Pull Request Checklist
- [x] Changes have tests
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [X] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
