### PR TITLE
migrate away from unittest and adopt pytest for test_internals.py

### DIFF
--- a/dateutil/test/test_internals.py
+++ b/dateutil/test/test_internals.py
@@ -7,9 +7,7 @@ The motivating case for these tests is #483, where we want to smoke-test
 code that may be difficult to reach through the standard API calls.
 """
 
-import unittest
 import sys
-
 import pytest
 
 from dateutil.parser._parser import _ymd
@@ -18,33 +16,31 @@ from dateutil import tz
 IS_PY32 = sys.version_info[0:2] == (3, 2)
 
 
-class TestYMD(unittest.TestCase):
+@pytest.mark.smoke
+def test_YMD_could_be_day():
+    ymd = _ymd('foo bar 124 baz')
 
-    # @pytest.mark.smoke
-    def test_could_be_day(self):
-        ymd = _ymd('foo bar 124 baz')
+    ymd.append(2, 'M')
+    assert ymd.has_month
+    assert not ymd.has_year
+    assert ymd.could_be_day(4)
+    assert not ymd.could_be_day(-6)
+    assert not ymd.could_be_day(32)
 
-        ymd.append(2, 'M')
-        assert ymd.has_month
-        assert not ymd.has_year
-        assert ymd.could_be_day(4)
-        assert not ymd.could_be_day(-6)
-        assert not ymd.could_be_day(32)
+    # Assumes leap year
+    assert ymd.could_be_day(29)
 
-        # Assumes leap year
-        assert ymd.could_be_day(29)
+    ymd.append(1999)
+    assert ymd.has_year
+    assert not ymd.could_be_day(29)
 
-        ymd.append(1999)
-        assert ymd.has_year
-        assert not ymd.could_be_day(29)
+    ymd.append(16, 'D')
+    assert ymd.has_day
+    assert not ymd.could_be_day(1)
 
-        ymd.append(16, 'D')
-        assert ymd.has_day
-        assert not ymd.could_be_day(1)
-
-        ymd = _ymd('foo bar 124 baz')
-        ymd.append(1999)
-        assert ymd.could_be_day(31)
+    ymd = _ymd('foo bar 124 baz')
+    ymd.append(1999)
+    assert ymd.could_be_day(31)
 
 
 ###


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
