### PR TITLE
Accept more than 6 fractional digits in `isoparse`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,6 +49,7 @@ switch, and thus all their contributions are dual-licensed.
 - Ionuț Ciocîrlan <jdxlark@MASKED>
 - Jake Chorley (gh: @jakec-github) **D**
 - Jan Studený <jendas1@MASKED>
+- Jay Weisskopf <jay@jayschwa.net> (gh: @jayschwa) **D**
 - Jitesh <jitesh@MASKED>
 - John Purviance <jpurviance@MASKED> (gh @jpurviance) **D**
 - Jon Dufresne <jon.dufresne@MASKED> (gh: @jdufresne) **R**

--- a/changelog.d/787.bugfix.rst
+++ b/changelog.d/787.bugfix.rst
@@ -1,0 +1,2 @@
+Accept more than 6 fractional digits in `isoparse`.
+Reported and fixed by @jayschwa (gh issue #786, gh pr #787).

--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -88,7 +88,7 @@ class isoparser(object):
         - ``hh``
         - ``hh:mm`` or ``hhmm``
         - ``hh:mm:ss`` or ``hhmmss``
-        - ``hh:mm:ss.sss`` or ``hh:mm:ss.ssssss`` (3-6 sub-second digits)
+        - ``hh:mm:ss.ssssss`` (Up to 6 sub-second digits)
 
         Midnight is a special case for `hh`, as the standard supports both
         00:00 and 24:00 as a representation. The decimal separator can be
@@ -199,10 +199,9 @@ class isoparser(object):
         return self._parse_tzstr(tzstr, zero_as_utc=zero_as_utc)
 
     # Constants
-    _MICROSECOND_END_REGEX = re.compile(b'[-+Z]+')
     _DATE_SEP = b'-'
     _TIME_SEP = b':'
-    _MICRO_SEPS = b'.,'
+    _FRACTION_REGEX = re.compile(b'[\\.,]([0-9]+)')
 
     def _parse_isodate(self, dt_str):
         try:
@@ -357,16 +356,14 @@ class isoparser(object):
                     pos += 1
 
             if comp == 3:
-                # Microsecond
-                if timestr[pos:pos + 1] not in self._MICRO_SEPS:
+                # Fraction of a second
+                frac = self._FRACTION_REGEX.match(timestr[pos:])
+                if not frac:
                     continue
 
-                pos += 1
-                us_str = self._MICROSECOND_END_REGEX.split(timestr[pos:pos + 6],
-                                                           1)[0]
-
+                us_str = frac.group(1)[:6]  # Truncate to microseconds
                 components[comp] = int(us_str) * 10**(6 - len(us_str))
-                pos += len(us_str)
+                pos += len(frac.group())
 
         if pos < len_str:
             raise ValueError('Unused components in ISO string')

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -130,6 +130,15 @@ def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
 
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset, precision)
 
+###
+# Truncation of extra digits beyond microsecond precision
+@pytest.mark.parametrize('dt_str', [
+    '2018-07-03T14:07:00.123456000001',
+    '2018-07-03T14:07:00.123456999999',
+])
+def test_extra_subsecond_digits(dt_str):
+    assert isoparse(dt_str) == datetime(2018, 7, 3, 14, 7, 0, 123456)
+
 @pytest.mark.parametrize('tzoffset', FULL_TZOFFSETS)
 def test_full_tzoffsets(tzoffset):
     dt = datetime(2017, 11, 27, 6, 14, 30, 123456)
@@ -473,12 +482,11 @@ def test_isotime_midnight(isostr):
     ('14時30分15秒', ValueError),                # Not ASCII
     ('14_30_15', ValueError),                   # Invalid separators
     ('1430:15', ValueError),                    # Inconsistent separator use
-    ('14:30:15.3684000309', ValueError),        # Too much us precision
     ('25', ValueError),                         # Invalid hours
     ('25:15', ValueError),                      # Invalid hours
     ('14:60', ValueError),                      # Invalid minutes
     ('14:59:61', ValueError),                   # Invalid seconds
-    ('14:30:15.3446830500', ValueError),        # No sign in time zone
+    ('14:30:15.34468305:00', ValueError),       # No sign in time zone
     ('14:30:15+', ValueError),                  # Time zone too short
     ('14:30:15+1234567', ValueError),           # Time zone invalid
     ('14:59:59+25:00', ValueError),             # Invalid tz hours


### PR DESCRIPTION
RFC 3339 does not specify a limit to the number of fractional digits
that can be provided. In the wild, languages like Go will provide up
to 9 digits by default.

Since the standard library's `datetime` only supports precision down
to microseconds, any extra digits in the fractional component are
truncated.

Closes #786

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
