### PR TITLE
Pin tox to 3.8.0 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - python: "nightly"
 
 install:
-  - pip install -U six && pip install -U tox
+  - pip install -U six && pip install -U 'tox<3.8.0'
   - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
   - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   - if [[ $TOXENV == "py" ]]; then ./ci_tools/retry.sh python updatezinfo.py; fi

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,7 @@ steps:
   condition: in(variables.PYTHON, 'pypy', 'pypy3')
 
 - bash: |
-    $PYTHON -m pip install -U six && $PYTHON -m pip install -U tox
+    $PYTHON -m pip install -U six && $PYTHON -m pip install -U 'tox < 3.8.0'
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   displayName: Ensure prereqs


### PR DESCRIPTION
## Summary of changes
Currently the `tz` env breaks when run with tox >= 3.8.0 due to some problem with the weak caches not invalidating properly. As a short-term mitigation, we will pin the tox version until we can get to the root of the problem.

This is a short-term mitigation for #908.