### PR TITLE
Pin sphinx to <1.8.0 for docs build

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,3 @@
-Sphinx>=1.7.3,<2
+Sphinx>=1.7.3,<1.8.0        # Type annotation bug
 sphinx_rtd_theme>=0.3.0
 readme-renderer>=21.0


### PR DESCRIPTION
Sphinx made some sort of type annotation related change that is throwing a warning for `rrule.rrulestr` which is a callable object defined in a closure rather than a Python function object. Until they fix this bug, we'll pin to the previous version of Sphinx.

See https://github.com/sphinx-doc/sphinx/pull/5345 for where this seems to be breaking.