### PR TITLE
Always use io.BytesIO/StringIO over six; on all supported Pythons

### DIFF
--- a/changelog.d/813.misc.rst
+++ b/changelog.d/813.misc.rst
@@ -1,0 +1,1 @@
+Dropped use of six.(Bytes|String)IO in favor of io.(Bytes|String)IO in two test files. Patch by @jdufresne (gh pr #813)

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -14,7 +14,7 @@ from dateutil.parser import UnknownTimezoneWarning
 from ._common import TZEnvContext
 
 from six import assertRaisesRegex, PY3
-from six.moves import StringIO
+from io import StringIO
 
 import pytest
 

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from datetime import time as dt_time
 from datetime import tzinfo
 from six import PY2
-from six import BytesIO, StringIO
+from io import BytesIO, StringIO
 import unittest
 
 import sys


### PR DESCRIPTION
More forward compatible by slightly reducing unnecessary use of the six library.