### PR TITLE
Fix custom repr for ParserError

### DIFF
--- a/changelog.d/991.bugfix.rst
+++ b/changelog.d/991.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the custom ``repr`` for ``dateutil.parser.ParserError``, which was not defined due to an indentation error. (gh issue #991, gh pr #993)

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1600,8 +1600,9 @@ class ParserError(ValueError):
         except (TypeError, IndexError):
             return super(ParserError, self).__str__()
 
-        def __repr__(self):
-            return "%s(%s)" % (self.__class__.__name__, str(self))
+    def __repr__(self):
+        args = ", ".join("'%s'" % arg for arg in self.args)
+        return "%s(%s)" % (self.__class__.__name__, args)
 
 
 class UnknownTimezoneWarning(RuntimeWarning):

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -943,3 +943,12 @@ def test_decimal_error(value):
     # when constructed with an invalid value
     with pytest.raises(ParserError):
         parse(value)
+
+def test_parsererror_repr():
+    # GH 991 — the __repr__ was not properly indented and so was never defined.
+    # This tests the current behavior of the ParserError __repr__, but the
+    # precise format is not guaranteed to be stable and may change even in
+    # minor versions. This test exists to avoid regressions.
+    s = repr(ParserError("Problem with string: %s", "2019-01-01"))
+
+    assert s == "ParserError('Problem with string: %s', '2019-01-01')"


### PR DESCRIPTION
## Summary of changes
This was originally dead code, because an indentation error had `__repr__` defined after the `return` statement in `__str__`. The definition of the `__repr__` is also changed to be more in line with the conception of a repr as "what you would have to evalue to get this object".

Even though this is not guaranteed behavior, this commit also adds a regression test to avoid simple errors like this in the future.

Closes #991 

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
