### PR TITLE
Ensure tests pass on Python 3 if long is redefined as int

### DIFF
--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -13,10 +13,15 @@ from dateutil.parser import UnknownTimezoneWarning
 
 from ._common import TZEnvContext
 
-from six import assertRaisesRegex, PY3
+from six import assertRaisesRegex
 from io import StringIO
 
 import pytest
+
+try:
+    long
+except NameError:
+    long = int
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -303,11 +308,10 @@ class ParserTest(unittest.TestCase):
                                   tzinfo=self.brsttz))
 
     def testDateCommandFormatWithLong(self):
-        if not PY3:
-            self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
-                                   tzinfos={"BRST": long(-10800)}),
-                             datetime(2003, 9, 25, 10, 36, 28,
-                                      tzinfo=self.brsttz))
+        self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
+                               tzinfos={"BRST": long(-10800)}),
+                         datetime(2003, 9, 25, 10, 36, 28,
+                                  tzinfo=self.brsttz))
 
     def testDateCommandFormatIgnoreTz(self):
         self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -4,7 +4,6 @@ from ._common import WarningTestMixin
 
 from datetime import datetime, date
 import unittest
-from six import PY3
 
 from dateutil import tz
 from dateutil.rrule import (
@@ -17,6 +16,11 @@ from dateutil.rrule import (
 from freezegun import freeze_time
 
 import pytest
+
+try:
+    long
+except NameError:
+    long = int
 
 
 @pytest.mark.rrule
@@ -2284,25 +2288,24 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                           datetime(2010, 3, 22, 14, 1)])
 
     def testLongIntegers(self):
-        if not PY3:  # There is no longs in python3
-            self.assertEqual(list(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 2, 5, 6, 6, 6),
-                              datetime(1998, 2, 12, 6, 6, 6)])
-            self.assertEqual(list(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 1, 5, 9, 0),
-                              datetime(2004, 1, 5, 9, 0)])
+        self.assertEqual(list(rrule(MINUTELY,
+                              count=long(2),
+                              interval=long(2),
+                              bymonth=long(2),
+                              byweekday=long(3),
+                              byhour=long(6),
+                              byminute=long(6),
+                              bysecond=long(6),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
+                         [datetime(1998, 2, 5, 6, 6, 6),
+                          datetime(1998, 2, 12, 6, 6, 6)])
+        self.assertEqual(list(rrule(YEARLY,
+                              count=long(2),
+                              bymonthday=long(5),
+                              byweekno=long(2),
+                              dtstart=datetime(1997, 9, 2, 9, 0))),
+                         [datetime(1998, 1, 5, 9, 0),
+                          datetime(2004, 1, 5, 9, 0)])
 
     def testHourlyBadRRule(self):
         """
@@ -4506,22 +4509,21 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
                               dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testToStrLongIntegers(self):
-        if not PY3:  # There is no longs in python3
-            self._rrulestr_reverse_test(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
+        self._rrulestr_reverse_test(rrule(MINUTELY,
+                              count=long(2),
+                              interval=long(2),
+                              bymonth=long(2),
+                              byweekday=long(3),
+                              byhour=long(6),
+                              byminute=long(6),
+                              bysecond=long(6),
+                              dtstart=datetime(1997, 9, 2, 9, 0)))
 
-            self._rrulestr_reverse_test(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
+        self._rrulestr_reverse_test(rrule(YEARLY,
+                              count=long(2),
+                              bymonthday=long(5),
+                              byweekno=long(2),
+                              dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testReplaceIfSet(self):
         rr = rrule(YEARLY,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

When most projects add support for Python 3, they conditionally add the redefinition __long = int__ so instead of skipping these tests on Python 3, let's run them with that redefinition in place just to be sure.

### Pull Request Checklist
- [x] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
