### PR TITLE
Remove unnecessary binary_type compatibility shim

### DIFF
--- a/changelog.d/817.bugfix.rst
+++ b/changelog.d/817.bugfix.rst
@@ -1,0 +1,1 @@
+Removed unnecessary binary_type compatibility shims. Added by @jdufresne (gh pr #817)

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -40,7 +40,7 @@ from calendar import monthrange
 from io import StringIO
 
 import six
-from six import binary_type, integer_types, text_type
+from six import integer_types, text_type
 
 from decimal import Decimal
 
@@ -63,7 +63,7 @@ class _timelex(object):
         if six.PY2:
             # In Python 2, we can't duck type properly because unicode has
             # a 'decode' function, and we'd be double-decoding
-            if isinstance(instream, (binary_type, bytearray)):
+            if isinstance(instream, (bytes, bytearray)):
                 instream = instream.decode()
         else:
             if getattr(instream, 'decode', None) is not None:

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -380,7 +380,7 @@ def test_parse_isodate(d, dt_fmt, as_bytes):
     d_str = d.strftime(dt_fmt)
     if isinstance(d_str, six.text_type) and as_bytes:
         d_str = d_str.encode('ascii')
-    elif isinstance(d_str, six.binary_type) and not as_bytes:
+    elif isinstance(d_str, bytes) and not as_bytes:
         d_str = d_str.decode('ascii')
 
     iparser = isoparser()
@@ -454,7 +454,7 @@ def test_isotime(time_val, time_fmt, as_bytes):
     tstr = time_val.strftime(time_fmt)
     if isinstance(time_val, six.text_type) and as_bytes:
         tstr = tstr.encode('ascii')
-    elif isinstance(time_val, six.binary_type) and not as_bytes:
+    elif isinstance(time_val, bytes) and not as_bytes:
         tstr = tstr.decode('ascii')
 
     iparser = isoparser()


### PR DESCRIPTION
The `bytes` type is available on all supported Pythons. Can remove workaround and make the code more forward compatible with Python 3.