### PR TITLE
Fix incorrect import in Python 3.7+

### DIFF
--- a/changelog.d/963.bugfix.rst
+++ b/changelog.d/963.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed issue where ``dateutil.tz`` was using a backport of ``contextlib.nullcontext``
+even in Python 3.7 due to a malformed import statement.

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1823,7 +1823,7 @@ else:
 
 try:
     # Python 3.7 feature
-    from contextmanager import nullcontext as _nullcontext
+    from contextlib import nullcontext as _nullcontext
 except ImportError:
     class _nullcontext(object):
         """


### PR DESCRIPTION
It turns out that the import of `contextlib.nullcontext` in Python 3.7+ was accidentally trying to import `contextmanager.nullcontext`, but this was never noticed because it simply fell back to the backport included here.

I do not know of a great way to test this that doesn't rely on implementation details, but I have manually tested it by setting a breakpoint after the import in the `try` statement and importing `dateutil.tz` manually on Python 3.7, so this version should work.