### PR TITLE
Fix changelog

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,19 +28,6 @@ Features
 Bugfixes
 --------
 
-- Added time zone inference when initializing an ``rrule`` with a specified
-  ``UNTIL`` but without an explicitly specified ``DTSTART``; the time zone
-  of the generated ``DTSTART`` will now be taken from the ``UNTIL`` rule.
-  Reported by @href (gh issue #652). Fixed by @absreim (gh pr #693).
-- Fixed an issue where ``parser.parse`` would raise ``Decimal``-specific errors
-  instead of a standard ``ValueError`` if certain malformed values were parsed
-  (e.g. ``NaN`` or infinite values). Reported and fixed by
-  @amureki (gh issue #662, gh pr #679).
-- Fixed issue in ``parser`` where a ``tzinfos`` call explicitly returning
-  ``None`` would throw a ``ValueError``.
-  Fixed by @parsethis (gh issue #661, gh pr #681)
-- Fixed incorrect parsing of certain dates earlier than 100 AD when repesented
-  in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)
 - Add support for ISO 8601 times with comma as the decimal separator in the
   ``dateutil.parser.isoparse`` function. (gh pr #721)
 - Changed handling of ``T24:00`` to be compliant with the standard. ``T24:00``
@@ -72,47 +59,31 @@ Documentation changes
 
 - Added documentation for the ``rrule.rrulestr`` function.
   Fixed by @prdickson (gh issue #623, gh pr #762)
-- Added documentation for ``dateutil.tz.gettz``.
-  Fixed by @weatherpattern (gh issue #647, gh pr #704)
 - Add documentation for the ``dateutil.tz.win`` module and mocked out certain
   Windows-specific modules so that autodoc can still be run on non-Windows
   systems. (gh issue #442, pr #715)
 - Added changelog to documentation. (gh issue #692, gh pr #707)
-- Changed order of keywords in the ``rrule`` docstring.
-  Reported and fixed by @rmahajan14 (gh issue #686, gh pr #695).
 - Improved documentation on the use of ``until`` and ``count`` parameters in
   ``rrule``. Fixed by @lucaferocino (gh pr #755).
 - Added an example of how to use a custom ``parserinfo`` subclass to parse
   non-standard datetime formats in the examples documentation for ``parser``.
   Added by @prdickson (gh #753)
-- Added doctest examples to ``tzfile`` documentation.
-  Patch by @weatherpattern (gh pr #671)
-- Updated the documentation for ``relativedelta``'s ``weekday`` arguments.
-  Fixed by @kvn219 @huangy22 and @ElliotJH (gh pr #673)
-- Improved explanation of the order that ``relativedelta`` components are
-  applied in. Fixed by @kvn219 @huangy22 and @ElliotJH (gh pr #673)
 - Expanded the description and examples in the ``relativedelta`` class.
   Contributed by @andrewcbennett (gh pr #759)
 - Improved the contributing documentation to clarify where to put new changelog
   files. Contributed by @andrewcbennett (gh pr #757)
 - Fixed a broken doctest in the ``relativedelta`` module.
   Fixed by @nherriot (gh pr #758).
-- Changed the default theme to ``sphinx_rtd_theme``, and changed the sphinx
-  configuration accordingly. (gh pr #707)
 - Reorganized ``dateutil.tz`` documentation and fixed issue with the
   ``dateutil.tz`` docstring. (gh pr #714)
-- Cleaned up malformed RST in the ``tz`` documentation.
-  (gh issue #702, gh pr #706)
-- Corrected link syntax and updated URL to https for ISO year week number
-  notation in ``relativedelta`` examples. (gh issue #670, pr #711)
 
 
 Misc
 ----
 
-- GH #674, GH #688, GH #699, GH #720, GH #723, GH #726, GH #727, GH #740,
-  GH #750, GH #760, GH #767, GH #772, GH #773, GH #780, GH #784, GH #785,
-  GH #791, GH #799, GH #813, GH #836, GH #839, GH #857
+- GH #720, GH #723, GH #726, GH #727, GH #740, GH #750, GH #760, GH #767,
+  GH #772, GH #773, GH #780, GH #784, GH #785, GH #791, GH #799, GH #813,
+  GH #836, GH #839, GH #857
 
 
 Version 2.7.5 (2018-10-27)
@@ -145,18 +116,19 @@ Data updates
 Bugfixes
 --------
 
-- Fixed an issue where decimal.Decimal would cast `NaN` or infinite value in a
-  parser.parse, which will raise decimal.Decimal-specific errors. Reported and
-  fixed by @amureki (gh issue #662, gh pr #679).
-- Fixed a ValueError being thrown if tzinfos call explicity returns ``None``.
-  Reported by @pganssle (gh issue #661) Fixed by @parsethis (gh pr #681)
+- Fixed an issue where ``parser.parse`` would raise ``Decimal``-specific errors
+  instead of a standard ``ValueError`` if certain malformed values were parsed
+  (e.g. ``NaN`` or infinite values). Reported and fixed by
+  @amureki (gh issue #662, gh pr #679).
+- Fixed issue in ``parser`` where a ``tzinfos`` call explicitly returning
+  ``None`` would throw a ``ValueError``.
+  Fixed by @parsethis (gh issue #661, gh pr #681)
 - Fixed incorrect parsing of certain dates earlier than 100 AD when repesented
   in the form "%B.%Y.%d", e.g. "December.0031.30". (gh issue #687, pr #700)
-- Fixed a bug where automatically generated DTSTART was naive even if a
-  specified UNTIL had a time zone. Automatically generated DTSTART will now
-  take on the timezone of an UNTIL date, if provided. Reported by @href (gh
-  issue #652). Fixed by @absreim (gh pr #693).
-
+- Added time zone inference when initializing an ``rrule`` with a specified
+  ``UNTIL`` but without an explicitly specified ``DTSTART``; the time zone
+  of the generated ``DTSTART`` will now be taken from the ``UNTIL`` rule.
+  Reported by @href (gh issue #652). Fixed by @absreim (gh pr #693).
 
 Documentation changes
 ---------------------
@@ -176,8 +148,8 @@ Documentation changes
   issue #647). Fixed by @weatherpattern (gh pr #704)
 - Cleaned up malformed RST in the ``tz`` documentation. (gh issue #702, gh pr
   #706)
-- Changed the default theme to sphinx_rtd_theme, and changed the sphinx
-  configuration to go along with that. (gh pr #707)
+- Changed the default theme to ``sphinx_rtd_theme``, and changed the sphinx
+  configuration accordingly. (gh pr #707)
 - Reorganized ``dateutil.tz`` documentation and fixed issue with the
   ``dateutil.tz`` docstring. (gh pr #714)
 


### PR DESCRIPTION
Somehow a bunch of old changelog stubs from 2.7.3 got included in the 2.8.0 release notes. This updates the release notes accordingly. We'll have to make a `post` release to get the documentation updated.