### PR TITLE
Pin colorama on Windows

### DIFF
--- a/changelog.d/962.misc.rst
+++ b/changelog.d/962.misc.rst
@@ -1,0 +1,1 @@
+Pin colorama in the Python 3.3 dependencies.

--- a/requirements/3.3/constraints.txt
+++ b/requirements/3.3/constraints.txt
@@ -1,4 +1,5 @@
 attrs==18.2.0
+colorama==0.3.9
 coverage==4.5.3
 enum34==1.1.6
 freezegun==0.3.10


### PR DESCRIPTION
As I worried about, there are apparently some windows-specific dependencies in the testing stack that are not covered in the 3.3 constraints file, which is causing new failures.