### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -33,8 +32,6 @@ matrix:
 
 install:
   - pip install -U six && pip install -U tox
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   - if [[ $TOXENV == "py" ]]; then ./ci_tools/retry.sh python updatezinfo.py; fi
 
 script:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -74,6 +74,7 @@ switch, and thus all their contributions are dual-licensed.
 - Maxime Lorant <maxime.lorant@MASKED>
 - Michael Aquilina <michaelaquilina@MASKED> (gh: @MichaelAquilina)
 - Michael J. Schultz <mjschultz@MASKED>
+- Michael Käufl (gh: michael-k) **D**
 - Mike Gilbert <floppym@MASKED>
 - Nicholas Herrriot <Nicholas.Herriot@gmail.com> **D**
 - Nicolas Évrard (gh: @nicoe) **D**

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ build: false
 environment:
   matrix:
     - PYTHON_VERSION: 27
-    - PYTHON_VERSION: 33
     - PYTHON_VERSION: 34
     - PYTHON_VERSION: 35
     - PYTHON_VERSION: 36
@@ -13,8 +12,6 @@ platform:
 matrix:
   fast_finish: true
   exclude:
-    - platform: x86
-      PYTHON_VERSION: 33
     - platform: x86
       PYTHON_VERSION: 34
     - platform: x86

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,8 +51,6 @@ steps:
 
 - bash: |
     $PYTHON -m pip install -U six && $PYTHON -m pip install -U tox
-    if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
-    if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   displayName: Ensure prereqs
 
 - bash: |

--- a/changelog.d/897.misc.rst
+++ b/changelog.d/897.misc.rst
@@ -1,0 +1,1 @@
+Dropped support for Python 3.3. Fixed by @michael-k (gh pr #897)

--- a/dateutil/test/conftest.py
+++ b/dateutil/test/conftest.py
@@ -6,13 +6,7 @@ import pytest
 # See: https://stackoverflow.com/a/53198349/467366
 def pytest_collection_modifyitems(items):
     for item in items:
-        marker_getter = getattr(item, 'get_closest_marker', None)
-
-        # Python 3.3 support
-        if marker_getter is None:
-            marker_getter = item.get_marker
-
-        marker = marker_getter('xfail')
+        marker = item.get_closest_marker('xfail')
 
         # Need to query the args because conditional xfail tests still have
         # the xfail mark even if they are not expected to fail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = [
-    "setuptools; python_version != '3.3'",
-    "setuptools<40.0; python_version == '3.3'",
+    "setuptools",
     "wheel",
     "setuptools_scm"
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,7 @@
 six
-pytest >= 3.0; python_version != '3.3'
-pytest <  3.3; python_version == '3.3'
+pytest >= 3.0
 pytest-cov >= 2.0.0
-freezegun < 0.3.11; python_version == '3.3'
-freezegun ; python_version != '3.3'
+freezegun
 hypothesis >= 3.30
 coverage
 mock ; python_version < '3.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ classifiers =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
@@ -32,7 +31,7 @@ classifiers =
 zip_safe = True
 setup_requires = setuptools_scm
 install_requires = six >= 1.5
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
 packages = find:
 test_suite = dateutil.test
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = py27,
-          py33,
           py34,
           py35,
           py36,


### PR DESCRIPTION
## Summary of changes

Python 3.3 reached its EOL in September 2017 and now even Python 3.4
will reach its EOL in a few days.

See https://github.com/dateutil/dateutil/issues/724#issuecomment-396908268 for “the pip installs for python-dateutil from PyPI for May 2018”.

Python 3.3 EOL: https://www.python.org/dev/peps/pep-0398/#x-end-of-life
Python 3.4 EOL: https://www.python.org/dev/peps/pep-0429/#release-schedule

### Pull Request Checklist
- [ ] ~~Changes have tests~~
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
