### PR TITLE
Don't upload coverage on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,7 +66,7 @@ steps:
     if [[ $TOXENV == "py" ]]; then
       ./ci_tools/retry.sh python updatezinfo.py
       python -m tox -- dateutil/test --cov-config=tox.ini --cov=dateutil --junitxml=unittests/TEST-$(Agent.JobName).xml
-      python -m tox -e coverage,codecov
+      python -m tox -e coverage,codecov || true
     else
       python -m tox
     fi

--- a/changelog.d/916.misc.rst
+++ b/changelog.d/916.misc.rst
@@ -1,0 +1,3 @@
+The Azure pipelines script now allows the ``tox -e coverage,codecov`` invocation
+to fail without error, since codecov integration with Azure pipelines is not
+yet set up.


### PR DESCRIPTION
Azure pipelines is failing because of coverage-related problems. Until we have it set up to upload coverage (which I think is getting native support soon, from what I'm told), we can just treat the "upload to codecov" job as an allowed failure.

### Pull Request Checklist
- [X] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
