### PR TITLE
Pin setuptools version on Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
 install:
   - pip install -U six && pip install -U tox
   - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   - if [[ $TOXENV == "py" ]]; then ./ci_tools/retry.sh python updatezinfo.py; fi
 
 script:

--- a/changelog.d/799.misc.rst
+++ b/changelog.d/799.misc.rst
@@ -1,0 +1,1 @@
+Pinned setuptools to <40.0 in CI build on Python 3.3, for whatever reason pip doesn't respect python_requires for that package on Python 3.3. (gh pr #799)


### PR DESCRIPTION
Not sure why but `setuptools` seems to have started breaking on Python 3.3