### PR TITLE
Add test for invalid separator in isoparser

### DIFF
--- a/changelog.d/772.misc.rst
+++ b/changelog.d/772.misc.rst
@@ -1,0 +1,1 @@
+Added tests that an error is raised for an incorrect separator character in a strict isoparser. Contribution by @alimcmaster1 (gh pr #772).

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -264,12 +264,15 @@ def test_iso_raises(isostr, exception):
         isoparse(isostr)
 
 
-@pytest.mark.parametrize('sep_act,valid_sep', [
-    ('C', 'T'),
-    ('T', 'C')
+@pytest.mark.parametrize('sep_act, valid_sep, exception', [
+    ('T', 'C', ValueError),
+    ('C', 'T', ValueError),
 ])
-def test_iso_raises_sep(sep_act, valid_sep):
+def test_iso_with_sep_raises(sep_act, valid_sep, exception):
+    parser = isoparser(sep=valid_sep)
     isostr = '2012-04-25' + sep_act + '01:25:00'
+    with pytest.raises(exception):
+        parser.isoparse(isostr)
 
 
 @pytest.mark.xfail()


### PR DESCRIPTION
## Summary of changes
Add test for invalid separator in ISO parser.

### Pull Request Checklist
- [X] Changes have tests
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [X] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
