### PR TITLE
Lazyload submodules python37+

### DIFF
--- a/changelog.d/1007.feature.rst
+++ b/changelog.d/1007.feature.rst
@@ -1,0 +1,6 @@
+Made all ``dateutil`` submodules lazily imported using `PEP 562
+<https://www.python.org/dev/peps/pep-0562/>`_. On Python 3.7+, things like
+``import dateutil; dateutil.tz.gettz("America/New_York")`` will now work
+without explicitly importing ``dateutil.tz``, with the import occurring behind
+the scenes on first use. The old behavior remains on Python 3.6 and earlier.
+Fixed by Orson Adams. (gh issue #771, gh pr #1007)

--- a/dateutil/__init__.py
+++ b/dateutil/__init__.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import sys
+
 try:
     from ._version import version as __version__
 except ImportError:
@@ -6,3 +8,17 @@ except ImportError:
 
 __all__ = ['easter', 'parser', 'relativedelta', 'rrule', 'tz',
            'utils', 'zoneinfo']
+
+def __getattr__(name):
+    import importlib
+
+    if name in __all__:
+        return importlib.import_module("." + name, __name__)
+    raise AttributeError(
+        "module {!r} has not attribute {!r}".format(__name__, name)
+    )
+
+
+def __dir__():
+    # __dir__ should include all the lazy-importable modules as well.
+    return [x for x in globals() if x not in sys.modules] + __all__


### PR DESCRIPTION
## Summary of changes

Allow submodule lazy loading for python version3.7+
Addresses #771 using [PEP: 562](https://www.python.org/dev/peps/pep-0562/)

### Pull Request Checklist
- [x] Changes have tests
Need help with testing
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details

This is fairly straightforward given the introduction of `__getattr__` for modules. The challenge is testing the import functionality for two subsets of versions: >= 3.7 & < 3.7.

I added what I thought would be reasonable tests if I used tox. Trouble is `import dateutil` loads the submodules regardless of versions - ignoring  `__init__.py `, Which when I think about it maybe is expected behavior.

How to test this bad boy?