### PR TITLE
Skip uploading Python 3.4 coverage on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,4 +43,5 @@ test_script:
   - C:\Python36\scripts\tox
 
 after_test:
-  - C:\Python36\scripts\tox -e coverage,codecov
+  # Uploading coverage on Python 3.4 on Windows is not worth the effort.
+  - if NOT %PYTHON_VERSION% == 34 (C:\Python36\scripts\tox -e coverage,codecov)

--- a/changelog.d/990.misc.rst
+++ b/changelog.d/990.misc.rst
@@ -1,0 +1,1 @@
+Python 3.4 coverage is no longer uploaded on Appveyor.


### PR DESCRIPTION
# Summary of changes

Builds have started failing on appveyor because we're using coverage 4.x to generate coverage data, but coverage 5.x to process it on Windows. This is because we're always using Python 3.6 to invoke `tox`, so the `coverage` job picks up a more recent version of `coverage` than the `py34` job.

As far as I can tell there are no lines uniquely hit by the Python 3.4-on-Windows tests, so we're not losing any coverage by not including it in the coverage uploads. I say it's not really worth trying to fix this, so I've just skipped the upload step on Python 3.4.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
