### PR TITLE
Register pytest markers

### DIFF
--- a/changelog.d/915.misc.rst
+++ b/changelog.d/915.misc.rst
@@ -1,0 +1,1 @@
+Explicitly listed all markers used in the pytest configuration.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,3 +56,18 @@ filterwarnings =
     error
     error::DeprecationWarning
     error:PendingDeprecationWarning
+markers =
+    gettz
+    import_star
+    isoparser
+    parserinfo
+    rrule
+    rruleset
+    rrulestr
+    smoke
+    tz_resolve_imaginary
+    tzfile
+    tzlocal
+    tzoffset
+    tzstr
+


### PR DESCRIPTION
The latest version of pytest has started warning on unregistered markers, which the test suite uses fairly extensively, causing the tests to fail. This explicitly registers all the markers 
used in the test suite.

In the future we can re-assess whether we want to replace these markers with something else, and also probably we'll want to start pinning all test and documentation dependencies.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
