### PR TITLE
Fix test_tzlocal_offset_equal[GMT-tzoff1]

### DIFF
--- a/changelog.d/928.bugfix.rst
+++ b/changelog.d/928.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue where ``test_tzlocal_offset_equal`` would fail in certain environments (such as FreeBSD) due to an invalid assumption about what time zone names are provided. Reported and fixed by Kubilay Kocak (gh issue #918, pr #928).

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -993,7 +993,7 @@ def test_tzlocal_local_time_trim_colon():
 @mark_tzlocal_nix
 @pytest.mark.parametrize('tzvar, tzoff', [
     ('EST5', tz.tzoffset('EST', -18000)),
-    ('GMT', tz.tzoffset('GMT', 0)),
+    ('GMT0', tz.tzoffset('GMT', 0)),
     ('YAKT-9', tz.tzoffset('YAKT', timedelta(hours=9))),
     ('JST-9', tz.tzoffset('JST', timedelta(hours=9))),
 ])


### PR DESCRIPTION
test_tzlocal_offset_equal[GMT-tzoff1] fails if a system does not 
have a defined (installed) GMT timezone, for example if "Link Etc/GMT GMT"
is not defined in the zoneinfo configuration:

>           assert tz.tzlocal() == tzoff
E           AssertionError: assert tzlocal() == tzoffset(u'GMT', 0)
E             -tzlocal()
E             +tzoffset(u'GMT', 0)

An example of such a configuration is FreeBSD, who's default timezone is
UTC [1][2]. This configuration results in any "non-present" or undefined TZ
name being returned/processed as the default timezone name (in FreeBSD's
case, UTC).

Further, POSIX does not recognize [3] TZ=GMT or TZ=UTC as valid values
because they neither start with a colon nor contain a numeric offset hour
field.

Accordingly, update the GMT value for this parametrized test to GMT0, a
specific (not aliased) timezone, making it more robust to system
configuration differences.

[1] https://svnweb.freebsd.org/changeset/base/130332
[2] https://svnweb.freebsd.org/changeset/base/199405
[3] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes #918

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
