### PR TITLE
Fix TypeError in parser's error-wrapping logic

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -70,6 +70,7 @@ switch, and thus all their contributions are dual-licensed.
 - Lauren Oldja <oldja@MASKED> (gh: @loldja) **D**
 - Luca Ferocino <luca.ferox@MASKED> (gh: @lucaferocino) **D**
 - Mario Corchero <mcorcherojim@MASKED> (gh: @mariocj89) **R**
+- Mark Bailey <msb@MASKED> **D**
 - Mateusz Dziedzic (gh: @m-dz) **D**
 - Matt Cooper <vtbassmatt@MASKED> (gh: @vtbassmatt) **D**
 - Matthew Schinckel <matt@MASKED>

--- a/changelog.d/987.bugfix.rst
+++ b/changelog.d/987.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a bug in the parser where non-``ValueError`` exceptions would be raised
+during exception handling; this would happen, for example, if an
+``IllegalMonthError`` was raised in ``dateutil`` code. Fixed by Mark Bailey.
+(gh issue #981, pr #987).

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -654,7 +654,7 @@ class parser(object):
         try:
             ret = self._build_naive(res, default)
         except ValueError as e:
-            six.raise_from(ParserError(e.args[0] + ": %s", timestr), e)
+            six.raise_from(ParserError(str(e) + ": %s", timestr), e)
 
         if not ignoretz:
             ret = self._build_tzaware(ret, res, tzinfos)

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -743,6 +743,10 @@ class TestOutOfBounds(object):
         with pytest.raises(ParserError):
             parse("Feb 30, 2007")
 
+    def test_illegal_month_error(self):
+        with pytest.raises(ParserError):
+            parse("0-100")
+
     def test_day_sanity(self, fuzzy):
         dstr = "2014-15-25"
         with pytest.raises(ParserError):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Guard against an integer value in ValueError args.  This is known to occur with IllegalMonthError.

Closes #981

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
