### PR TITLE
Pin freezegun on Python 3.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,8 @@ six
 pytest >= 3.0; python_version != '3.3'
 pytest <  3.3; python_version == '3.3'
 pytest-cov >= 2.0.0
-freezegun
+freezegun < 0.3.11; python_version == '3.3'
+freezegun ; python_version != '3.3'
 hypothesis >= 3.30
 coverage
 mock ; python_version < '3.0'


### PR DESCRIPTION
freezegun version 0.3.11 has the common issue of incorrect PyPI metadata
mismatched with Requires-Python:

https://github.com/spulec/freezegun/issues/268