### PR TITLE
REF: collect parser methods by function

### DIFF
--- a/changelog.d/735.misc.rst
+++ b/changelog.d/735.misc.rst
@@ -1,0 +1,2 @@
+Converted many tests in ``test_parser`` over to using ``pytest`` style tests.
+Patch by @jbrockmendel (gh pr #735)

--- a/changelog.d/882.misc.rst
+++ b/changelog.d/882.misc.rst
@@ -1,0 +1,2 @@
+Reorganized ``parser`` methods by functionality.
+Patch by @jbrockmendel (gh pr #882)


### PR DESCRIPTION
The methods within `parser` are a bit of a jumble.  This separates out two sections for methods that a) act on individual tokens and b) are for creating the datetime output after the string is fully parsed.

No hurry on this if it would cause rebasing conflicts elsewhere.

Methods are unchanged, with the exception of a long line in a comment in to_decimal that is wrapped.