### PR TITLE
Pin requirements more thoroughly on py33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 cache: pip
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -16,6 +15,8 @@ env:
 matrix:
   fast_finish: true
   include:
+    - python: 3.3
+      env: TOXENV=py33   # Needed because "py" won't invoke testenv:py33
     - python: 3.6
       env: TOXENV=docs
     - python: 3.6
@@ -32,9 +33,12 @@ matrix:
     - python: "nightly"
 
 install:
-  - pip install -U six && pip install -U 'tox<3.8.0'
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
+  - |
+    if [[ $TRAVIS_PYTHON_VERSION == "3.3" ]]; then
+      pip install -U "pip==10.0.1"
+      PIP_ARGS="-c requirements/3.3/constraints.txt"
+    fi
+  - pip install -U "tox<3.8.0" $PIP_ARGS
   - if [[ $TOXENV == "py" ]]; then ./ci_tools/retry.sh python updatezinfo.py; fi
 
 script:

--- a/changelog.d/934.misc.rst
+++ b/changelog.d/934.misc.rst
@@ -1,0 +1,1 @@
+Pinned all test dependencies on Python 3.3.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,6 @@
 six
 pytest >= 3.0; python_version != '3.3'
-pytest <  3.3; python_version == '3.3'
 pytest-cov >= 2.0.0
-freezegun < 0.3.11; python_version == '3.3'
 freezegun ; python_version != '3.3'
 hypothesis >= 3.30
 coverage

--- a/requirements/3.3/constraints.txt
+++ b/requirements/3.3/constraints.txt
@@ -1,0 +1,14 @@
+attrs==18.2.0
+coverage==4.5.3
+enum34==1.1.6
+freezegun==0.3.10
+hypothesis==3.30.4
+pip==10.0.1
+pluggy==0.5.2
+py==1.4.34
+pytest==3.2.5
+pytest-cov==2.5.1
+setuptools==39.2.0
+six==1.12.0
+tox==2.9.1
+virtualenv==15.2.0

--- a/requirements/3.3/requirements-dev.txt
+++ b/requirements/3.3/requirements-dev.txt
@@ -1,0 +1,8 @@
+virtualenv<16.0
+setuptools<40.0
+tox<3.8.0
+pytest<3.3
+freezegun<0.3.11
+hypothesis >= 3.30
+coverage
+pytest-cov >= 2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,15 @@ passenv = DATEUTIL_MAY_CHANGE_TZ TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* C
 commands = python -m pytest {posargs: "{toxinidir}/dateutil/test" --cov-config="{toxinidir}/tox.ini" --cov=dateutil}
 deps = -rrequirements-dev.txt
 
+[testenv:py33]
+description = run the unit tests with pytest under Python 3.3
+setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
+passenv = DATEUTIL_MAY_CHANGE_TZ TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_* CODECOV_* SYSTEM_* AGENT_* BUILD_* TF_BUILD
+commands = python -m pytest {posargs: "{toxinidir}/dateutil/test" --cov-config="{toxinidir}/tox.ini" --cov=dateutil}
+deps =
+    -rrequirements/3.3/requirements-dev.txt
+    -crequirements/3.3/constraints.txt
+
 [testenv:coverage]
 description = combine coverage data and create reports
 deps = coverage


### PR DESCRIPTION
## Summary of changes
This does two things to alleviate the current (and hopefully all future) problems we're having testing Python 3.3:

1. Upgrade to the latest supported `pip` on Python 3.3, version 10.0.1, which actually *does* seem to support `python_requires`
2. Add a constraints file to all `pip` operations for Python 3.3 pinning all direct and transitive dependencies.

With all dependencies pinned, the 3.3 build should be more stable.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
