### PR TITLE
Improve tzname_in_python2 decorator

### DIFF
--- a/changelog.d/811.bugfix.rst
+++ b/changelog.d/811.bugfix.rst
@@ -1,0 +1,1 @@
+Improved performance and inspection properties of tzname methods. (gh pr #811)

--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -1,4 +1,4 @@
-from six import PY3
+from six import PY2
 
 from functools import wraps
 
@@ -16,14 +16,18 @@ def tzname_in_python2(namefunc):
     tzname() API changed in Python 3. It used to return bytes, but was changed
     to unicode strings
     """
-    def adjust_encoding(*args, **kwargs):
-        name = namefunc(*args, **kwargs)
-        if name is not None and not PY3:
-            name = name.encode()
+    if PY2:
+        @wraps(namefunc)
+        def adjust_encoding(*args, **kwargs):
+            name = namefunc(*args, **kwargs)
+            if name is not None:
+                name = name.encode()
 
-        return name
+            return name
 
-    return adjust_encoding
+        return adjust_encoding
+    else:
+        return namefunc
 
 
 # The following is adapted from Alexander Belopolsky's tz library


### PR DESCRIPTION
This improves the ability to inspect wrapped tzname methods in Python 2
and removes an unnecessary function call (to the nested function) in
Python 3. From my measurements, this is about twice as fast in Python 3
and approximately the same speed in Python 2.

### Pull Request Checklist
- Changes have tests (N/A)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
