### PR TITLE
Warnings as errors

### DIFF
--- a/changelog.d/780.misc.rst
+++ b/changelog.d/780.misc.rst
@@ -1,0 +1,1 @@
+Switched test suite over to throwing errors whenever unexpected warnings are raised. As part of this, the test_import_star test was cleaned up, as it had been throwing deprecation warnings. (gh pr #780)

--- a/dateutil/test/test_import_star.py
+++ b/dateutil/test/test_import_star.py
@@ -2,7 +2,7 @@
 
 As import * can be only done at module level, it has been added in a separate file
 """
-import unittest
+import pytest
 
 prev_locals = list(locals())
 from dateutil import *
@@ -10,24 +10,24 @@ new_locals = {name:value for name,value in locals().items()
               if name not in prev_locals}
 new_locals.pop('prev_locals')
 
-class ImportStarTest(unittest.TestCase):
-    """ Test that `from dateutil import *` adds the modules in __all__ locally"""
 
-    def testImportedModules(self):
-        import dateutil.easter
-        import dateutil.parser
-        import dateutil.relativedelta
-        import dateutil.rrule
-        import dateutil.tz
-        import dateutil.utils
-        import dateutil.zoneinfo
+@pytest.mark.import_star
+def test_imported_modules():
+    """ Test that `from dateutil import *` adds modules in __all__ locally """
+    import dateutil.easter
+    import dateutil.parser
+    import dateutil.relativedelta
+    import dateutil.rrule
+    import dateutil.tz
+    import dateutil.utils
+    import dateutil.zoneinfo
 
-        self.assertEqual(dateutil.easter, new_locals.pop("easter"))
-        self.assertEqual(dateutil.parser, new_locals.pop("parser"))
-        self.assertEqual(dateutil.relativedelta, new_locals.pop("relativedelta"))
-        self.assertEqual(dateutil.rrule, new_locals.pop("rrule"))
-        self.assertEqual(dateutil.tz, new_locals.pop("tz"))
-        self.assertEqual(dateutil.utils, new_locals.pop("utils"))
-        self.assertEqual(dateutil.zoneinfo, new_locals.pop("zoneinfo"))
+    assert dateutil.easter == new_locals.pop("easter")
+    assert dateutil.parser == new_locals.pop("parser")
+    assert dateutil.relativedelta == new_locals.pop("relativedelta")
+    assert dateutil.rrule == new_locals.pop("rrule")
+    assert dateutil.tz == new_locals.pop("tz")
+    assert dateutil.utils == new_locals.pop("utils")
+    assert dateutil.zoneinfo == new_locals.pop("zoneinfo")
 
-        self.assertFalse(new_locals)
+    assert not new_locals

--- a/dateutil/test/test_import_star.py
+++ b/dateutil/test/test_import_star.py
@@ -22,12 +22,12 @@ class ImportStarTest(unittest.TestCase):
         import dateutil.utils
         import dateutil.zoneinfo
 
-        self.assertEquals(dateutil.easter, new_locals.pop("easter"))
-        self.assertEquals(dateutil.parser, new_locals.pop("parser"))
-        self.assertEquals(dateutil.relativedelta, new_locals.pop("relativedelta"))
-        self.assertEquals(dateutil.rrule, new_locals.pop("rrule"))
-        self.assertEquals(dateutil.tz, new_locals.pop("tz"))
-        self.assertEquals(dateutil.utils, new_locals.pop("utils"))
-        self.assertEquals(dateutil.zoneinfo, new_locals.pop("zoneinfo"))
+        self.assertEqual(dateutil.easter, new_locals.pop("easter"))
+        self.assertEqual(dateutil.parser, new_locals.pop("parser"))
+        self.assertEqual(dateutil.relativedelta, new_locals.pop("relativedelta"))
+        self.assertEqual(dateutil.rrule, new_locals.pop("rrule"))
+        self.assertEqual(dateutil.tz, new_locals.pop("tz"))
+        self.assertEqual(dateutil.utils, new_locals.pop("utils"))
+        self.assertEqual(dateutil.zoneinfo, new_locals.pop("zoneinfo"))
 
         self.assertFalse(new_locals)

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,7 @@ license_file = LICENSE
 
 [tool:pytest]
 xfail_strict = true
+filterwarnings =
+    error
+    error::DeprecationWarning
+    error:PendingDeprecationWarning


### PR DESCRIPTION
## Summary of changes
This makes the tests stricter by enforcing that the test suite raises no warnings accidentally, including deprecation warnings.

As part of adding this, I realized that the test suite was using `self.assertEquals`, so I converted it first to the non-deprecated version and then moved `test_import_star` over to a pytest-style test.

### Pull Request Checklist
- [X] Changes have tests
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
