### PR TITLE
Fix the parser eating away part of the date string when using underscore delimiter

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -263,7 +263,7 @@ class parserinfo(object):
     """
 
     # m from a.m/p.m, t from ISO T separator
-    JUMP = [" ", ".", ",", ";", "-", "/", "'",
+    JUMP = [" ", ".", ",", ";", "-", "_", "/", "'",
             "at", "on", "and", "ad", "m", "t", "of",
             "st", "nd", "rd", "th"]
 

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -732,6 +732,11 @@ class ParserTest(unittest.TestCase):
         else:
             pytest.fail("Failed to raise ParserError")
 
+    def test_parsing_with_underscore_delimiter(self):
+        dt = parse("somedate 2004_09_17", fuzzy=True)
+        #dt = parse("somedate 17_09_2014", fuzzy=True, dayfirst=True)
+        assert dt == datetime(2004, 9, 17)
+
 
 class TestOutOfBounds(object):
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Fix the parser eating away part of the date string when using underscore delimiter. It is done by adding "_" to the list of JUMP in the _parser.

Closes #959 

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
