### PR TITLE
Add _DatetimeWithFold.nanosecond attr for Pandas

### DIFF
--- a/dateutil/tz/_common.py
+++ b/dateutil/tz/_common.py
@@ -99,6 +99,12 @@ else:
         def fold(self):
             return 1
 
+        # Because pandas._libs.tslibs.conversion.convert_datetime_to_tsobject
+        # requires a .nanosecond attribute.
+        @property
+        def nanosecond(self):
+            return self.microsecond * 1000
+ 
     def enfold(dt, fold=1):
         """
         Provides a unified interface for assigning the ``fold`` attribute to


### PR DESCRIPTION
Pandas requires a nanosecond attribute.  Add one to _DatetimeWithFold so that these work on pre-3.6 Python with Pandas.

## Summary of changes

Pandas requires a nanosecond attribute.  Add one to _DatetimeWithFold so that these work on pre-3.6 Python with Pandas.

Closes #941 

TODO: Tests presumably needed (just something asserting that .nanosecond works); I'm proposing this via the github editor as a way of filing the change being needed by pasting in the tiny bit of code in my local modified copy that works so I don't have a dev environment setup to do that.