### PR TITLE
Add GitHub URL for PyPi

### DIFF
--- a/changelog.d/975.misc.rst
+++ b/changelog.d/975.misc.rst
@@ -1,0 +1,1 @@
+Added project_urls for documentation and source. Patch by @andriyor (gh pr #975).

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,10 @@ author = Gustavo Niemeyer
 author_email = gustavo@niemeyer.net
 maintainer = Paul Ganssle
 maintainer_email = dateutil@python.org
-url = https://dateutil.readthedocs.io
+url = https://github.com/dateutil/dateutil
+project_urls =
+    Documentation = https://dateutil.readthedocs.io/en/stable/
+    Source = https://github.com/dateutil/dateutil
 long_description_content_type = text/x-rst
 license = Dual License
 license_file = LICENSE
@@ -71,4 +74,3 @@ markers =
     tzlocal
     tzoffset
     tzstr
-


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Warehouse now uses the `project_urls` provided to display links in the sidebar, as well as including them in API responses to help automation tool find the source code for dateutil. For example, see Django's [setup.cfg](https://github.com/django/django/blob/master/setup.cfg) and [PyPI listing](https://pypi.org/project/Django/).

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
