### PR TITLE
Fix bug with Samoan offset change, refactor base offset change handling

### DIFF
--- a/changelog.d/810.bugfix.rst
+++ b/changelog.d/810.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug with base offset changes during DST in ``tzfile``, and refactored the way base offset changes are detected. Originally reported on StackOverflow by @MartinThoma. (gh issue #812, gh pr #810)

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -2032,9 +2032,8 @@ def test_sub_minute_rounding_tzfile():
 
 
 @pytest.mark.tzfile
-@pytest.mark.xfail
 def test_samoa_transition():
-    # utcoffset() is erroneously returning +14:00 an hour early (GH #812)
+    # utcoffset() was erroneously returning +14:00 an hour early (GH #812)
     APIA = tz.gettz('Pacific/Apia')
     dt = datetime(2011, 12, 29, 23, 59, tzinfo=APIA)
     assert dt.utcoffset() == timedelta(hours=-10)

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1950,11 +1950,6 @@ class TZTest(unittest.TestCase):
         tzc = tz.tzfile(fileobj)
         self.assertEqual(repr(tzc), 'tzfile(' + repr('foo') + ')')
 
-
-
-
-
-
     def testLeapCountDecodesProperly(self):
         # This timezone has leapcnt, and failed to decode until
         # Eugene Oden notified about the issue.
@@ -2034,6 +2029,20 @@ def test_sub_minute_rounding_tzfile():
     tzc = tz.tzfile(BytesIO(base64.b64decode(EUROPE_HELSINKI)))
     offset = timedelta(hours=1, minutes=40)
     assert datetime(1900, 1, 1, 0, 0, tzinfo=tzc).utcoffset() == offset
+
+
+@pytest.mark.tzfile
+@pytest.mark.xfail
+def test_samoa_transition():
+    # utcoffset() is erroneously returning +14:00 an hour early (GH #812)
+    APIA = tz.gettz('Pacific/Apia')
+    dt = datetime(2011, 12, 29, 23, 59, tzinfo=APIA)
+    assert dt.utcoffset() == timedelta(hours=-10)
+
+    # Make sure the transition actually works, too
+    dt_after = (dt.astimezone(tz.UTC) + timedelta(minutes=1)).astimezone(APIA)
+    assert dt_after == datetime(2011, 12, 31, tzinfo=APIA)
+    assert dt_after.utcoffset() == timedelta(hours=14)
 
 
 @unittest.skipUnless(IS_WIN, "Requires Windows")


### PR DESCRIPTION
This is a test and fix for the bug first reported [in this StackOverflow question](https://stackoverflow.com/q/52136980/467366), and migrated to GH in issue #812.

When cleaning that up, I discovered a cleaner way to handle the issue of Portugal's base offset shift without a corresponding total offset shift, obviating the need for a second traversal of the transition list.

Fixes #812.