### PR TITLE
function annotations for utils.py

### DIFF
--- a/dateutil/utils.py
+++ b/dateutil/utils.py
@@ -7,10 +7,11 @@ datetimes.
 """
 from __future__ import unicode_literals
 
-from datetime import datetime, time
+from datetime import datetime, time, tzinfo, timedelta
+from typing import Union
 
 
-def today(tzinfo=None):
+def today(tzinfo=None):  # type: (Union[tzinfo, None]) -> datetime
     """
     Returns a :py:class:`datetime` representing the current day at midnight
 
@@ -26,7 +27,7 @@ def today(tzinfo=None):
     return datetime.combine(dt.date(), time(0, tzinfo=tzinfo))
 
 
-def default_tzinfo(dt, tzinfo):
+def default_tzinfo(dt, tzinfo):  # type: (datetime, tzinfo) -> datetime
     """
     Sets the the ``tzinfo`` parameter on naive datetimes only
 
@@ -61,9 +62,9 @@ def default_tzinfo(dt, tzinfo):
         return dt.replace(tzinfo=tzinfo)
 
 
-def within_delta(dt1, dt2, delta):
+def within_delta(dt1, dt2, delta):  # type: (datetime, datetime, timedelta) -> bool
     """
-    Useful for comparing two datetimes that may a negilible difference
+    Useful for comparing two datetimes that may a negligible difference
     to be considered equal.
     """
     delta = abs(delta)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

First pass on function annotations for tools like `Mypy` and `pyre` for utils.py. 
addresses #383 for utils.py

- Not sure how I feel about the fact that imports now exists at the top of the file just for type checking. 
- Not sure how well this will work for modules that depend on this code (will they know that the annotation `def within_delta(dt1, dt2, delta):  # type: (datetime, datetime, timedelta) -> bool` assumes that `datetime`is coming from the `datetime` module. `Mypy` knows this when it's ran on this module. Will the code that imports this know this?)

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
