### PR TITLE
Fix typo in documentation and comment

### DIFF
--- a/changelog.d/944.doc.rst
+++ b/changelog.d/944.doc.rst
@@ -1,0 +1,1 @@
+Fixed a typo in the utils documentation, and another one in a comment in the parser code.

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1025,7 +1025,7 @@ class parser(object):
             hms_idx = idx + 2
 
         elif idx > 0 and info.hms(tokens[idx-1]) is not None:
-            # There is a "h", "m", or "s" preceeding this token.  Since neither
+            # There is a "h", "m", or "s" preceding this token.  Since neither
             # of the previous cases was hit, there is no label following this
             # token, so we use the previous label.
             # e.g. the "04" in "12h04"

--- a/dateutil/utils.py
+++ b/dateutil/utils.py
@@ -28,7 +28,7 @@ def today(tzinfo=None):
 
 def default_tzinfo(dt, tzinfo):
     """
-    Sets the the ``tzinfo`` parameter on naive datetimes only
+    Sets the ``tzinfo`` parameter on naive datetimes only
 
     This is useful for example when you are provided a datetime that may have
     either an implicit or explicit time zone, such as when parsing a time zone


### PR DESCRIPTION
# Summary of changes
Fixes two minor typos.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
