### PR TITLE
Bug fix for tzoffset.

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -358,7 +358,7 @@ class parserinfo(object):
         return name.lower() in self._utczone
 
     def tzoffset(self, name):
-        if name in self._utczone:
+        if name.lower() in self._utczone:
             return 0
 
         return self.TZOFFSET.get(name)


### PR DESCRIPTION
Since self._utczone stores UTC names in lower case, the argument 'name' should be cast to lower case to make the comparison, just like in other functions.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
