### PR TITLE
Change travis Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
   - "3.5"
   - "3.6"
   - "nightly"
-  - "pypy-5.4"
-  - "pypy3"
+  - "pypy2.7"
+  - "pypy3.5"
 env:
   TOXENV=py
 
@@ -31,6 +31,7 @@ matrix:
       dist: xenial
   allow_failures:
     - python: "nightly"
+    - python: "pypy3.6"
 
 install:
   - |


### PR DESCRIPTION
Apparently we are pinning a fairly old version of pyp2.7 (probably for good reasons) that Travis no longer wants to download, and `pypy3` gets you a beta version of PyPy3.6, which has all kinds of bugs (including a bunch in `datetime`).