### PR TITLE
BUG: Closes #820 Accepting 'z' as valid UTC in isoparser

### DIFF
--- a/changelog.d/822.bugfix.rst
+++ b/changelog.d/822.bugfix.rst
@@ -1,0 +1,1 @@
+Accept 'z' as valid UTC time zone in isoparser. Reported by @cjgibson (gh issue #820). Fixed by @Cheukting (gh pr #822)

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -291,7 +291,7 @@ class parserinfo(object):
            ("s", "second", "seconds")]
     AMPM = [("am", "a"),
             ("pm", "p")]
-    UTCZONE = ["UTC", "GMT", "Z"]
+    UTCZONE = ["UTC", "GMT", "Z", "z"]
     PERTAIN = ["of"]
     TZOFFSET = {}
     # TODO: ERA = ["AD", "BC", "CE", "BCE", "Stardate",

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -388,7 +388,8 @@ class parserinfo(object):
         if res.year is not None:
             res.year = self.convertyear(res.year, res.century_specified)
 
-        if res.tzoffset == 0 and not res.tzname or res.tzname == 'Z':
+        if (res.tzoffset == 0 and not res.tzname or res.tzname == 'Z'
+            or res.tzname == 'z'):
             res.tzname = "UTC"
             res.tzoffset = 0
         elif res.tzoffset != 0 and res.tzname and self.utczone(res.tzname):
@@ -1060,7 +1061,8 @@ class parser(object):
                 tzname is None and
                 tzoffset is None and
                 len(token) <= 5 and
-                all(x in string.ascii_uppercase for x in token))
+                (all(x in string.ascii_uppercase for x in token)
+                 or token in self.info.UTCZONE))
 
     def _ampm_valid(self, hour, ampm, fuzzy):
         """

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -388,8 +388,8 @@ class parserinfo(object):
         if res.year is not None:
             res.year = self.convertyear(res.year, res.century_specified)
 
-        if (res.tzoffset == 0 and not res.tzname or res.tzname == 'Z'
-            or res.tzname == 'z'):
+        if ((res.tzoffset == 0 and not res.tzname) or
+             (res.tzname == 'Z' or res.tzname == 'z')):
             res.tzname = "UTC"
             res.tzoffset = 0
         elif res.tzoffset != 0 and res.tzname and self.utczone(res.tzname):

--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -341,7 +341,7 @@ class isoparser(object):
         while pos < len_str and comp < 5:
             comp += 1
 
-            if timestr[pos:pos + 1] in b'-+Z':
+            if timestr[pos:pos + 1] in b'-+Zz':
                 # Detect time zone boundary
                 components[-1] = self._parse_tzstr(timestr[pos:])
                 pos = len_str
@@ -376,7 +376,7 @@ class isoparser(object):
         return components
 
     def _parse_tzstr(self, tzstr, zero_as_utc=True):
-        if tzstr == b'Z':
+        if tzstr == b'Z' or tzstr == b'z':
             return tz.tzutc()
 
         if len(tzstr) not in {3, 5, 6}:

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -228,6 +228,8 @@ def test_iso_ordinal(isoord, dt_expected):
     (b'20140204T123015.224', datetime(2014, 2, 4, 12, 30, 15, 224000)),
     (b'2014-02-04T12:30:15.224Z', datetime(2014, 2, 4, 12, 30, 15, 224000,
                                            tz.tzutc())),
+    (b'2014-02-04T12:30:15.224z', datetime(2014, 2, 4, 12, 30, 15, 224000,
+                                           tz.tzutc())),
     (b'2014-02-04T12:30:15.224+05:00',
         datetime(2014, 2, 4, 12, 30, 15, 224000,
                  tzinfo=tz.tzoffset(None, timedelta(hours=5))))])

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -472,6 +472,11 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse("1976-07-04T00:01:02Z", ignoretz=True),
                          datetime(1976, 7, 4, 0, 1, 2))
 
+    def testRandomFormat18(self):
+        self.assertEqual(parse("1986-07-05T08:15:30z",
+                               ignoretz=True),
+                         datetime(1986, 7, 5, 8, 15, 30))
+
     def testRandomFormat20(self):
         self.assertEqual(parse("Tue Apr 4 00:22:12 PDT 1995", ignoretz=True),
                          datetime(1995, 4, 4, 0, 22, 12))


### PR DESCRIPTION
## Summary of changes

Accepting 'z' as valid UTC in isoparser

Closes #820 

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
