### PR TITLE
Use tz.UTC in favor of tz.tzutc() where possible.

### DIFF
--- a/changelog.d/910.bugfix.rst
+++ b/changelog.d/910.bugfix.rst
@@ -1,0 +1,2 @@
+Updated many modules to use ``tz.UTC`` in favor of ``tz.tzutc()`` internally,
+to avoid an unnecessary function call.

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1195,10 +1195,10 @@ class parser(object):
             # This is mostly relevant for winter GMT zones parsed in the UK
             if (aware.tzname() != res.tzname and
                     res.tzname in self.info.UTCZONE):
-                aware = aware.replace(tzinfo=tz.tzutc())
+                aware = aware.replace(tzinfo=tz.UTC)
 
         elif res.tzoffset == 0:
-            aware = naive.replace(tzinfo=tz.tzutc())
+            aware = naive.replace(tzinfo=tz.UTC)
 
         elif res.tzoffset:
             aware = naive.replace(tzinfo=tz.tzoffset(res.tzname, res.tzoffset))

--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -377,7 +377,7 @@ class isoparser(object):
 
     def _parse_tzstr(self, tzstr, zero_as_utc=True):
         if tzstr == b'Z' or tzstr == b'z':
-            return tz.tzutc()
+            return tz.UTC
 
         if len(tzstr) not in {3, 5, 6}:
             raise ValueError('Time zone offset must be 1, 3, 5 or 6 characters')
@@ -396,7 +396,7 @@ class isoparser(object):
             minutes = int(tzstr[(4 if tzstr[3:4] == self._TIME_SEP else 3):])
 
         if zero_as_utc and hours == 0 and minutes == 0:
-            return tz.tzutc()
+            return tz.UTC
         else:
             if minutes > 59:
                 raise ValueError('Invalid minutes in time zone offset')

--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -21,7 +21,6 @@ from six.moves import _thread, range
 import heapq
 
 from ._common import weekday as weekdaybase
-from .tz import tzutc, tzlocal
 
 # For warning about deprecation of until and count
 from warnings import warn

--- a/dateutil/test/property/test_isoparse_prop.py
+++ b/dateutil/test/property/test_isoparse_prop.py
@@ -7,7 +7,7 @@ from dateutil.parser import isoparse
 import pytest
 
 # Strategies
-TIME_ZONE_STRATEGY = st.sampled_from([None, tz.tzutc()] +
+TIME_ZONE_STRATEGY = st.sampled_from([None, tz.UTC] +
     [tz.gettz(zname) for zname in ('US/Eastern', 'US/Pacific',
                                    'Australia/Sydney', 'Europe/London')])
 ASCII_STRATEGY = st.characters(max_codepoint=127)

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from datetime import datetime, timedelta, date, time
 import itertools as it
 
-from dateutil.tz import tz
+from dateutil import tz
 from dateutil.parser import isoparser, isoparse
 
 import pytest

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -5,12 +5,12 @@ from datetime import datetime, timedelta, date, time
 import itertools as it
 
 from dateutil import tz
+from dateutil.tz import UTC
 from dateutil.parser import isoparser, isoparse
 
 import pytest
 import six
 
-UTC = tz.tzutc()
 
 def _generate_tzoffsets(limited):
     def _mkoffset(hmtuple, fmt):
@@ -36,7 +36,7 @@ def _generate_tzoffsets(limited):
     out += [_mkoffset(hm, fmt) for hm in hm_out for fmt in fmts]
 
     # Also add in UTC and naive
-    out.append((tz.tzutc(), 'Z'))
+    out.append((UTC, 'Z'))
     out.append((None, ''))
 
     return out
@@ -227,9 +227,9 @@ def test_iso_ordinal(isoord, dt_expected):
     (b'2014-02-04T12:30:15.224', datetime(2014, 2, 4, 12, 30, 15, 224000)),
     (b'20140204T123015.224', datetime(2014, 2, 4, 12, 30, 15, 224000)),
     (b'2014-02-04T12:30:15.224Z', datetime(2014, 2, 4, 12, 30, 15, 224000,
-                                           tz.tzutc())),
+                                           UTC)),
     (b'2014-02-04T12:30:15.224z', datetime(2014, 2, 4, 12, 30, 15, 224000,
-                                           tz.tzutc())),
+                                           UTC)),
     (b'2014-02-04T12:30:15.224+05:00',
         datetime(2014, 2, 4, 12, 30, 15, 224000,
                  tzinfo=tz.tzoffset(None, timedelta(hours=5))))])
@@ -333,7 +333,7 @@ def test_parse_tzstr(tzoffset):
 @pytest.mark.parametrize('zero_as_utc', [True, False])
 def test_parse_tzstr_zero_as_utc(tzstr, zero_as_utc):
     tzi = isoparser().parse_tzstr(tzstr, zero_as_utc=zero_as_utc)
-    assert tzi == tz.tzutc()
+    assert tzi == UTC
     assert (type(tzi) == tz.tzutc) == zero_as_utc
 
 

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -890,7 +890,7 @@ class TestTZVar(object):
             # This is an imaginary datetime in tz.tzlocal() but should still
             # parse using the GMT-as-alias-for-UTC rule
             dt = parse('2004-05-01T12:00 GMT')
-            dt_exp = datetime(2004, 5, 1, 12, tzinfo=tz.tzutc())
+            dt_exp = datetime(2004, 5, 1, 12, tzinfo=tz.UTC)
 
             assert dt == dt_exp
 
@@ -907,7 +907,7 @@ class TestTZVar(object):
             assert dt.tzname() == dt_exp.tzname()
             assert dt.replace(tzinfo=None) == dt_exp.replace(tzinfo=None)
             assert getattr(dt, 'fold') == getattr(dt_exp, 'fold')
-            assert dt.astimezone(tz.tzutc()) == dt_exp.astimezone(tz.tzutc())
+            assert dt.astimezone(tz.UTC) == dt_exp.astimezone(tz.UTC)
 
 
 def test_parse_tzinfos_fold():
@@ -920,7 +920,7 @@ def test_parse_tzinfos_fold():
     assert dt == dt_exp
     assert dt.tzinfo is dt_exp.tzinfo
     assert getattr(dt, 'fold') == getattr(dt_exp, 'fold')
-    assert dt.astimezone(tz.tzutc()) == dt_exp.astimezone(tz.tzutc())
+    assert dt.astimezone(tz.UTC) == dt_exp.astimezone(tz.UTC)
 
 
 @pytest.mark.parametrize('dtstr,dt', [

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -198,8 +198,8 @@ class TzFoldMixin(object):
         with self._gettz_context(tzname):
             SYD = self.gettz(tzname)
 
-            t0_u = datetime(2012, 3, 31, 15, 30, tzinfo=tz.tzutc())  # AEST
-            t1_u = datetime(2012, 3, 31, 16, 30, tzinfo=tz.tzutc())  # AEDT
+            t0_u = datetime(2012, 3, 31, 15, 30, tzinfo=tz.UTC)  # AEST
+            t1_u = datetime(2012, 3, 31, 16, 30, tzinfo=tz.UTC)  # AEDT
 
             t0_syd0 = t0_u.astimezone(SYD)
             t1_syd1 = t1_u.astimezone(SYD)
@@ -220,8 +220,8 @@ class TzFoldMixin(object):
         with self._gettz_context(tzname):
             SYD = self.gettz(tzname)
 
-            t0_u = datetime(2012, 10, 6, 15, 30, tzinfo=tz.tzutc())  # AEST
-            t1_u = datetime(2012, 10, 6, 16, 30, tzinfo=tz.tzutc())  # AEDT
+            t0_u = datetime(2012, 10, 6, 15, 30, tzinfo=tz.UTC)  # AEST
+            t1_u = datetime(2012, 10, 6, 16, 30, tzinfo=tz.UTC)  # AEDT
 
             t0 = t0_u.astimezone(SYD)
             t1 = t1_u.astimezone(SYD)
@@ -242,8 +242,8 @@ class TzFoldMixin(object):
             with self._gettz_context(tzname):
                 TOR = self.gettz(tzname)
 
-                t0_u = datetime(2011, 11, 6, 5, 30, tzinfo=tz.tzutc())
-                t1_u = datetime(2011, 11, 6, 6, 30, tzinfo=tz.tzutc())
+                t0_u = datetime(2011, 11, 6, 5, 30, tzinfo=tz.UTC)
+                t1_u = datetime(2011, 11, 6, 6, 30, tzinfo=tz.UTC)
 
                 t0_tor = t0_u.astimezone(TOR)
                 t1_tor = t1_u.astimezone(TOR)
@@ -265,8 +265,8 @@ class TzFoldMixin(object):
         with self._gettz_context(tzname):
             TOR = self.gettz(tzname)
 
-            t0_u = datetime(2011, 3, 13, 6, 30, tzinfo=tz.tzutc())
-            t1_u = datetime(2011, 3, 13, 7, 30, tzinfo=tz.tzutc())
+            t0_u = datetime(2011, 3, 13, 6, 30, tzinfo=tz.UTC)
+            t1_u = datetime(2011, 3, 13, 7, 30, tzinfo=tz.UTC)
 
             t0 = t0_u.astimezone(TOR)
             t1 = t1_u.astimezone(TOR)
@@ -286,7 +286,7 @@ class TzFoldMixin(object):
 
         with self._gettz_context(tzname):
             LON = self.gettz(tzname)
-            UTC = tz.tzutc()
+            UTC = tz.UTC
 
             t0_u = datetime(2013, 10, 27, 0, 30, tzinfo=UTC)   # BST
             t1_u = datetime(2013, 10, 27, 1, 30, tzinfo=UTC)   # GMT
@@ -308,7 +308,7 @@ class TzFoldMixin(object):
 
         with self._gettz_context(tzname):
             NYC = self.gettz(tzname)
-            UTC = tz.tzutc()
+            UTC = tz.UTC
             hour = timedelta(hours=1)
 
             # Firmly 2015-11-01 0:30 EDT-4
@@ -339,7 +339,7 @@ class TzFoldMixin(object):
 
         with self._gettz_context(tzname):
             NYC = self.gettz(tzname)
-            UTC = tz.tzutc()
+            UTC = tz.UTC
 
             dt0 = datetime(2011, 11, 6, 1, 30, tzinfo=NYC)
             dt1 = tz.enfold(dt0, fold=1)
@@ -425,7 +425,7 @@ class TzFoldMixin(object):
             SYD0 = self.gettz(tzname)
             SYD1 = self.gettz(tzname)
 
-            t0_u = datetime(2012, 3, 31, 14, 30, tzinfo=tz.tzutc())  # AEST
+            t0_u = datetime(2012, 3, 31, 14, 30, tzinfo=tz.UTC)  # AEST
 
             t0_syd0 = t0_u.astimezone(SYD0)
             t0_syd1 = t0_u.astimezone(SYD1)
@@ -454,13 +454,13 @@ class TzWinFoldMixin(object):
         if gap:
             t_n = dston - timedelta(minutes=30)
 
-            t0_u = t_n.replace(tzinfo=tzi).astimezone(tz.tzutc())
+            t0_u = t_n.replace(tzinfo=tzi).astimezone(tz.UTC)
             t1_u = t0_u + timedelta(hours=1)
         else:
             # Get 1 hour before the first ambiguous date
             t_n = dstoff - timedelta(minutes=30)
 
-            t0_u = t_n.replace(tzinfo=tzi).astimezone(tz.tzutc())
+            t0_u = t_n.replace(tzinfo=tzi).astimezone(tz.UTC)
             t_n += timedelta(hours=1)                   # Naive ambiguous date
             t0_u = t0_u + timedelta(hours=1)            # First ambiguous date
             t1_u = t0_u + timedelta(hours=1)            # Second ambiguous date
@@ -561,7 +561,7 @@ class TzWinFoldMixin(object):
 
         with self.context(tzname):
             NYC = self.tzclass(*args)
-            UTC = tz.tzutc()
+            UTC = tz.UTC
             hour = timedelta(hours=1)
 
             # Firmly 2015-11-01 0:30 EDT-4
@@ -596,7 +596,7 @@ class TzWinFoldMixin(object):
 
         with self.context(tzname):
             NYC = self.tzclass(*args)
-            UTC = tz.tzutc()
+            UTC = tz.UTC
 
             t_n, t0_u, t1_u = self.get_utc_transitions(NYC, 2011, False)
 
@@ -700,7 +700,7 @@ class TzOffsetTest(unittest.TestCase):
         self.assertEqual(utc, gmt)
 
     def testUTCEquality(self):
-        utc = tz.tzutc()
+        utc = tz.UTC
         o_utc = tz.tzoffset('UTC', 0)
 
         self.assertEqual(utc, o_utc)
@@ -955,7 +955,7 @@ class TzLocalNixTest(unittest.TestCase, TzFoldMixin):
 
     def testUTCEquality(self):
         with TZEnvContext(self.UTC):
-            assert tz.tzlocal() == tz.tzutc()
+            assert tz.tzlocal() == tz.UTC
 
 
 # TODO: Maybe a better hack than this?
@@ -1316,7 +1316,7 @@ class TZRangeTest(unittest.TestCase, TzFoldMixin):
     def testBrokenIsDstHandling(self):
         # tzrange._isdst() was using a date() rather than a datetime().
         # Issue reported by Lennart Regebro.
-        dt = datetime(2007, 8, 6, 4, 10, tzinfo=tz.tzutc())
+        dt = datetime(2007, 8, 6, 4, 10, tzinfo=tz.UTC)
         self.assertEqual(dt.astimezone(tz=tz.gettz("GMT+2")),
                           datetime(2007, 8, 6, 6, 10, tzinfo=tz.tzstr("GMT+2")))
 
@@ -2034,7 +2034,7 @@ class TZTest(unittest.TestCase):
     def testGMTOffset(self):
         # GMT and UTC offsets have inverted signal when compared to the
         # usual TZ variable handling.
-        dt = datetime(2007, 8, 6, 4, 10, tzinfo=tz.tzutc())
+        dt = datetime(2007, 8, 6, 4, 10, tzinfo=tz.UTC)
         self.assertEqual(dt.astimezone(tz=tz.tzstr("GMT+2")),
                           datetime(2007, 8, 6, 6, 10, tzinfo=tz.tzstr("GMT+2")))
         self.assertEqual(dt.astimezone(tz=tz.gettz("UTC-2")),
@@ -2175,7 +2175,7 @@ class TzWinTest(unittest.TestCase, TzWinFoldMixin):
     def testTzWinEqualityInvalid(self):
         # Compare to objects that do not implement comparison with this
         # (should default to False)
-        UTC = tz.tzutc()
+        UTC = tz.UTC
         EST = tz.tzwin('Eastern Standard Time')
 
         self.assertFalse(EST == UTC)
@@ -2719,7 +2719,7 @@ def test_resolve_imaginary_ambiguous(dt):
     datetime(2017, 12, 2, 12, 30, tzinfo=tz.gettz('America/New_York')),
     datetime(2018, 12, 2, 9, 30, tzinfo=tz.gettz('Europe/London')),
     datetime(2017, 6, 2, 16, 30, tzinfo=tz.gettz('Australia/Sydney')),
-    datetime(2025, 9, 25, 1, 17, tzinfo=tz.tzutc()),
+    datetime(2025, 9, 25, 1, 17, tzinfo=tz.UTC),
     datetime(2025, 9, 25, 1, 17, tzinfo=tz.tzoffset('EST', -18000)),
     datetime(2019, 3, 4, tzinfo=None)
 ])

--- a/dateutil/test/test_utils.py
+++ b/dateutil/test/test_utils.py
@@ -6,11 +6,11 @@ import unittest
 
 from dateutil import tz
 from dateutil import utils
+from dateutil.tz import UTC
 from dateutil.utils import within_delta
 
 from freezegun import freeze_time
 
-UTC = tz.tzutc()
 NYC = tz.gettz("America/New_York")
 
 

--- a/dateutil/tz/__init__.py
+++ b/dateutil/tz/__init__.py
@@ -2,11 +2,6 @@
 from .tz import *
 from .tz import __doc__
 
-#: Convenience constant providing a :class:`tzutc()` instance
-#:
-#: .. versionadded:: 2.7.0
-UTC = tzutc()
-
 __all__ = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
            "tzstr", "tzical", "tzwin", "tzwinlocal", "gettz",
            "enfold", "datetime_ambiguous", "datetime_exists",

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -123,6 +123,12 @@ class tzutc(datetime.tzinfo):
     __reduce__ = object.__reduce__
 
 
+#: Convenience constant providing a :class:`tzutc()` instance
+#:
+#: .. versionadded:: 2.7.0
+UTC = tzutc()
+
+
 @six.add_metaclass(_TzOffsetFactory)
 class tzoffset(datetime.tzinfo):
     """

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1661,7 +1661,7 @@ def __get_gettz():
                                     break
                             else:
                                 if name in ("GMT", "UTC"):
-                                    tz = tzutc()
+                                    tz = UTC
                                 elif name in time.tzname:
                                     tz = tzlocal()
             return tz
@@ -1701,7 +1701,7 @@ def datetime_exists(dt, tz=None):
 
     # This is essentially a test of whether or not the datetime can survive
     # a round trip to UTC.
-    dt_rt = dt.replace(tzinfo=tz).astimezone(tzutc()).astimezone(tz)
+    dt_rt = dt.replace(tzinfo=tz).astimezone(UTC).astimezone(tz)
     dt_rt = dt_rt.replace(tzinfo=None)
 
     return dt == dt_rt

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1209,15 +1209,15 @@ tzutc examples
 .. doctest:: tzutc
 
     >>> from datetime import *
-    >>> from dateutil.tz import *
+    >>> from dateutil import tz
 
     >>> datetime.now()
     datetime.datetime(2003, 9, 27, 9, 40, 1, 521290)
 
-    >>> datetime.now(tzutc())
+    >>> datetime.now(tz.UTC)
     datetime.datetime(2003, 9, 27, 12, 40, 12, 156379, tzinfo=tzutc())
 
-    >>> datetime.now(tzutc()).tzname()
+    >>> datetime.now(tz.UTC).tzname()
     'UTC'
 
 
@@ -1237,7 +1237,7 @@ tzoffset examples
     >>> datetime.now(tzoffset("BRST", -10800)).tzname()
     'BRST'
 
-    >>> datetime.now(tzoffset("BRST", -10800)).astimezone(tzutc())
+    >>> datetime.now(tzoffset("BRST", -10800)).astimezone(UTC)
     datetime.datetime(2003, 9, 27, 12, 53, 11, 446419,
               tzinfo=tzutc())
 
@@ -1383,7 +1383,7 @@ tzfile examples
 .. testsetup:: tzfile
 
     from datetime import datetime
-    from dateutil.tz import tzfile, tzutc
+    from dateutil.tz import tzfile, UTC
 
 .. doctest:: tzfile
    :options: +NORMALIZE_WHITESPACE
@@ -1393,7 +1393,7 @@ tzfile examples
     datetime.datetime(2003, 9, 27, 12, 3, 48, 392138,
               tzinfo=tzfile('/etc/localtime'))
 
-    >>> datetime.now(tz).astimezone(tzutc())
+    >>> datetime.now(tz).astimezone(UTC)
     datetime.datetime(2003, 9, 27, 15, 3, 53, 70863,
               tzinfo=tzutc())
 

--- a/docs/tz.rst
+++ b/docs/tz.rst
@@ -11,6 +11,8 @@ Objects
 
     A convenience instance of :class:`dateutil.tz.tzutc`.
 
+    .. versionadded:: 2.7.0
+
 Functions
 ---------
 


### PR DESCRIPTION
## Summary of changes
In version 2.7.0, we added the `tz.UTC` object as a convenience accessor for the `tzutc` singleton. This PR goes updates other modules and tests that were using `tzutc()` to use `tz.UTC`, except where it doesn't make sense to do so.

### Pull Request Checklist
- [X] Changes have tests
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
