### PR TITLE
Skip coverage on xfailed tests

### DIFF
--- a/changelog.d/836.misc.rst
+++ b/changelog.d/836.misc.rst
@@ -1,0 +1,1 @@
+Fixed test coverage communication so that only one ``pytest`` invocation is necessary to avoid ``xfail`` tests contributing to the code coverage. (gh pr #836)

--- a/dateutil/test/conftest.py
+++ b/dateutil/test/conftest.py
@@ -1,4 +1,21 @@
 import os
+import pytest
+
+
+# Configure pytest to ignore xfailing tests
+# See: https://stackoverflow.com/a/53198349/467366
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # Python 3.3 support
+        marker_getter = getattr(item, 'get_closest_marker',
+                                getattr(item, 'get_marker'))
+
+        marker = marker_getter('xfail')
+
+        # Need to query the args because conditional xfail tests still have
+        # the xfail mark even if they are not expected to fail
+        if marker and (not marker.args or marker.args[0]):
+            item.add_marker(pytest.mark.no_cover)
 
 
 def set_tzpath():

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,7 @@ skip_missing_interpreters = true
 description = run the unit tests with pytest under {basepython}
 setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 passenv = DATEUTIL_MAY_CHANGE_TZ TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_*
-commands = python -m pytest -m "not xfail" {posargs: "{toxinidir}/dateutil/test" --cov-config="{toxinidir}/tox.ini" --cov=dateutil}
-           python -m pytest -m "xfail"     {posargs: "{toxinidir}/dateutil/test"}
+commands = python -m pytest {posargs: "{toxinidir}/dateutil/test" --cov-config="{toxinidir}/tox.ini" --cov=dateutil}
 deps = -rrequirements-dev.txt
 
 [testenv:coverage]


### PR DESCRIPTION
This automatically attaches the `no_cover` marker to anything marked `xfail` *if* the `xfail` condition is met. This allows us to do the test coverage in one run instead of two.

### Pull Request Checklist
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
