### PR TITLE
Fix isotime behavior for strings with hour == 24

### DIFF
--- a/changelog.d/773.bugfix.rst
+++ b/changelog.d/773.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where ``isoparser.parse_isotime`` was unable to handle the ``24:00`` variant representation of midnight. (gh pr #773)

--- a/changelog.d/773.misc.rst
+++ b/changelog.d/773.misc.rst
@@ -1,0 +1,1 @@
+Added tests that parse_isotime only allows hours == 24 when the time is midnight. (gh pr #773)

--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -176,7 +176,7 @@ class isoparser(object):
         components = self._parse_isotime(timestr)
         if components[0] == 24:
             components[0] = 0
-        return time(*self._parse_isotime(timestr))
+        return time(*components)
 
     @_takes_ascii
     def parse_tzstr(self, tzstr, zero_as_utc=True):

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -452,6 +452,22 @@ def test_isotime(time_val, time_fmt, as_bytes):
 
     assert iparser.parse_isotime(tstr) == time_val
 
+
+@pytest.mark.parametrize('isostr', [
+    '24:00',
+    '2400',
+    '24:00:00',
+    '240000',
+    '24:00:00.000',
+    '24:00:00,000',
+    '24:00:00.000000',
+    '24:00:00,000000',
+])
+def test_isotime_midnight(isostr):
+    iparser = isoparser()
+    assert iparser.parse_isotime(isostr) == time(0, 0, 0, 0)
+
+
 @pytest.mark.parametrize('isostr,exception', [
     ('3', ValueError),                          # ISO string too short
     ('14時30分15秒', ValueError),                # Not ASCII

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -484,6 +484,10 @@ def test_isotime_midnight(isostr):
     ('14:59:59+25:00', ValueError),             # Invalid tz hours
     ('14:59:59+12:62', ValueError),             # Invalid tz minutes
     ('14:59:30_344583', ValueError),            # Invalid microsecond separator
+    ('24:01', ValueError),                      # 24 used for non-midnight time
+    ('24:00:01', ValueError),                   # 24 used for non-midnight time
+    ('24:00:00.001', ValueError),               # 24 used for non-midnight time
+    ('24:00:00.000001', ValueError),            # 24 used for non-midnight time
 ])
 def test_isotime_raises(isostr, exception):
     iparser = isoparser()


### PR DESCRIPTION
## Summary of changes
I discovered this when writing tests to hit the last uncovered line in isoparser.py, `parse_isotime` was actually parsing all time strings twice - first it would parse and adjust 24 -> 0, then it would parse again and pass the unmodified string directly to `datetime.time`.

This adds fixes the behavior and brings the test coverage to 100%.

### Pull Request Checklist
- [X] Changes have tests
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
