### PR TITLE
Make tzutc and tzoffset hashable

### DIFF
--- a/changelog.d/794.feature.rst
+++ b/changelog.d/794.feature.rst
@@ -1,0 +1,1 @@
+Made ``tzutc`` and ``tzoffset`` explicitly hashable. Reported by @mroeschke (gh issue #792, gh pr #794)

--- a/dateutil/test/property/test_tz_prop.py
+++ b/dateutil/test/property/test_tz_prop.py
@@ -1,0 +1,42 @@
+from hypothesis import strategies as st
+from hypothesis import given, example, assume
+
+from dateutil import tz
+
+from datetime import timedelta
+
+import pytest
+
+#
+# Pre-made strategies
+#
+TZO_NAME_ST = st.one_of(st.none(), st.text())
+TZO_OFFSET_ST = st.timedeltas(min_value=timedelta(hours=-24),
+                              max_value=timedelta(hours=24))
+
+@pytest.mark.tzoffset
+@given(name1=TZO_NAME_ST, off1=TZO_OFFSET_ST,
+       name2=TZO_NAME_ST, off2=TZO_OFFSET_ST)
+def test_tzoffset_hashable(name1, off1, name2, off2):
+    tzo1_td = tz.tzoffset(name1, off1)
+    tzo1_se = tz.tzoffset(name1, off1.total_seconds())
+
+    tzo2_td = tz.tzoffset(name2, off2)
+    tzo2_se = tz.tzoffset(name2, off2.total_seconds())
+
+    assume(tzo1_td != tzo2_td)
+
+    assert hash(tzo1_td) == hash(tzo1_se)
+    assert hash(tzo2_td) == hash(tzo2_se)
+
+    assert hash(tzo1_td) != hash(tzo2_td)
+    assert hash(tzo1_se) != hash(tzo2_se)
+
+
+@pytest.mark.tzoffset
+@given(name=TZO_NAME_ST, off=TZO_OFFSET_ST)
+def test_tzoffset_in_sets(name, off):
+    tzo = tz.tzoffset(name, off)
+    s = {tzo}
+    assert tzo in s
+

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -610,6 +610,7 @@ class TzWinFoldMixin(object):
 
 ###
 # Test Cases
+@pytest.mark.tzutc
 class TzUTCTest(unittest.TestCase):
     def testSingleton(self):
         UTC_0 = tz.tzutc()
@@ -666,6 +667,13 @@ class TzUTCTest(unittest.TestCase):
         dt = datetime(2011, 9, 1, 2, 30, tzinfo=tz.tzutc())
 
         self.assertFalse(tz.datetime_ambiguous(dt))
+
+    def testHashable(self):
+        assert hash(tz.UTC) == hash(tz.tzutc())
+
+    def testCanBeInSets(self):
+        s = {tz.UTC}
+        assert tz.tzutc() in s
 
 
 @pytest.mark.tzoffset

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -111,7 +111,8 @@ class tzutc(datetime.tzinfo):
         return (isinstance(other, tzutc) or
                 (isinstance(other, tzoffset) and other._offset == ZERO))
 
-    __hash__ = None
+    def __hash__(self):
+        return hash(id(self))
 
     def __ne__(self, other):
         return not (self == other)

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -179,7 +179,8 @@ class tzoffset(datetime.tzinfo):
 
         return self._offset == other._offset
 
-    __hash__ = None
+    def __hash__(self):
+        return hash((self._name, self._offset))
 
     def __ne__(self, other):
         return not (self == other)


### PR DESCRIPTION
## Summary of changes
This makes `tzutc` and `tzoffset` hashable.

The one thing that I think might be a problem here is that the other time zone classes are not hashable, and defining hashability for those is I think a bit more problematic. Might be worth defaulting to hashing by identity.

Closes #792

### Pull Request Checklist
- [X] Changes have tests
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details