### PR TITLE
Parser (and other) documentation fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,8 +27,8 @@ dateutil - powerful extensions to datetime
     :target: https://dev.azure.com/pythondateutilazure/dateutil/_build/latest?definitionId=1&branchName=master
     :alt: azure pipelines build status
 
-.. |coverage| image:: https://codecov.io/github/dateutil/dateutil/coverage.svg?branch=master
-    :target: https://codecov.io/github/dateutil/dateutil?branch=master
+.. |coverage| image:: https://codecov.io/gh/dateutil/dateutil/branch/master/graphs/badge.svg?branch=master
+    :target: https://codecov.io/gh/dateutil/dateutil?branch=master
     :alt: Code coverage
 
 .. |gitter| image:: https://badges.gitter.im/dateutil/dateutil.svg
@@ -153,7 +153,7 @@ Releases     Signing key fingerprint
 Contact
 =======
 Our mailing list is available at `dateutil@python.org <https://mail.python.org/mailman/listinfo/dateutil>`_. As it is hosted by the PSF, it is subject to the `PSF code of
-conduct <https://www.python.org/psf/codeofconduct/>`_.
+conduct <https://www.python.org/psf/conduct/>`_.
 
 License
 =======

--- a/changelog.d/992.doc.rst
+++ b/changelog.d/992.doc.rst
@@ -1,0 +1,2 @@
+Rearranged parser documentation into "Functions", "Classes" and "Warnings and
+Exceptions" categories. (gh issue #992, pr #994).

--- a/changelog.d/994.doc.rst
+++ b/changelog.d/994.doc.rst
@@ -1,0 +1,2 @@
+Updated ``parser.parse`` documentation to reflect the switch from
+``ValueError`` to ``ParserError``. (gh issue #992, pr #994).

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1359,10 +1359,10 @@ def parse(timestr, parserinfo=None, **kwargs):
         first element being a :class:`datetime.datetime` object, the second
         a tuple containing the fuzzy tokens.
 
-    :raises ValueError:
-        Raised for invalid or unknown string format, if the provided
-        :class:`tzinfo` is not in a valid format, or if an invalid date
-        would be created.
+    :raises ParserError:
+        Raised for invalid or unknown string formats, if the provided
+        :class:`tzinfo` is not in a valid format, or if an invalid date would
+        be created.
 
     :raises OverflowError:
         Raised if the parsed date exceeds the largest valid C integer on

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -20,11 +20,11 @@ value falls back to the end of the month.
 Additional resources about date/time string formats can be found below:
 
 - `A summary of the international standard date and time notation
-  <http://www.cl.cam.ac.uk/~mgk25/iso-time.html>`_
-- `W3C Date and Time Formats <http://www.w3.org/TR/NOTE-datetime>`_
+  <https://www.cl.cam.ac.uk/~mgk25/iso-time.html>`_
+- `W3C Date and Time Formats <https://www.w3.org/TR/NOTE-datetime>`_
 - `Time Formats (Planetary Rings Node) <https://pds-rings.seti.org:443/tools/time_formats.html>`_
 - `CPAN ParseDate module
-  <http://search.cpan.org/~muir/Time-modules-2013.0912/lib/Time/ParseDate.pm>`_
+  <https://metacpan.org/pod/release/MUIR/Time-modules-2013.0912/lib/Time/ParseDate.pm>`_
 - `Java SimpleDateFormat Class
   <https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html>`_
 """

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1593,7 +1593,13 @@ def _parsetz(tzstr):
 
 
 class ParserError(ValueError):
-    """Error class for representing failure to parse a datetime string."""
+    """Exception subclass used for any failure to parse a datetime string.
+
+    This is a subclass of :py:exc:`ValueError`, and should be raised any time
+    earlier versions of ``dateutil`` would have raised ``ValueError``.
+
+    .. versionadded:: 2.8.1
+    """
     def __str__(self):
         try:
             return self.args[0] % self.args[1:]
@@ -1606,5 +1612,8 @@ class ParserError(ValueError):
 
 
 class UnknownTimezoneWarning(RuntimeWarning):
-    """Raised when the parser finds a timezone it cannot parse into a tzinfo"""
+    """Raised when the parser finds a timezone it cannot parse into a tzinfo.
+
+    .. versionadded:: 2.7.0
+    """
 # vim:ts=4:sw=4:et

--- a/docs/parser.rst
+++ b/docs/parser.rst
@@ -1,12 +1,29 @@
 ======
 parser
 ======
+
 .. automodule:: dateutil.parser
 
-   .. automethod:: dateutil.parser.parse
+Functions
+---------
 
-   .. autoclass:: dateutil.parser.parserinfo
-      :members:
-      :undoc-members:
+.. automethod:: dateutil.parser.parse
 
-   .. automethod:: dateutil.parser.isoparse
+.. automethod:: dateutil.parser.isoparse
+
+
+Classes
+-------
+
+.. autoclass:: dateutil.parser.parserinfo
+  :members:
+  :undoc-members:
+
+
+Warnings and Exceptions
+-----------------------
+
+.. autoclass:: dateutil.parser.ParserError
+
+.. autoclass:: dateutil.parser.UnknownTimezoneWarning
+


### PR DESCRIPTION
## Summary of changes

This introduces four related changes:

1. Updates links with redirects or pointing to HTTP websites that have HTTPS versions.
2. Rearranges the parser documentation to break it down into functions/classes/exceptions.
3. Documents that `parser.parse` raises `ParserError` now.
4. Cleans up the docstrings for `ParserError` and `UnknownTimezone`.

Closes #992

### Pull Request Checklist
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
