### PR TITLE
Catch UnicodeEncodeError for Windows in tz.gettz

### DIFF
--- a/changelog.d/861.bugfix.rst
+++ b/changelog.d/861.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed error condition in ``tz.gettz`` when a non-ASCII timezone is passed on Windows in Python 2.7. (gh issue #802, pr #861)

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1095,8 +1095,6 @@ def test_gettz_badzone(badzone):
 
 
 @pytest.mark.gettz
-@pytest.mark.xfail(IS_WIN and PY2,
-                   reason='tzwin fails with non-unicode characters on 2.7')
 def test_gettz_badzone_unicode():
     # Make sure a unicode string can be passed to TZ (GH #802)
     # When fixed, combine this with test_gettz_badzone

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1633,7 +1633,8 @@ def __get_gettz():
                         if tzwin is not None:
                             try:
                                 tz = tzwin(name)
-                            except WindowsError:
+                            except (WindowsError, UnicodeEncodeError):
+                                # UnicodeEncodeError is for Python 2.7 compat
                                 tz = None
 
                         if not tz:


### PR DESCRIPTION
On Windows and Python 2.7, calling `tzwin` with a non-ascii name will raise a `UnicodeEncodeError` instead of `WindowsError`, as it does on other platforms and versions.

Fixes GH #802.

### Pull Request Checklist
- [X] Changes have tests
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
