### PR TITLE
Travis CI: Fix Python 3.3 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 cache: pip
 python:
@@ -26,7 +25,6 @@ matrix:
     - python: 3.7
       # This is required to run Python 3.7 on Travis
       dist: xenial
-      sudo: required
     - python: 3.7
       env: TOXENV=build
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,8 @@ matrix:
     - python: 3.6
       env: TOXENV=tz
     - python: 3.7
-      # This is required to run Python 3.7 on Travis
-      dist: xenial
     - python: 3.7
       env: TOXENV=build
-      dist: xenial
   allow_failures:
     - python: "nightly"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,15 @@ matrix:
   fast_finish: true
   include:
     - python: 3.3
+      # This is required to run Python 3.3 on Travis
+      dist: trusty
       env: TOXENV=py33   # Needed because "py" won't invoke testenv:py33
     - python: 3.6
       env: TOXENV=docs
     - python: 3.6
       env: TOXENV=tz
     - python: 3.7
-      # This is required until Travis has a default image that
-      # can run Python 3.7
+      # This is required to run Python 3.7 on Travis
       dist: xenial
       sudo: required
     - python: 3.7

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -51,6 +51,7 @@ switch, and thus all their contributions are dual-licensed.
 - Grant Garrett-Grossman <grantlycee@gmail.com> (gh: @FakeNameSE) **D**
 - Gustavo Niemeyer <gustavo@niemeyer.net> (gh: @niemeyer)
 - Holger Joukl <holger.joukl@MASKED> (gh: @hjoukl)
+- Hugo van Kemenade (gh: @hugovk) **D**
 - Igor <mrigor83@MASKED>
 - Ionuț Ciocîrlan <jdxlark@MASKED>
 - Jacqueline Chen <jacqueline415@outlook.com> (gh: @jachen20) **D**


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Travis now defaults to Ubuntu 16.04 (Xenial Xerus), but Python 3.3 was not added to this image presumably because it was EOL.

It's still available on the older Ubuntu 14.04 (Trusty Tahr) images, so let's use that. Trusty is also EOL, so it's possible it may need additional fixes or updates in the near future, but this gets things green.


### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [n/a?] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
