### PR TITLE
Fix tzwinlocal() with non-ASCII timezone names

### DIFF
--- a/dateutil/tz/win.py
+++ b/dateutil/tz/win.py
@@ -282,8 +282,14 @@ class tzwinlocal(tzwinbase):
             self._dst_abbr = keydict["DaylightName"]
 
             try:
-                tzkeyname = text_type('{kn}\\{sn}').format(kn=TZKEYNAME,
-                                                          sn=self._std_abbr)
+                try:
+                    # NOTE: This works from Windows 7 onwards
+                    tzkeyname = text_type('{kn}\\{sn}').format(kn=TZKEYNAME,
+                                                               sn=keydict["TimeZoneKeyName"])
+                except KeyError:
+                    # NOTE: Backward compatibility for pre Windows 7 (but suffers from #210)
+                    tzkeyname = text_type('{kn}\\{sn}').format(kn=TZKEYNAME,
+                                                               sn=self._std_abbr)
                 with winreg.OpenKey(handle, tzkeyname) as tzkey:
                     _keydict = valuestodict(tzkey)
                     self._display = _keydict["Display"]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes
This is the fix as suggested in https://github.com/dateutil/dateutil/issues/210#issuecomment-320348647

Closes #210 (at least for Windows 7 and newer)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details