### PR TITLE
Add test cases for positive offsets

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -23,6 +23,7 @@ switch, and thus all their contributions are dual-licensed.
 - Andrew Bennett (gh: @andrewcbennett) **D**
 - Andrew Murray <radarhere@MASKED>
 - Bernat Gabor <bgabor8@bloomberg.net> (gh: @gaborbernat) **D**
+- Bradlee Speice <bradlee@speice.io> (gh: @bspeice) **D**
 - Brandon W Maister <quodlibetor@MASKED>
 - Brock Mendel <jbrockmendel@MASKED> (gh: @jbrockmendel) **R**
 - Brook Li (gh: @absreim) **D**

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -314,6 +314,11 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 10, 49, 41,
                                   tzinfo=self.brsttz))
 
+    def testISOFormatStrip2(self):
+        self.assertEqual(parse("2003-09-25T10:49:41+03:00"),
+                         datetime(2003, 9, 25, 10, 49, 41,
+                                  tzinfo=tzoffset(None, 10800)))
+
     def testISOStrippedFormat(self):
         self.assertEqual(parse("20030925T104941.5-0300"),
                          datetime(2003, 9, 25, 10, 49, 41, 500000,
@@ -323,6 +328,11 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("20030925T104941-0300"),
                          datetime(2003, 9, 25, 10, 49, 41,
                                   tzinfo=self.brsttz))
+
+    def testISOStrippedFormatStrip2(self):
+        self.assertEqual(parse("20030925T104941+0300"),
+                         datetime(2003, 9, 25, 10, 49, 41,
+                                  tzinfo=tzoffset(None, 10800)))
 
     def testDateWithDash8(self):
         self.assertEqual(parse("10-09-2003", dayfirst=True),


### PR DESCRIPTION
## Summary of changes

Add test cases that already pass. I'm working on a reimplementation of the parser in Rust, and copied all the test cases from dateutil; found out tonight there was a bug because I wasn't handling "GMT+03" correctly, and so wanted to add these as part of the coverage.

### Pull Request Checklist
- [✓] Changes have tests
- [✓] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [N/A] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
