### PR TITLE
Update pyproject.toml for version 3.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = [
+    "setuptools; python_version != '3.3'",
+    "setuptools<40.0; python_version == '3.3'",
+    "wheel",
+    "setuptools_scm"
+]
 
 [tool.towncrier]
     package = "dateutil"


### PR DESCRIPTION
The CI is broken once again on Python 3.3, trying to fix this.

I believe this is a problem with `python_requires` when installing `setuptools` on Python 3.3.

This does not bode well for dropping support for python 2, though this may be just the fact that it's using a fairly old version of `pip`.