### PR TITLE
Change sphinx pin to != 1.8.0

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,3 @@
-Sphinx>=1.7.3,<1.8.0        # Type annotation bug
+Sphinx>=1.7.3,!=1.8.0
 sphinx_rtd_theme>=0.3.0
 readme-renderer>=21.0


### PR DESCRIPTION
The callable function typing issue should be fixed in sphinx commit bbb4593bfaa65611b6bd600c5, so the next release after 1.8.0 should contain the fix.

Fixed in GH sphinx-doc/sphinx#5431

https://github.com/sphinx-doc/sphinx/commit/bbb4593bfaa65611b6bd600c5e37c4c54af87f1a

Probably best to wait until a new version of Sphinx is released to merge this rather than just having to revert it if the new version still doesn't work.