### PR TITLE
Release 2.8.0

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,120 @@
+Version 2.8.0 (2019-02-04)
+==========================
+
+Data updates
+------------
+
+- Updated tzdata version to to 2018i.
+
+
+Features
+--------
+
+- Added support for ``EXDATE`` parameters when parsing ``rrule`` strings.
+  Reported by @mlorant (gh issue #410), fixed by @nicoe (gh pr #859).
+- Added support for sub-minute time zone offsets in Python 3.6+.
+  Fixed by @cssherry (gh issue #582, pr #763)
+- Switched the ``tzoffset``, ``tzstr`` and ``gettz`` caches over to using weak
+  references, so that the cache expires when no other references to the
+  original ``tzinfo`` objects exist. This cache-expiry behavior is not
+  guaranteed in the public interface and may change in the future. To improve
+  performance in the case where transient references to the same time zones
+  are repeatedly created but no strong reference is continuously held, a
+  smaller "strong value" cache was also added. Weak value cache implemented by
+  @cs-cordero (gh pr #672, #801), strong cache added by
+  Gökçen Nurlu (gh issue #691, gh pr #761)
+
+
+Bugfixes
+--------
+
+- Added time zone inference when initializing an ``rrule`` with a specified
+  ``UNTIL`` but without an explicitly specified ``DTSTART``; the time zone
+  of the generated ``DTSTART`` will now be taken from the ``UNTIL`` rule.
+  Reported by @href (gh issue #652). Fixed by @absreim (gh pr #693).
+- Fixed an issue where ``parser.parse`` would raise ``Decimal``-specific errors
+  instead of a standard ``ValueError`` if certain malformed values were parsed
+  (e.g. ``NaN`` or infinite values). Reported and fixed by
+  @amureki (gh issue #662, gh pr #679).
+- Fixed issue in ``parser`` where a ``tzinfos`` call explicitly returning
+  ``None`` would throw a ``ValueError``.
+  Fixed by @parsethis (gh issue #661, gh pr #681)
+- Fixed incorrect parsing of certain dates earlier than 100 AD when repesented
+  in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)
+- Add support for ISO 8601 times with comma as the decimal separator in the
+  ``dateutil.parser.isoparse`` function. (gh pr #721)
+- Changed handling of ``T24:00`` to be compliant with the standard. ``T24:00``
+  now represents midnight on the *following* day.
+  Fixed by @cheukting (gh issue #658, gh pr #751)
+- Fixed an issue where ``isoparser.parse_isotime`` was unable to handle the
+  ``24:00`` variant representation of midnight. (gh pr #773)
+- Added support for more than 6 fractional digits in `isoparse`.
+  Reported and fixed by @jayschwa (gh issue #786, gh pr #787).
+- Added 'z' (lower case Z) as valid UTC time zone in isoparser.
+  Reported by @cjgibson (gh issue #820). Fixed by @Cheukting (gh pr #822)
+- Fixed a bug with base offset changes during DST in ``tzfile``, and refactored
+  the way base offset changes are detected. Originally reported on
+  StackOverflow by @MartinThoma. (gh issue #812, gh pr #810)
+- Fixed error condition in ``tz.gettz`` when a non-ASCII timezone is passed on
+  Windows in Python 2.7. (gh issue #802, pr #861)
+- Improved performance and inspection properties of ``tzname`` methods.
+  (gh pr #811)
+- Removed unnecessary binary_type compatibility shims.
+  Added by @jdufresne (gh pr #817)
+- Changed ``python setup.py test`` to print an error to ``stderr`` and exit
+  with 1 instead of 0. Reported and fixed by @hroncok (gh pr #814)
+- Added a ``pyproject.toml`` file with build requirements and an explicitly
+  specified build backend. (gh issue #736, gh prs #746, #863)
+
+
+Documentation changes
+---------------------
+
+- Added documentation for the ``rrule.rrulestr`` function.
+  Fixed by @prdickson (gh issue #623, gh pr #762)
+- Added documentation for ``dateutil.tz.gettz``.
+  Fixed by @weatherpattern (gh issue #647, gh pr #704)
+- Add documentation for the ``dateutil.tz.win`` module and mocked out certain
+  Windows-specific modules so that autodoc can still be run on non-Windows
+  systems. (gh issue #442, pr #715)
+- Added changelog to documentation. (gh issue #692, gh pr #707)
+- Changed order of keywords in the ``rrule`` docstring.
+  Reported and fixed by @rmahajan14 (gh issue #686, gh pr #695).
+- Improved documentation on the use of ``until`` and ``count`` parameters in
+  ``rrule``. Fixed by @lucaferocino (gh pr #755).
+- Added an example of how to use a custom ``parserinfo`` subclass to parse
+  non-standard datetime formats in the examples documentation for ``parser``.
+  Added by @prdickson (gh #753)
+- Added doctest examples to ``tzfile`` documentation.
+  Patch by @weatherpattern (gh pr #671)
+- Updated the documentation for ``relativedelta``'s ``weekday`` arguments.
+  Fixed by @kvn219 @huangy22 and @ElliotJH (gh pr #673)
+- Improved explanation of the order that ``relativedelta`` components are
+  applied in. Fixed by @kvn219 @huangy22 and @ElliotJH (gh pr #673)
+- Expanded the description and examples in the ``relativedelta`` class.
+  Contributed by @andrewcbennett (gh pr #759)
+- Improved the contributing documentation to clarify where to put new changelog
+  files. Contributed by @andrewcbennett (gh pr #757)
+- Fixed a broken doctest in the ``relativedelta`` module.
+  Fixed by @nherriot (gh pr #758).
+- Changed the default theme to ``sphinx_rtd_theme``, and changed the sphinx
+  configuration accordingly. (gh pr #707)
+- Reorganized ``dateutil.tz`` documentation and fixed issue with the
+  ``dateutil.tz`` docstring. (gh pr #714)
+- Cleaned up malformed RST in the ``tz`` documentation.
+  (gh issue #702, gh pr #706)
+- Corrected link syntax and updated URL to https for ISO year week number
+  notation in ``relativedelta`` examples. (gh issue #670, pr #711)
+
+
+Misc
+----
+
+- GH #674, GH #688, GH #699, GH #720, GH #723, GH #726, GH #727, GH #740,
+  GH #750, GH #760, GH #767, GH #772, GH #773, GH #780, GH #784, GH #785,
+  GH #791, GH #799, GH #813, GH #836, GH #839, GH #857
+
+
 Version 2.7.5 (2018-10-27)
 ==========================
 

--- a/changelog.d/410.feature.rst
+++ b/changelog.d/410.feature.rst
@@ -1,2 +1,0 @@
-Added support for EXDATE parameters when parsing rrule strings.
-Reported by @mlorant (gh issue #410), fixed by @nicoe (gh pr #859).

--- a/changelog.d/582.bug.rst
+++ b/changelog.d/582.bug.rst
@@ -1,1 +1,0 @@
-Added support for sub-minute offsets in Python 3.6+. Fixed by @cssherry (gh issue #582, pr #763)

--- a/changelog.d/670.doc.rst
+++ b/changelog.d/670.doc.rst
@@ -1,1 +1,0 @@
-Corrected link syntax and updated URL to https for ISO year week number notation in relativedelta examples. (gh issue #670, pr #711)

--- a/changelog.d/671.doc.rst
+++ b/changelog.d/671.doc.rst
@@ -1,1 +1,0 @@
-Add doctest examples to tzfile documentation. Done by @weatherpattern and @pganssle (gh pr #671)

--- a/changelog.d/672.bugfix.rst
+++ b/changelog.d/672.bugfix.rst
@@ -1,1 +1,0 @@
-Switched the ``tzoffset``, ``tzstr`` and ``gettz`` caches over to using weak references, so that the cache expires when no other references to the original ``tzinfo`` objects exist. This cache-expiry behavior is not considered part of the public interface and may change in the future. Implemented by @cs-cordero (gh pr #672, #801)

--- a/changelog.d/673.doc.rst
+++ b/changelog.d/673.doc.rst
@@ -1,4 +1,0 @@
-Updated the documentation for relativedelta. Removed references to
-tuple arguments for weekday, explained effect of weekday(_, 1) and
-better explained the order of operations that relativedelta
-applies. Fixed by @kvn219 @huangy22 and @ElliotJH (gh pr #673)

--- a/changelog.d/674.misc.rst
+++ b/changelog.d/674.misc.rst
@@ -1,1 +1,0 @@
-Add property testing with hypothesis with property tests for parserinfo.convertyear. Implemented by @coreygirard and @loldja (gh pr #674)

--- a/changelog.d/679.bugfix.rst
+++ b/changelog.d/679.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed an issue where decimal.Decimal would cast `NaN` or infinite value in a parser.parse, which will raise decimal.Decimal-specific errors. Reported and fixed by @amureki (gh issue #662, gh pr #679).

--- a/changelog.d/681.bugfix.rst
+++ b/changelog.d/681.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a ValueError being thrown if tzinfos call explicity returns ``None``.  Reported by @pganssle (gh issue #661) Fixed by @parsethis (gh pr #681)

--- a/changelog.d/687.bugfix.rst
+++ b/changelog.d/687.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed incorrect parsing of certain dates earlier than 100 AD when repesented in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)

--- a/changelog.d/688.misc.rst
+++ b/changelog.d/688.misc.rst
@@ -1,1 +1,0 @@
-Add a test for the property that ``dateutil.parser.parse`` will support inversion of ``datetime.isoformat()`` so long as ``sep`` is an ASCII character. Added by @pganssle (gh pr #688)

--- a/changelog.d/692.doc.rst
+++ b/changelog.d/692.doc.rst
@@ -1,1 +1,0 @@
-Added changelog to documentation. (gh issue #692, gh pr #707)

--- a/changelog.d/693.feature.rst
+++ b/changelog.d/693.feature.rst
@@ -1,1 +1,0 @@
-Adds a feature when initializing an rrule with a specified UNTIL but without an explicitly specified DTSTART so that the generated DTSTART takes on the time zone of the UNTIL. Reported by @href (gh issue #652). Fixed by @absreim (gh pr #693).

--- a/changelog.d/695.doc.rst
+++ b/changelog.d/695.doc.rst
@@ -1,1 +1,0 @@
-Changed order of keywords in rrule docstring. Reported and fixed by @rmahajan14 (gh issue #686, gh pr #695).

--- a/changelog.d/699.misc.rst
+++ b/changelog.d/699.misc.rst
@@ -1,2 +1,0 @@
-Added unittest to check if tz's objects repr contains the "name" attribute of an input fileobject.
-Added by @Bergvca (gh pr #699)

--- a/changelog.d/704.doc.rst
+++ b/changelog.d/704.doc.rst
@@ -1,1 +1,0 @@
-Added documentation for ``dateutil.tz.gettz``. Reported by @pganssle (gh issue #647). Fixed by @weatherpattern (gh pr #704)

--- a/changelog.d/706.doc.rst
+++ b/changelog.d/706.doc.rst
@@ -1,1 +1,0 @@
-Cleaned up malformed RST in the ``tz`` documentation. (gh issue #702, gh pr #706)

--- a/changelog.d/707.doc.rst
+++ b/changelog.d/707.doc.rst
@@ -1,1 +1,0 @@
-Changed the default theme to sphinx_rtd_theme, and changed the sphinx configuration to go along with that. (gh pr #707)

--- a/changelog.d/710.data.rst
+++ b/changelog.d/710.data.rst
@@ -1,1 +1,0 @@
-Update tzdata to 2018e. (gh pr #710)

--- a/changelog.d/714.doc.rst
+++ b/changelog.d/714.doc.rst
@@ -1,1 +1,0 @@
-Reorganized ``dateutil.tz`` documentation and fixed issue with the ``dateutil.tz`` docstring. (gh pr #714)

--- a/changelog.d/715.doc.rst
+++ b/changelog.d/715.doc.rst
@@ -1,1 +1,0 @@
-Add documentation for the ``dateutil.tz.win`` module and mocked out certain Windows-specific modules so that autodoc can still be run on non-Windows systems. (gh issue #442, pr #715)

--- a/changelog.d/720.misc.rst
+++ b/changelog.d/720.misc.rst
@@ -1,1 +1,0 @@
-Remove deprecated requires from setup.py. Reported by @mhsmith (gh issue #720). Fixed by @cssherry (gh pr #752)

--- a/changelog.d/721.bugfix.rst
+++ b/changelog.d/721.bugfix.rst
@@ -1,1 +1,0 @@
-Add support for ISO 8601 times with comma as the decimal separator. (gh pr #721)

--- a/changelog.d/723.misc.rst
+++ b/changelog.d/723.misc.rst
@@ -1,1 +1,0 @@
-Brought setup.py into compliance with PEP8. (gh pr #723)

--- a/changelog.d/726.doc.rst
+++ b/changelog.d/726.doc.rst
@@ -1,1 +1,0 @@
-Added documentation for the ``rrule.rrulestr`` function. Fixed by @prdickson (gh issue #623, gh pr #762)

--- a/changelog.d/726.misc.rst
+++ b/changelog.d/726.misc.rst
@@ -1,1 +1,0 @@
-Migrated easter tests to use parametrized pytest tests rather than a for loop within a single test. Implemented by @jpurviance (gh pr #726)

--- a/changelog.d/727.misc.rst
+++ b/changelog.d/727.misc.rst
@@ -1,1 +1,0 @@
-Parametrized many parser tests. Fixed by @jpurviance (gh pr #727)

--- a/changelog.d/740.misc.rst
+++ b/changelog.d/740.misc.rst
@@ -1,2 +1,0 @@
-Check that README is rendered correctly on PyPI. Reported by @pganssle (gh issue #734). Fixed by
-@alimcmaster1 (gh pr #740)

--- a/changelog.d/746.bugfix.rst
+++ b/changelog.d/746.bugfix.rst
@@ -1,1 +1,0 @@
-Add build requirements to pyproject.toml. (gh issue #736, gh pr #746)

--- a/changelog.d/750.misc.txt
+++ b/changelog.d/750.misc.txt
@@ -1,1 +1,0 @@
-Relicensed Alex Willmer's commits (mainly those in pr #120) @moreati (gh pr #750)

--- a/changelog.d/751.bugfix.rst
+++ b/changelog.d/751.bugfix.rst
@@ -1,1 +1,0 @@
-Changed handling of T24:00 to be compliant with the standard. T24:00 now represents midnight on the *following* day. Fixed by @cheukting (gh issue #658, gh pr #751)

--- a/changelog.d/753.doc.rst
+++ b/changelog.d/753.doc.rst
@@ -1,1 +1,0 @@
-Added an example of how to customize the parser with a parserinfo subclass. Added by @prdickson (gh #753)

--- a/changelog.d/755.doc.rst
+++ b/changelog.d/755.doc.rst
@@ -1,2 +1,0 @@
-Improved documentation on the use of ``until`` and ``count`` parameters in ``rrule``.
-Fixed by @lucaferocino (gh pr #755).

--- a/changelog.d/757.doc.rst
+++ b/changelog.d/757.doc.rst
@@ -1,1 +1,0 @@
-Improved the contributing documentation to specify where to create changelog files. Contributed by @andrewcbennett (gh pr #757)

--- a/changelog.d/758.doc.rst
+++ b/changelog.d/758.doc.rst
@@ -1,1 +1,0 @@
-Fixed a broken doctest in the relativedelta module. Fixed by @nherriot (gh pr #758).

--- a/changelog.d/759.doc.rst
+++ b/changelog.d/759.doc.rst
@@ -1,1 +1,0 @@
-Improved the documentation for the ``relativedelta.relativedelta`` class. Contributed by @andrewcbennett (gh pr #759)

--- a/changelog.d/760.misc.rst
+++ b/changelog.d/760.misc.rst
@@ -1,1 +1,0 @@
-Added tests to bring relativedelta.py to 100% test coverage. Contribution by @lucaferocino (gh issue #521, gh pr #760).

--- a/changelog.d/761.feature.rst
+++ b/changelog.d/761.feature.rst
@@ -1,1 +1,0 @@
-Added a small "strong value" cache into ``tz.gettz``, ``tz.tzoffset`` and ``tz.tzstr`` to improve performance in the situation where transient references are repeatedly created to the same time zones, but no strong reference is continuously held. Patch by Gökçen Nurlu (gh issue #691, gh pr #761)

--- a/changelog.d/767.misc.rst
+++ b/changelog.d/767.misc.rst
@@ -1,1 +1,0 @@
-Refactored some parser input format tests into a separate class. Patch by @jbrockmendel (gh pr #767)

--- a/changelog.d/772.misc.rst
+++ b/changelog.d/772.misc.rst
@@ -1,1 +1,0 @@
-Added tests that an error is raised for an incorrect separator character in a strict isoparser. Contribution by @alimcmaster1 (gh pr #772).

--- a/changelog.d/773.bugfix.rst
+++ b/changelog.d/773.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed an issue where ``isoparser.parse_isotime`` was unable to handle the ``24:00`` variant representation of midnight. (gh pr #773)

--- a/changelog.d/773.misc.rst
+++ b/changelog.d/773.misc.rst
@@ -1,1 +1,0 @@
-Added tests that parse_isotime only allows hours == 24 when the time is midnight. (gh pr #773)

--- a/changelog.d/780.misc.rst
+++ b/changelog.d/780.misc.rst
@@ -1,1 +1,0 @@
-Switched test suite over to throwing errors whenever unexpected warnings are raised. As part of this, the test_import_star test was cleaned up, as it had been throwing deprecation warnings. (gh pr #780)

--- a/changelog.d/784.misc.rst
+++ b/changelog.d/784.misc.rst
@@ -1,1 +1,0 @@
-Started testing against Python 3.7 on Linux. (gh pr #784)

--- a/changelog.d/785.misc.rst
+++ b/changelog.d/785.misc.rst
@@ -1,1 +1,0 @@
-Tests are now run against the master branch of the tz database. (gh issue #617, gh pr #785)

--- a/changelog.d/787.bugfix.rst
+++ b/changelog.d/787.bugfix.rst
@@ -1,2 +1,0 @@
-Accept more than 6 fractional digits in `isoparse`.
-Reported and fixed by @jayschwa (gh issue #786, gh pr #787).

--- a/changelog.d/791.misc.rst
+++ b/changelog.d/791.misc.rst
@@ -1,1 +1,0 @@
-Moved the ``tz.tz._ContextWrapper`` class to ``tz.tz._nullcontext``; the old class is now a backport of ``contextmanager.nullcontext``, which is used if available. (gh pr #791)

--- a/changelog.d/799.misc.rst
+++ b/changelog.d/799.misc.rst
@@ -1,1 +1,0 @@
-Pinned setuptools to <40.0 in CI build on Python 3.3, for whatever reason pip doesn't respect python_requires for that package on Python 3.3. (gh pr #799)

--- a/changelog.d/810.bugfix.rst
+++ b/changelog.d/810.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a bug with base offset changes during DST in ``tzfile``, and refactored the way base offset changes are detected. Originally reported on StackOverflow by @MartinThoma. (gh issue #812, gh pr #810)

--- a/changelog.d/811.bugfix.rst
+++ b/changelog.d/811.bugfix.rst
@@ -1,1 +1,0 @@
-Improved performance and inspection properties of tzname methods. (gh pr #811)

--- a/changelog.d/813.misc.rst
+++ b/changelog.d/813.misc.rst
@@ -1,1 +1,0 @@
-Dropped use of six.(Bytes|String)IO in favor of io.(Bytes|String)IO in two test files. Patch by @jdufresne (gh pr #813)

--- a/changelog.d/814.bugfix.rst
+++ b/changelog.d/814.bugfix.rst
@@ -1,1 +1,0 @@
-Changed the ``python setup.py test`` to print an error to ``stderr`` and exit with 1 instead of 0. Reported and fixed by @hroncok (gh pr #814)

--- a/changelog.d/817.bugfix.rst
+++ b/changelog.d/817.bugfix.rst
@@ -1,1 +1,0 @@
-Removed unnecessary binary_type compatibility shims. Added by @jdufresne (gh pr #817)

--- a/changelog.d/822.bugfix.rst
+++ b/changelog.d/822.bugfix.rst
@@ -1,1 +1,0 @@
-Accept 'z' as valid UTC time zone in isoparser. Reported by @cjgibson (gh issue #820). Fixed by @Cheukting (gh pr #822)

--- a/changelog.d/836.misc.rst
+++ b/changelog.d/836.misc.rst
@@ -1,1 +1,0 @@
-Fixed test coverage communication so that only one ``pytest`` invocation is necessary to avoid ``xfail`` tests contributing to the code coverage. (gh pr #836)

--- a/changelog.d/839.misc.rst
+++ b/changelog.d/839.misc.rst
@@ -1,1 +1,0 @@
-Added some tests for _DatetimeWithFold to improve test coverage.

--- a/changelog.d/857.misc.rst
+++ b/changelog.d/857.misc.rst
@@ -1,2 +1,0 @@
-Fixed issue with get_marker API change introduced by pytest version >= 4.0
-Reported and fixed by @nicoe (gh issue #857, pr #858)

--- a/changelog.d/861.bugfix.rst
+++ b/changelog.d/861.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed error condition in ``tz.gettz`` when a non-ASCII timezone is passed on Windows in Python 2.7. (gh issue #802, pr #861)

--- a/changelog.d/862.data.rst
+++ b/changelog.d/862.data.rst
@@ -1,1 +1,0 @@
-Updated tzdata version to to 2018i.

--- a/changelog.d/863.bugfix.rst
+++ b/changelog.d/863.bugfix.rst
@@ -1,1 +1,0 @@
-Added a ``build-system.build-backend`` key in ``pyproject.toml`` and explicitly started shipping the ``pyproject.toml`` file in source distributions. (gh pr #863)


### PR DESCRIPTION
## Summary of changes
This has been far too-long delayed, it's time to cut a new feature release for `dateutil`.

This PR updates the NEWS, when merged I can tag and cut a release.

CC: @jbrockmendel

Thanks to all the contributors to this release: @nicoe @mlorant @cssherry @cs-cordero @gokcennurlu  @href @absreim @amureki @ParseThis @Cheukting @jayschwa @cjgibson @MarinThoma @jdufresne @hroncok @prdickson @weatherpattern @rmahajan14 @lucaferocino @kvn219 @huangy22 @ElliotJH @andrewcbennett @nherriot @coreygirard @loldja @Bergvca @jpurviance @alimcmaster1 
