### PR TITLE
setup.py test doesn't work, so exit with 1

### DIFF
--- a/changelog.d/814.bugfix.rst
+++ b/changelog.d/814.bugfix.rst
@@ -1,0 +1,1 @@
+Changed the ``python setup.py test`` to print an error to ``stderr`` and exit with 1 instead of 0. Reported and fixed by @hroncok (gh pr #814)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from distutils.version import LooseVersion
 import warnings
 
 import io
+import sys
 
 if isfile("MANIFEST"):
     os.unlink("MANIFEST")
@@ -21,8 +22,9 @@ if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
 
 class Unsupported(TestCommand):
     def run(self):
-        print("Running 'test' with setup.py is not supported. "
-              "Use 'pytest' or 'tox' to run the tests.")
+        sys.stderr.write("Running 'test' with setup.py is not supported. "
+                         "Use 'pytest' or 'tox' to run the tests.\n")
+        sys.exit(1)
 
 
 ###


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

The error message was printed, but the process exited with 0.
That is extremely error prone in automated environments.

Also, print the error message to standard error.

This is **completely untested** as I'm doing the change from the web interface.

### Pull Request Checklist
- [x] Changes have tests - AFAIK there are no setup.py related tests here
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md) - consider this trivial and Public Domain
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details - I'm doing this from the GitHub web interface and it starts to be rather complicated :(

I will eventually get to this from a machine where I can clone and rebase and stuff.
