### PR TITLE
Fix Travis build command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,15 @@
 language: python
 cache: pip
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
   - "3.7"
-  - "nightly"
-  - "pypy"
-  - "pypy3.5"
-  - "pypy3.6"
 env:
   TOXENV=py
 
 matrix:
   fast_finish: true
   include:
-    - python: 3.3
-      # This is required to run Python 3.3 on Travis
-      dist: trusty
-      env: TOXENV=py33   # Needed because "py" won't invoke testenv:py33
-    - python: 3.6
-      env: TOXENV=docs
-    - python: 3.6
-      env: TOXENV=tz
     - python: 3.7
       env: TOXENV=build
-  allow_failures:
-    - python: "nightly"
-    - python: "pypy3.6"
 
 install:
   - |
@@ -41,7 +22,9 @@ install:
 
 script:
   - tox
-  - if [[ $TOXENV == "build" ]]; then [ ! -e "dist/*.whl" ] && [ ! -e "dist/*.tar.gz" ]; fi
+  - echo $TOXENV
+  - if [[ $TOXENV == "build" ]]; then echo "Hi" && [ ! -e "dist/*.whl" ] && [ ! -e "dist/*.tar.gz" ]; fi
+  - ls dist
 
 after_success:
   - if [[ $TOXENV == "py" ]]; then tox -e coverage,codecov; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,11 @@ install:
 
 script:
   - tox
-  - echo $TOXENV
-  - if [[ $TOXENV == "build" ]]; then echo "Hi" && [ ! -e "dist/*.whl" ] && [ ! -e "dist/*.tar.gz" ]; fi
-  - ls dist
+  - if [[ $TOXENV == "build" ]]; then
+     # Check that exactly one tarball and one wheel are created
+     [ $(find . -iwholename 'dist/*.tar.gz' | wc -l) -eq 1 ]
+     [ $(find . -iwholename 'dist/*.whl' | wc -l) -eq 1 ]
+    fi
 
 after_success:
   - if [[ $TOXENV == "py" ]]; then tox -e coverage,codecov; fi

--- a/RELEASING
+++ b/RELEASING
@@ -1,7 +1,6 @@
 Release Checklist
 -----------------------------------------
-[ ] Update __version__ string
-[ ] Update classifiers in setup.py to include the latest supported Python
+[ ] Update classifiers in setup.cfg to include the latest supported Python
     versions.
 [ ] Update the metadata in zonefile_metadata.json to include the latest tzdata
     release from https://www.iana.org/time-zones.
@@ -37,59 +36,3 @@ for more details.
 Versioning
 ----------
 Try and keep to a semantic versioning scheme (http://semver.org/).
-
-
-Source releases
-----------
-Release the sources with, at a minimum, .tar.gz and .zip. Make sure you have a
-relatively recent version of setuptools when making the source distribution, as
-earlier version will not include the tests. Other formats are
-optional. They can be generated using:
-
-    python setup.py sdist --formats=zip,gztar
-
-To verify that a source release is correct, inspect it using whatever archive
-utility you have and make sure it contains all the modules and the tests. Also
-make sure that the zoneinfo file is included in the You
-may also want to generate a new clean virtualenv and run the tests from the
-source distribution (python setup.py test).
-
-
-Binary releases
-----------
-It should always be possible to generate a universal wheel binary distribution
-for each release. Generally we do not generate .egg files. In order to generate
-a wheel, you need the wheel package (https://wheel.readthedocs.io/en/latest/)
-installed, which can be installed with:
-
-    pip install wheel
-
-Once this is done, generate the wheel with:
-
-    python setup.py bdist_wheel
-
-
-Signing and generate checksums
-----------
-Since all the outputs are generated in the dist/ directory, can generate all the
-md5 checksums at once from the base directory by executing:
-
-    md5sum dist/*
-
-Save these for when uploading the files. Following this, go into the dist
-directory and sign each of the results with the relevant key:
-
-    gpg --armor --output <fname>.asc --detach-sig <fname>
-
-To automate this for all files, you can use the following command:
-
-    for f  in dist/*; do gpg --armor --output $f.asc --detach-sig $f; done
-
-Save these .asc files for when uploading to pypi. Before uploading them, verify
-that they are valid signatures:
-
-    gpg --verify <fname>.asc <fname>
-
-To do this in bulk, you can use the command:
-
-    for f in $(find ./dist -type f | grep -v '.asc$'); do gpg --verify $f.asc $f; done

--- a/RELEASING
+++ b/RELEASING
@@ -5,15 +5,10 @@ Release Checklist
 [ ] Update the metadata in zonefile_metadata.json to include the latest tzdata
     release from https://www.iana.org/time-zones.
 [ ] If necessary, update the tzdata mirror at https://github.com/dateutil/tzdata
-[ ] Update NEWS with list of changes, giving credit to contributors.
-[ ] Build the source distribution as, at a minimum, .tar.gz and .zip
-[ ] Verify that the source distribution contains all necessary components.
-[ ] Build the binary distribution as a wheel
-[ ] Verify that the binary distribution can be installed and works.
-[ ] Generate MD5 hashes for the source and binary distributions
-[ ] Sign the source and binary distributions with a GPG key (if not the one
-    that made the release, then one signed by the one that made the last
-    release)
+[ ] Update NEWS with list of changes:
+    [ ] Invoke `tox -e towncrier -- --version <NEXT_VERSION>`
+    [ ] Make sure that only `template.rst` remains in changelog.d/
+    [ ] Manually clean up the new NEWS file and then check it in.
 [ ] Commit the changes in git and make a pull request.
 [ ] Accept the pull request and tag the repository with the release number.
 [ ] Add the contents of the NEWS file to the github release notes for the
@@ -35,4 +30,34 @@ for more details.
 
 Versioning
 ----------
-Try and keep to a semantic versioning scheme (http://semver.org/).
+Try and keep to a semantic versioning scheme (http://semver.org/). The versions
+are managed with setuptools_scm, so to update the version, simply tag the
+relevant commit with the new version number.
+
+
+Building and Releasing
+----------------------
+Building and releasing can be done using the `release.py` script, which
+automates building, signing and uploading. Since it uses GPG for signing and
+for decrypting a stored token, it requires that `gpg` be installed on your
+system. Because it has python dependencies, the best way to use the
+`release.py` script is to invoke it using `tox`. To build the source and binary
+distributions, use:
+
+    tox -e build
+
+This will build and sign the distributions and put them in `dist/`. Once that
+is done, you can release them with:
+
+    tox -e release
+
+If you have the token stored in your `~/.pypirc` file. If you have stored the
+relevant token in an encrypted file, use the `--passfile` argument:
+
+    tox -e release -- --passfile token.gpg
+
+The `release` command defaults to uploading to test.pypi.org. To upload to
+pypi.org, use the `--release` flag, so putting it all together, we have:
+
+    tox -e build
+    tox -e release -- --passfile token.gpg --release

--- a/changelog.d/971.misc.rst
+++ b/changelog.d/971.misc.rst
@@ -1,0 +1,1 @@
+Updated the release procedure and added tox environments to help with releasing. (gh pr #971)

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,15 @@ commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_o
            sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_out" {posargs:-W --color -blinkcheck}
            python setup.py check -r -s
 
+
+[testenv:news]
+description = Invoke towncrier to update the NEWS file
+basepython = python3.7
+passenv = *
+deps = towncrier
+commands =
+    towncrier {posargs}
+
 [testenv:build]
 description = Build and sign an sdist and bdist
 basepython = python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ commands =
     towncrier {posargs}
 
 [testenv:build]
-description = Build and sign an sdist and bdist
+description = Build an sdist and bdist
 basepython = python3.7
 skip_install = true
 passenv = *
@@ -96,14 +96,14 @@ deps = click >= 7.0
       pep517 >= 0.5.0
 commands =
     python release.py build
-    python release.py sign
 
 [testenv:release]
-description = Upload the built distributions to PyPI
+description = Sign and upload the built distributions to PyPI
 basepython = python3.7
 skip_install = true
 passenv = *
 deps = click >= 7.0
        twine >= 2.0.0
 commands =
+    python release.py sign
     python release.py upload {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -79,10 +79,22 @@ commands = sphinx-build -d "{toxworkdir}/docs_doctree" docs "{toxworkdir}/docs_o
            python setup.py check -r -s
 
 [testenv:build]
-description = do a build
+description = Build and sign an sdist and bdist
 basepython = python3.7
 skip_install = true
 passenv = *
 deps = click >= 7.0
       pep517 >= 0.5.0
-commands = python release.py
+commands =
+    python release.py build
+    python release.py sign
+
+[testenv:release]
+description = Upload the built distributions to PyPI
+basepython = python3.7
+skip_install = true
+passenv = *
+deps = click >= 7.0
+       twine >= 2.0.0
+commands =
+    python release.py upload {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,7 @@ passenv = *
 deps = click >= 7.0
       pep517 >= 0.5.0
 commands =
-    python release.py build
+    python release.py
 
 [testenv:release]
 description = Sign and upload the built distributions to PyPI


### PR DESCRIPTION
Seems like #971 is no longer sending out webhooks or something. Creating this new PR to debug the issue where Travis wasn't failing even though the `build` command wasn't building any files.

The issue is that the current shell test `[ ! -e "dist/*.whl" ]` is expanding to nothing if no build happens, and I guess `[ -e` thinks I'm asking if "nothing" exists or something. Switching over to using `find`.