### PR TITLE
Drop Python 3.3 on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ build: false
 environment:
   matrix:
     - PYTHON_VERSION: 27
-    - PYTHON_VERSION: 33
     - PYTHON_VERSION: 34
     - PYTHON_VERSION: 35
     - PYTHON_VERSION: 36
@@ -14,12 +13,10 @@ matrix:
   fast_finish: true
   exclude:
     - platform: x86
-      PYTHON_VERSION: 33
-    - platform: x86
       PYTHON_VERSION: 34
     - platform: x86
       PYTHON_VERSION: 35
-    
+
 install:
   # set env variables
   - set TOXENV=py%PYTHON_VERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ environment:
     - PYTHON_VERSION: 34
     - PYTHON_VERSION: 35
     - PYTHON_VERSION: 36
+    - PYTHON_VERSION: 37
+    - PYTHON_VERSION: 38
 platform:
   - x64
   - x86
@@ -16,6 +18,8 @@ matrix:
       PYTHON_VERSION: 34
     - platform: x86
       PYTHON_VERSION: 35
+    - platform: x86
+      PYTHON_VERSION: 36
 
 install:
   # set env variables

--- a/changelog.d/982.misc.rst
+++ b/changelog.d/982.misc.rst
@@ -1,0 +1,1 @@
+Dropped Python 3.3 and added Python 3.7 and 3.8 to the Appveyor builds.


### PR DESCRIPTION
# Summary of changes

Appveyor has been failing recently because of Python 3.3. We're mainly still testing Python 3.3 as a sort of "canary" to determine when we can drop it from the `python_requires`, so I believe it's sufficient to just test on Travis.

I have also added Python 3.7 and 3.8 tests. For now we can do x86/x64 on 3.7 and 3.8 until 3.8 is the more common platform.