### PR TITLE
Add build backend to pyproject.toml

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include LICENSE NEWS zonefile_metadata.json updatezinfo.py
+include LICENSE NEWS zonefile_metadata.json updatezinfo.py pyproject.toml
 recursive-include dateutil/test *
 global-exclude __pycache__
 global-exclude *.py[co]

--- a/changelog.d/863.bugfix.rst
+++ b/changelog.d/863.bugfix.rst
@@ -1,0 +1,1 @@
+Added a ``build-system.build-backend`` key in ``pyproject.toml`` and explicitly started shipping the ``pyproject.toml`` file in source distributions. (gh pr #863)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = [
     "wheel",
     "setuptools_scm"
 ]
+build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
     package = "dateutil"


### PR DESCRIPTION
## Summary of changes
This explicitly specifies `dateutil`'s backend and ensures that `pyproject.toml` is in the sdist.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
