### PR TITLE
Remove WarningTestMixin in favor of pytest.warns

### DIFF
--- a/changelog.d/969.misc.rst
+++ b/changelog.d/969.misc.rst
@@ -1,0 +1,1 @@
+Switched from using assertWarns to using pytest.warns in the test suite. (gh pr #969)

--- a/dateutil/test/_common.py
+++ b/dateutil/test/_common.py
@@ -7,54 +7,6 @@ import tempfile
 import pickle
 
 
-class WarningTestMixin(object):
-    # Based on https://stackoverflow.com/a/12935176/467366
-    class _AssertWarnsContext(warnings.catch_warnings):
-        def __init__(self, expected_warnings, parent, **kwargs):
-            super(WarningTestMixin._AssertWarnsContext, self).__init__(**kwargs)
-
-            self.parent = parent
-            try:
-                self.expected_warnings = list(expected_warnings)
-            except TypeError:
-                self.expected_warnings = [expected_warnings]
-
-            self._warning_log = []
-
-        def __enter__(self, *args, **kwargs):
-            rv = super(WarningTestMixin._AssertWarnsContext, self).__enter__(*args, **kwargs)
-
-            if self._showwarning is not self._module.showwarning:
-                super_showwarning = self._module.showwarning
-            else:
-                super_showwarning = None
-
-            def showwarning(*args, **kwargs):
-                if super_showwarning is not None:
-                    super_showwarning(*args, **kwargs)
-
-                self._warning_log.append(warnings.WarningMessage(*args, **kwargs))
-
-            self._module.showwarning = showwarning
-            return rv
-
-        def __exit__(self, *args, **kwargs):
-            super(WarningTestMixin._AssertWarnsContext, self).__exit__(self, *args, **kwargs)
-
-            self.parent.assertTrue(any(issubclass(item.category, warning)
-                                       for warning in self.expected_warnings
-                                       for item in self._warning_log))
-
-    def assertWarns(self, warning, callable=None, *args, **kwargs):
-        warnings.simplefilter('always')
-        context = self.__class__._AssertWarnsContext(warning, self)
-        if callable is None:
-            return context
-        else:
-            with context:
-                callable(*args, **kwargs)
-
-
 class PicklableMixin(object):
     def _get_nobj_bytes(self, obj, dump_kwargs, load_kwargs):
         """

--- a/dateutil/test/test_relativedelta.py
+++ b/dateutil/test/test_relativedelta.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from ._common import WarningTestMixin, NotAValue
+from ._common import NotAValue
 
 import calendar
 from datetime import datetime, date, timedelta
 import unittest
 
+import pytest
+
 from dateutil.relativedelta import relativedelta, MO, TU, WE, FR, SU
 
 
-class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
+class RelativeDeltaTest(unittest.TestCase):
     now = datetime(2003, 9, 17, 20, 54, 47, 282310)
     today = date(2003, 9, 17)
 
@@ -371,25 +373,25 @@ class RelativeDeltaTest(WarningTestMixin, unittest.TestCase):
     def testRelativeDeltaFractionalAbsolutes(self):
         # Fractional absolute values will soon be unsupported,
         # check for the deprecation warning.
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             relativedelta(year=2.86)
 
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             relativedelta(month=1.29)
 
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             relativedelta(day=0.44)
 
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             relativedelta(hour=23.98)
 
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             relativedelta(minute=45.21)
 
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             relativedelta(second=13.2)
 
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             relativedelta(microsecond=157221.93)
 
     def testRelativeDeltaFractionalRepr(self):

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from ._common import WarningTestMixin
 
 from datetime import datetime, date
 import unittest
@@ -20,7 +19,7 @@ import pytest
 
 
 @pytest.mark.rrule
-class RRuleTest(WarningTestMixin, unittest.TestCase):
+class RRuleTest(unittest.TestCase):
     def _rrulestr_reverse_test(self, rule):
         """
         Call with an `rrule` and it will test that `str(rrule)` generates a
@@ -2372,7 +2371,7 @@ class RRuleTest(WarningTestMixin, unittest.TestCase):
         See rfc-5545 3.3.10 - This checks for the deprecation warning, and will
         eventually check for an error.
         """
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             rrule(DAILY, dtstart=datetime(1997, 9, 2, 9, 0),
                          count=3, until=datetime(1997, 9, 4, 9, 0))
 

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 from ._common import PicklableMixin
 from ._common import TZEnvContext, TZWinContext
-from ._common import WarningTestMixin
 from ._common import ComparesEqual
 
 from datetime import datetime, timedelta
@@ -1159,7 +1158,7 @@ def test_gettz_weakref():
     assert NYC_ref() is None    # Should have been pushed out
     assert tz.gettz('America/New_York') is not NYC_ref()
 
-class ZoneInfoGettzTest(GettzTest, WarningTestMixin):
+class ZoneInfoGettzTest(GettzTest):
     def gettz(self, name):
         zoneinfo_file = zoneinfo.get_zonefile_instance()
         return zoneinfo_file.get(name)
@@ -1219,11 +1218,11 @@ class ZoneInfoGettzTest(GettzTest, WarningTestMixin):
         self.assertIs(zif_1, zif_2)
 
     def testZoneInfoDeprecated(self):
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             zoneinfo.gettz('US/Eastern')
 
     def testZoneInfoMetadataDeprecated(self):
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             zoneinfo.gettz_db_metadata()
 
 


### PR DESCRIPTION
This was originally added when we were still supporting `unittest`-only tests, but now that we require pytest, we can switch over to using the built-in `pytest.warns` context manager.

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
