### PR TITLE
Add ability to require timestamp components in parse method

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1359,6 +1359,30 @@ def parse(timestr, parserinfo=None, **kwargs):
             >>> parse("Today is January 1, 2047 at 8:21:00AM", fuzzy_with_tokens=True)
             (datetime.datetime(2047, 1, 1, 8, 21), (u'Today is ', u' ', u'at '))
 
+    :param require_year:
+        If ``True``, will raise a :class:`ValueError` when the ``timestr`` is missing
+        the year (defaults to ``False``)
+
+    :param require_month:
+        If ``True``, will raise a :class:`ValueError` when the ``timestr`` is missing
+        the month (defaults to ``False``)
+
+    :param require_day:
+        If ``True``, will raise a :class:`ValueError` when the ``timestr`` is missing
+        the day (defaults to ``False``)
+
+    :param require_hour:
+        If ``True``, will raise a :class:`ValueError` when the ``timestr`` is missing
+        the hour (defaults to ``False``)
+
+    :param require_minute:
+        If ``True``, will raise a :class:`ValueError` when the ``timestr`` is missing
+        the minute (defaults to ``False``)
+
+    :param require_second:
+        If ``True``, will raise a :class:`ValueError` when the ``timestr`` is missing
+        the second (defaults to ``False``)
+
     :return:
         Returns a :class:`datetime.datetime` object or, if the
         ``fuzzy_with_tokens`` option is ``True``, returns a tuple, the

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -643,6 +643,10 @@ class parser(object):
             default = datetime.datetime.now().replace(hour=0, minute=0,
                                                       second=0, microsecond=0)
 
+        required_components = {}
+        for attr in ("year", "month", "day", "hour", "minute", "second"):
+            required_components[attr] = kwargs.pop("require_{attr}".format(attr=attr), False)
+
         res, skipped_tokens = self._parse(timestr, **kwargs)
 
         if res is None:
@@ -652,7 +656,7 @@ class parser(object):
             raise ParserError("String does not contain a date: %s", timestr)
 
         try:
-            ret = self._build_naive(res, default)
+            ret = self._build_naive(res, default, **required_components)
         except ValueError as e:
             six.raise_from(ParserError(str(e) + ": %s", timestr), e)
 
@@ -1220,13 +1224,15 @@ class parser(object):
 
         return aware
 
-    def _build_naive(self, res, default):
+    def _build_naive(self, res, default, **required_components):
         repl = {}
         for attr in ("year", "month", "day", "hour",
                      "minute", "second", "microsecond"):
             value = getattr(res, attr)
             if value is not None:
                 repl[attr] = value
+            elif required_components.get(attr, False):
+                raise ValueError("String is missing components")
 
         if 'day' not in repl:
             # If the default day exceeds the last day of the month, fall back

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -952,3 +952,37 @@ def test_parsererror_repr():
     s = repr(ParserError("Problem with string: %s", "2019-01-01"))
 
     assert s == "ParserError('Problem with string: %s', '2019-01-01')"
+
+
+@pytest.mark.parametrize('required_components,datestr,valid', [
+    ({'require_year': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_year': True}, 'January 20th at 12:34:56.7890', False),
+    ({'require_year': False}, 'January 20th at 12:34:56.7890', True),
+    ({'require_month': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_month': True}, '2020 at 12:34:56.7890', False),
+    ({'require_month': False}, '2020 at 12:34:56.7890', True),
+    ({'require_day': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_day': True}, 'January 2020 at 12:34:56.7890', False),
+    ({'require_day': False}, 'January 2020 at 12:34:56.7890', True),
+    ({'require_hour': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_hour': True}, 'January 20th 2020', False),
+    ({'require_hour': False}, 'January 20th 2020', True),
+    ({'require_minute': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_minute': True}, 'January 20th 2020 at 12', False),
+    ({'require_minute': False}, 'January 20th 2020 at 12', True),
+    ({'require_second': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_second': True}, 'January 20th 2020 at 12:34', False),
+    ({'require_second': False}, 'January 20th 2020 at 12:34', True),
+    ({'require_year': True, 'require_month': True, 'require_day': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_year': True, 'require_month': True, 'require_day': True}, 'January 20th at 12:34:56.7890', False),
+    ({'require_year': True, 'require_month': True, 'require_day': True}, 'January 2020 at 12:34:56.7890', False),
+    ({'require_hour': True, 'require_minute': True, 'require_second': True}, 'January 20th 2020 at 12:34:56.7890', True),
+    ({'require_hour': True, 'require_minute': True, 'require_second': True}, 'January 20th 2020 at 12:34', False),
+    ({'require_hour': True, 'require_minute': True, 'require_second': True}, 'January 20th 2020', False),
+])
+def test_parse_required_components(required_components, datestr, valid):
+    if valid:
+        parse(datestr, **required_components)
+    else:
+        with pytest.raises(ParserError):
+            parse(datestr, **required_components)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Adds keyword arguments to the `parse` method:
- `require_year`
- `require_month`
- `require_day`
- `require_hour`
- `require_minute`
- `require_second`

When these are set to `True` and the input string is missing the component, a `ValueError` will be raised instead of using the default date. This is useful for instances when you don't have a sane default date.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
