### PR TITLE
Fix typo in setup.cfg warning configuration

### DIFF
--- a/changelog.d/966.misc.rst
+++ b/changelog.d/966.misc.rst
@@ -1,0 +1,2 @@
+Fix typo in setup.cfg causing PendingDeprecationWarning to not be explicitly
+specified as an error in the warnings filter.

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ xfail_strict = true
 filterwarnings =
     error
     error::DeprecationWarning
-    error:PendingDeprecationWarning
+    error::PendingDeprecationWarning
 markers =
     gettz
     import_star


### PR DESCRIPTION
## Summary of changes
It appears that we were relying on the "errors" filter to treat PendingDeprecationWarning as an error due to a typo in setup.cfg. This line is apparently redundant with the "error" line anyway, but it's best to have a working version of it if we're going to have it at all. I am leaving it in place to be explicit that even these "ignored by default" warnings should be errors, in case a default changes later.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
