### PR TITLE
Use Python3.7's nullcontext if available

### DIFF
--- a/changelog.d/791.misc.rst
+++ b/changelog.d/791.misc.rst
@@ -1,0 +1,1 @@
+Moved the ``tz.tz._ContextWrapper`` class to ``tz.tz._nullcontext``; the old class is now a backport of ``contextmanager.nullcontext``, which is used if available. (gh pr #791)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -465,7 +465,7 @@ class tzfile(_tzinfo):
 
         if fileobj is not None:
             if not file_opened_here:
-                fileobj = _ContextWrapper(fileobj)
+                fileobj = _nullcontext(fileobj)
 
             with fileobj as file_stream:
                 tzobj = self._read_tzfile(file_stream)
@@ -1257,7 +1257,7 @@ class tzical(object):
             fileobj = open(fileobj, 'r')
         else:
             self._s = getattr(fileobj, 'name', repr(fileobj))
-            fileobj = _ContextWrapper(fileobj)
+            fileobj = _nullcontext(fileobj)
 
         self._vtz = {}
 
@@ -1784,18 +1784,22 @@ else:
         return calculated_offset
 
 
-class _ContextWrapper(object):
-    """
-    Class for wrapping contexts so that they are passed through in a
-    with statement.
-    """
-    def __init__(self, context):
-        self.context = context
+try:
+    # Python 3.7 feature
+    from contextmanager import nullcontext as _nullcontext
+except ImportError:
+    class _nullcontext(object):
+        """
+        Class for wrapping contexts so that they are passed through in a
+        with statement.
+        """
+        def __init__(self, context):
+            self.context = context
 
-    def __enter__(self):
-        return self.context
+        def __enter__(self):
+            return self.context
 
-    def __exit__(*args, **kwargs):
-        pass
+        def __exit__(*args, **kwargs):
+            pass
 
 # vim:ts=4:sw=4:et


### PR DESCRIPTION
## Summary of changes
The _ContextWrapper class was added before nullcontext was added
to the standard library. When available, we should prefer to use
nullcontext.

### Pull Request Checklist
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
