### PR TITLE
Return datetime, skipped tokens, date tokens if fuzzy_with_tokens is True (Added date tokens)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -79,6 +79,7 @@ switch, and thus all their contributions are dual-licensed.
 - Michael Aquilina <michaelaquilina@MASKED> (gh: @MichaelAquilina)
 - Michael J. Schultz <mjschultz@MASKED>
 - Mike Gilbert <floppym@MASKED>
+- Mike Rans  (gh @mcarans) **D**
 - Nicholas Herrriot <Nicholas.Herriot@gmail.com> **D**
 - Nicolas Évrard (gh: @nicoe) **D**
 - Nick Smith <nick.smith@MASKED>

--- a/changelog.d/999.feature.rst
+++ b/changelog.d/999.feature.rst
@@ -1,0 +1,1 @@
+Return datetime, skipped tokens, date tokens if fuzzy_with_tokens is True (Added date tokens).

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1262,7 +1262,6 @@ class parser(object):
         """
         skipped_tokens = []
         date_tokens = []
-        skipped_idxs = sorted(skipped_idxs)
         prev = None
         for idx, token in enumerate(tokens):
             if idx in skipped_idxs:

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -512,12 +512,15 @@ class ParserTest(unittest.TestCase):
                          (datetime(2003, 9, 25, 10, 49, 41,
                                    tzinfo=self.brsttz),
                          ('Today is ', 'of ', ', exactly at ',
-                          ' with timezone ', '.')))
+                          ' with timezone ', '.'),
+                         ('25 ', 'September of 2003', '10:49:41',
+                          '-03:00')))
 
         s2 = "http://biz.yahoo.com/ipo/p/600221.html"
         self.assertEqual(parse(s2, fuzzy_with_tokens=True),
                          (datetime(2060, 2, 21, 0, 0, 0),
-                         ('http://biz.yahoo.com/ipo/p/', '.html')))
+                         ('http://biz.yahoo.com/ipo/p/', '.html'),
+                         ('600221',)))
 
     def testFuzzyAMPMProblem(self):
         # Sometimes fuzzy parsing results in AM/PM flag being set without


### PR DESCRIPTION
## Summary of changes
Added return of date tokens eg.

        s1 = "Today is 25 of September of 2003, exactly " \
            "at 10:49:41 with timezone -03:00."
        self.assertEqual(parse(s1, fuzzy_with_tokens=True),
                         (datetime(2003, 9, 25, 10, 49, 41,
                                   tzinfo=self.brsttz),
                         ('Today is ', 'of ', ', exactly at ',
                          ' with timezone ', '.'),
                         ('25 ', 'September of 2003', '10:49:41',
                          '-03:00')))

Closes https://github.com/dateutil/dateutil/issues/998

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
