### PR TITLE
Prepare 2.8.1 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,83 @@
+Version 2.8.1 (2019-11-03)
+==========================
+
+Data updates
+------------
+
+- Updated tzdata version to 2019c.
+
+
+Bugfixes
+--------
+
+- Fixed a race condition in the ``tzoffset`` and ``tzstr`` "strong" caches on
+  Python 2.7. Reported by @kainjow (gh issue #901).
+- Parsing errors will now raise ``ParserError``, a subclass of ``ValueError``,
+  which has a nicer string representation. Patch by @gfyoung (gh pr #881).
+- ``parser.parse`` will now raise ``TypeError`` when ``tzinfos`` is passed a
+  type that cannot be interpreted as a time zone. Prior to this change, it
+  would raise an ``UnboundLocalError`` instead.  Patch by @jbrockmendel (gh pr
+  #891).
+- Changed error message raised when when passing a ``bytes`` object as the time
+  zone name to gettz in Python 3.  Reported and fixed by @labrys () (gh issue
+  #927, gh pr #935).
+- Changed compatibility logic to support a potential Python 4.0 release. Patch
+  by Hugo van Kemenade (gh pr #950).
+- Updated many modules to use ``tz.UTC`` in favor of ``tz.tzutc()`` internally,
+  to avoid an unnecessary function call. (gh pr #910).
+- Fixed issue where ``dateutil.tz`` was using a backported version of
+  ``contextlib.nullcontext`` even in Python 3.7 due to a malformed import
+  statement. (gh pr #963).
+
+
+Tests
+-----
+
+- Switched from using assertWarns to using pytest.warns in the test suite. (gh
+  pr #969).
+- Fix typo in setup.cfg causing PendingDeprecationWarning to not be explicitly
+  specified as an error in the warnings filter. (gh pr #966)
+- Fixed issue where ``test_tzlocal_offset_equal`` would fail in certain
+  environments (such as FreeBSD) due to an invalid assumption about what time
+  zone names are provided. Reported and fixed by Kubilay Kocak (gh issue #918,
+  pr #928).
+- Fixed a minor bug in ``test_isoparser`` related to ``bytes``/``str``
+  handling. Fixed by @fhuang5 (gh issue #776, gh pr #879).
+- Explicitly listed all markers used in the pytest configuration. (gh pr #915)
+- Extensive improvements to the parser test suite, including the adoption of
+  ``pytest``-style tests and the addition of parametrization of several test
+  cases. Patches by @jbrockmendel (gh prs #735, #890, #892, #894).
+- Added tests for tzinfos input types. Patch by @jbrockmendel (gh pr #891).
+- Fixed failure of test suite when changing the TZ variable is forbidden.
+  Patch by @shadchin (gh pr #893).
+- Pinned all test dependencies on Python 3.3. (gh prs #934, #962)
+
+
+Documentation changes
+---------------------
+
+- Fixed many misspellings, typos and styling errors in the comments and
+  documentation. Patch by Hugo van Kemenade (gh pr #952).
+
+
+Misc
+----
+
+- Added Python 3.8 to the trove classifiers. (gh pr #970)
+- Moved as many keys from ``setup.py`` to ``setup.cfg`` as possible.  Fixed by
+  @FakeNameSE, @aquinlan82, @jachen20, and @gurgenz221 (gh issue #871, gh pr
+  #880).
+- Reorganized ``parser`` methods by functionality. Patch by @jbrockmendel (gh
+  pr #882).
+- Switched ``release.py`` over to using ``pep517.build`` for creating releases,
+  rather than direct invocations of ``setup.py``. Fixed by @smeng10 (gh issue
+  #869, gh pr #875).
+- Added a "build" environment into the tox configuration, to handle dependency
+  management when making releases. Fixed by @smeng10 (gh issue #870,r
+  gh pr #876).
+- GH #916, GH #971
+
+
 Version 2.8.0 (2019-02-04)
 ==========================
 

--- a/changelog.d/735.misc.rst
+++ b/changelog.d/735.misc.rst
@@ -1,2 +1,0 @@
-Converted many tests in ``test_parser`` over to using ``pytest`` style tests.
-Patch by @jbrockmendel (gh pr #735)

--- a/changelog.d/871.misc.rst
+++ b/changelog.d/871.misc.rst
@@ -1,3 +1,0 @@
-Moved as many keys from ``setup.py`` to ``setup.cfg`` as possible.
-Fixed by @FakeNameSE, @aquinlan82, @jachen20, and @gurgenz221
-(gh issue #871, gh pr #880)

--- a/changelog.d/875.misc.rst
+++ b/changelog.d/875.misc.rst
@@ -1,3 +1,0 @@
-Switched release.py over to using ``pep517.build`` for creating releases,
-rather than direct invocations of ``setup.py``.
-Fixed by @smeng10 (gh issue #869, gh pr #875)

--- a/changelog.d/876.misc.rst
+++ b/changelog.d/876.misc.rst
@@ -1,2 +1,0 @@
-Added a "build" environment into the tox configuration, to handle dependency
-management when making releases. Fixed by @smeng10 (gh issue #870 gh pr #876)

--- a/changelog.d/879.misc.rst
+++ b/changelog.d/879.misc.rst
@@ -1,3 +1,0 @@
-Fixed a minor bug in ``test_isoparser`` related to ``bytes``/``str`` handling.
-Fixed by @fhuang5 (gh issue #776, gh pr #879)
-

--- a/changelog.d/881.bugfix.rst
+++ b/changelog.d/881.bugfix.rst
@@ -1,3 +1,0 @@
-Parsing errors will now raise ``ParserError``, a subclass of ``ValueError``,
-which has a nicer string representation.
-Patch by @gfyoung (gh pr #881)

--- a/changelog.d/882.misc.rst
+++ b/changelog.d/882.misc.rst
@@ -1,2 +1,0 @@
-Reorganized ``parser`` methods by functionality.
-Patch by @jbrockmendel (gh pr #882)

--- a/changelog.d/890.misc.rst
+++ b/changelog.d/890.misc.rst
@@ -1,2 +1,0 @@
-Removed duplicate tests in test_parser and renamed one test class.
-Patch by @jbrockmendel (gh pr #890)

--- a/changelog.d/891.bugfix.rst
+++ b/changelog.d/891.bugfix.rst
@@ -1,4 +1,0 @@
-``parser.parse`` will now raise ``TypeError`` when ``tzinfos`` is passed a type
-that cannot be interpreted as a time zone. Prior to this change, it would raise
-an ``UnboundLocalError`` instead.
-Patch by @jbrockmendel (gh pr #891)

--- a/changelog.d/891.misc.rst
+++ b/changelog.d/891.misc.rst
@@ -1,2 +1,0 @@
-Added tests for tzinfos input types.
-Patch by @jbrockmendel (gh pr #891)

--- a/changelog.d/892.misc.rst
+++ b/changelog.d/892.misc.rst
@@ -1,2 +1,0 @@
-Added test cases for parser.
-Patch by @jbrockmendel (gh pr #892)

--- a/changelog.d/893.misc.rst
+++ b/changelog.d/893.misc.rst
@@ -1,2 +1,0 @@
-Fix tests if TZ not change allowed.
-Patch by @shadchin (gh pr #893)

--- a/changelog.d/894.misc.rst
+++ b/changelog.d/894.misc.rst
@@ -1,2 +1,0 @@
-Parametrized parser test cases.
-Patch by @jbrockmendel (gh pr #894)

--- a/changelog.d/910.bugfix.rst
+++ b/changelog.d/910.bugfix.rst
@@ -1,2 +1,0 @@
-Updated many modules to use ``tz.UTC`` in favor of ``tz.tzutc()`` internally,
-to avoid an unnecessary function call.

--- a/changelog.d/915.misc.rst
+++ b/changelog.d/915.misc.rst
@@ -1,1 +1,0 @@
-Explicitly listed all markers used in the pytest configuration.

--- a/changelog.d/916.misc.rst
+++ b/changelog.d/916.misc.rst
@@ -1,3 +1,0 @@
-The Azure pipelines script now allows the ``tox -e coverage,codecov`` invocation
-to fail without error, since codecov integration with Azure pipelines is not
-yet set up.

--- a/changelog.d/928.bugfix.rst
+++ b/changelog.d/928.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed issue where ``test_tzlocal_offset_equal`` would fail in certain environments (such as FreeBSD) due to an invalid assumption about what time zone names are provided. Reported and fixed by Kubilay Kocak (gh issue #918, pr #928).

--- a/changelog.d/934.misc.rst
+++ b/changelog.d/934.misc.rst
@@ -1,1 +1,0 @@
-Pinned all test dependencies on Python 3.3.

--- a/changelog.d/935.misc.rst
+++ b/changelog.d/935.misc.rst
@@ -1,1 +1,0 @@
-Raise a more helpful TypeError message when passing a bytes zonename to gettz in Python 3.  Reported by @labrys (gh issue #927). Fixed by @labrys (gh pr #935)

--- a/changelog.d/950.bugfix.rst
+++ b/changelog.d/950.bugfix.rst
@@ -1,1 +1,0 @@
-Changed compatibility logic to support a potential Python 4.0 release. Patch by Hugo van Kemenade (gh pr #950)

--- a/changelog.d/952.misc.rst
+++ b/changelog.d/952.misc.rst
@@ -1,1 +1,0 @@
-Fixed many misspellings, typos and styling errors in the comments and documentation. Patch by Hugo van Kemenade (gh pr #952)

--- a/changelog.d/961.data.rst
+++ b/changelog.d/961.data.rst
@@ -1,1 +1,0 @@
-Updated tzdata version to 2019c.

--- a/changelog.d/962.misc.rst
+++ b/changelog.d/962.misc.rst
@@ -1,1 +1,0 @@
-Pin colorama in the Python 3.3 dependencies.

--- a/changelog.d/963.bugfix.rst
+++ b/changelog.d/963.bugfix.rst
@@ -1,2 +1,0 @@
-Fixed issue where ``dateutil.tz`` was using a backport of ``contextlib.nullcontext``
-even in Python 3.7 due to a malformed import statement.

--- a/changelog.d/966.misc.rst
+++ b/changelog.d/966.misc.rst
@@ -1,2 +1,0 @@
-Fix typo in setup.cfg causing PendingDeprecationWarning to not be explicitly
-specified as an error in the warnings filter.

--- a/changelog.d/969.misc.rst
+++ b/changelog.d/969.misc.rst
@@ -1,1 +1,0 @@
-Switched from using assertWarns to using pytest.warns in the test suite. (gh pr #969)

--- a/changelog.d/970.misc.rst
+++ b/changelog.d/970.misc.rst
@@ -1,1 +1,0 @@
-Added Python 3.8 to the trove classifiers and Travis CI builds. (gh pr #970)

--- a/changelog.d/971.misc.rst
+++ b/changelog.d/971.misc.rst
@@ -1,1 +1,0 @@
-Updated the release procedure and added tox environments to help with releasing. (gh pr #971)

--- a/changelog.d/973.bugfix.rst
+++ b/changelog.d/973.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a race condition in the ``tzoffset`` and ``tzstr`` "strong" caches on Python 2.7. Reported by @kainjow (gh issue #901).


### PR DESCRIPTION
## Summary of changes

This updates the changelog for the 2.8.1 release, which includes the following changes:

Version 2.8.1 (2019-11-03)
==========================

Data updates
------------

-   Updated tzdata version to 2019c.

Bugfixes
--------

-   Fixed a race condition in the `tzoffset` and `tzstr` \"strong\"
    caches on Python 2.7. Reported by \@kainjow (gh issue \#901).
-   Parsing errors will now raise `ParserError`, a subclass of
    `ValueError`, which has a nicer string representation. Patch by
    \@gfyoung (gh pr \#881).
-   `parser.parse` will now raise `TypeError` when `tzinfos` is passed a
    type that cannot be interpreted as a time zone. Prior to this
    change, it would raise an `UnboundLocalError` instead. Patch by
    \@jbrockmendel (gh pr \#891).
-   Changed error message raised when when passing a `bytes` object as
    the time zone name to gettz in Python 3. Reported and fixed by
    \@labrys () (gh issue \#927, gh pr \#935).
-   Changed compatibility logic to support a potential Python 4.0
    release. Patch by Hugo van Kemenade (gh pr \#950).
-   Updated many modules to use `tz.UTC` in favor of `tz.tzutc()`
    internally, to avoid an unnecessary function call. (gh pr \#910).
-   Fixed issue where `dateutil.tz` was using a backported version of
    `contextlib.nullcontext` even in Python 3.7 due to a malformed
    import statement. (gh pr \#963).

Tests
-----

-   Switched from using assertWarns to using pytest.warns in the test
    suite. (gh pr \#969).
-   Fix typo in setup.cfg causing PendingDeprecationWarning to not be
    explicitly specified as an error in the warnings filter. (gh pr
    \#966)
-   Fixed issue where `test_tzlocal_offset_equal` would fail in certain
    environments (such as FreeBSD) due to an invalid assumption about
    what time zone names are provided. Reported and fixed by Kubilay
    Kocak (gh issue \#918, pr \#928).
-   Fixed a minor bug in `test_isoparser` related to `bytes`/`str`
    handling. Fixed by \@fhuang5 (gh issue \#776, gh pr \#879).
-   Explicitly listed all markers used in the pytest configuration. (gh
    pr \#915)
-   Extensive improvements to the parser test suite, including the
    adoption of `pytest`-style tests and the addition of parametrization
    of several test cases. Patches by \@jbrockmendel (gh prs \#735,
    \#890, \#892, \#894).
-   Added tests for tzinfos input types. Patch by \@jbrockmendel (gh pr
    \#891).
-   Fixed failure of test suite when changing the TZ variable is
    forbidden. Patch by \@shadchin (gh pr \#893).
-   Pinned all test dependencies on Python 3.3. (gh prs \#934, \#962)

Documentation changes
---------------------

-   Fixed many misspellings, typos and styling errors in the comments
    and documentation. Patch by Hugo van Kemenade (gh pr \#952).

Misc
----

-   Added Python 3.8 to the trove classifiers. (gh pr \#970)
-   Moved as many keys from `setup.py` to `setup.cfg` as possible. Fixed
    by \@FakeNameSE, \@aquinlan82, \@jachen20, and \@gurgenz221 (gh
    issue \#871, gh pr \#880).
-   Reorganized `parser` methods by functionality. Patch by
    \@jbrockmendel (gh pr \#882).
-   Switched `release.py` over to using `pep517.build` for creating
    releases, rather than direct invocations of `setup.py`. Fixed by
    \@smeng10 (gh issue \#869, gh pr \#875).
-   Added a \"build\" environment into the tox configuration, to handle
    dependency management when making releases. Fixed by \@smeng10 (gh
    issue \#870,r gh pr \#876).
-   GH \#916, GH \#971

If you are listed here and would like to make any changes, unfortunately I'm springing this on you quite late in the game, as I plan to make a release tonight some time between 2019-11-03T05:00Z and 2019-11-03T06:59Z because I find it funny to make a release during an ambiguous datetime in my current local time zone (`America/New_York`).