### PR TITLE
Fixed get_marker API change introduced by pytest version >= 4.0

### DIFF
--- a/changelog.d/857.misc.rst
+++ b/changelog.d/857.misc.rst
@@ -1,0 +1,2 @@
+Fixed issue with get_marker API change introduced by pytest version >= 4.0
+Reported and fixed by @nicoe (gh issue #857, pr #858)

--- a/dateutil/test/conftest.py
+++ b/dateutil/test/conftest.py
@@ -6,9 +6,11 @@ import pytest
 # See: https://stackoverflow.com/a/53198349/467366
 def pytest_collection_modifyitems(items):
     for item in items:
+        marker_getter = getattr(item, 'get_closest_marker', None)
+
         # Python 3.3 support
-        marker_getter = getattr(item, 'get_closest_marker',
-                                getattr(item, 'get_marker'))
+        if marker_getter is None:
+            marker_getter = item.get_marker
 
         marker = marker_getter('xfail')
 


### PR DESCRIPTION
## Summary of changes

I simply added a default value to the getattr call that is used only on python3.3 which should hopefully not be used anymore but in case it happens and the getattr fails (which it shouldn't) then the marker is skipped.

Closes #857 

### Pull Request Checklist
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [X] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
