### PR TITLE
Lock around strong cache updates

### DIFF
--- a/changelog.d/973.bugfix.rst
+++ b/changelog.d/973.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a race condition in the ``tzoffset`` and ``tzstr`` "strong" caches on Python 2.7. Reported by @kainjow (gh issue #901).


### PR DESCRIPTION
## Summary of changes
Since the strong cache uses operations in OrderedDict that are not thread-safe in Python 2, it is necessary to acquire a lock while updating the dictionary.

When Python 2 support is dropped, we can likely refactor this to avoid locking.

I have a small script that reproduces the issue on Python 2.7, but unfortunately it only reproduces the issue intermittently, and in the current implementation seems to be prone to deadlocks (possibly that is another issue with the tz code..), so it is not really an ideal unit test.

Still, I'll include it here in case anyone wants to verify that this solution works:

<details>

```python
from dateutil import tz

import threading
try:
    from threading import Barrier
except ImportError:
    from threading import Semaphore

    class Barrier(object):
        def __init__(self, n):
            self.n = n
            self.count = 0
            self.mutex = Semaphore(1)
            self.barrier = Semaphore(0)

        def wait(self):
            self.mutex.acquire()
            self.count = self.count + 1
            self.mutex.release()
            if self.count == self.n:
                self.barrier.release()
            self.barrier.acquire()
            self.barrier.release()

N = 2500
b = Barrier(N)
b2 = Barrier(N-1)

def constructor():
    b.wait()
    tz.tzstr("EST5EDT")
    b2.wait()

for i in range(N):
    threading.Thread(target=constructor).start()

b2.wait()
print("Done")
```

</details>

Closes #901.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
