### PR TITLE
Add solution to Next Monday meeting exercise in docs

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,6 +38,7 @@ switch, and thus all their contributions are dual-licensed.
 - Claudio Canepa <ccanepacc@MASKED>
 - Corey Girard <corey.r.girard@gmail.com> (gh: @coreygirard) **D**
 - Cosimo Lupo <cosimo@anthrotype.com> (gh: @anthrotype) **D**
+- Daniel Lemm (gh: @ffe4) **D**
 - Daniel Lepage <dplepage@MASKED>
 - David Lehrian <david@MASKED>
 - Dean Allsopp (gh: @daplantagenet) **D**

--- a/docs/exercises/index.rst
+++ b/docs/exercises/index.rst
@@ -71,6 +71,8 @@ To solve this exercise, copy-paste this script into a document, change anything 
 A solution to this problem is provided :doc:`here <solutions/mlk-day-rrule>`.
 
 
+.. _next-monday-meeting:
+
 Next Monday meeting
 -------------------
 
@@ -120,6 +122,8 @@ To solve this exercise, copy-paste this script into a document, change anything 
 .. raw:: html
 
     </details>
+
+A solution to this problem is provided :doc:`here <solutions/next_monday_meeting_relativedelta>`.
 
 
 Parsing a local tzname

--- a/docs/exercises/solutions/next_monday_meeting_relativedelta.rst
+++ b/docs/exercises/solutions/next_monday_meeting_relativedelta.rst
@@ -1,0 +1,11 @@
+:orphan:
+
+Next Monday meeting: Solution
+=============================
+
+Presented here is a solution to the :ref:`Next Monday meeting exercise <next-monday-meeting>`.
+
+
+.. include:: next_monday_meeting_relativedelta_solution.py
+   :code: python3
+

--- a/docs/exercises/solutions/next_monday_meeting_relativedelta_solution.py
+++ b/docs/exercises/solutions/next_monday_meeting_relativedelta_solution.py
@@ -1,0 +1,38 @@
+# --------- YOUR CODE -------------- #
+from dateutil.relativedelta import relativedelta, MO
+
+
+def next_monday(dt):
+    next_meeting = dt + relativedelta(
+        dt, weekday=MO, weeks=0, hour=10, minute=0, second=0, microsecond=0
+    )
+    if next_meeting < dt:
+        next_meeting = next_meeting + relativedelta(weeks=1)
+    return next_meeting
+
+
+# ---------------------------------- #
+
+from datetime import datetime
+from dateutil import tz
+
+NEXT_MONDAY_CASES = [
+    (datetime(2018, 4, 11, 14, 30, 15, 123456), datetime(2018, 4, 16, 10, 0)),
+    (datetime(2018, 4, 16, 10, 0), datetime(2018, 4, 16, 10, 0)),
+    (datetime(2018, 4, 16, 10, 30), datetime(2018, 4, 23, 10, 0)),
+    (
+        datetime(2018, 4, 14, 9, 30, tzinfo=tz.gettz("America/New_York")),
+        datetime(2018, 4, 16, 10, 0, tzinfo=tz.gettz("America/New_York")),
+    ),
+]
+
+
+def test_next_monday_1():
+    for dt_in, dt_out in NEXT_MONDAY_CASES:
+        print(dt_in, dt_out, next_monday(dt_in))
+        assert next_monday(dt_in) == dt_out
+
+
+if __name__ == "__main__":
+    test_next_monday_1()
+    print("Success!")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Adds a solution to the docs exercise from #665. Since #782 seems pretty stale I decided to offer an alternative PR.

It’s my first time using `dateutil` and I found the docs quite clear.

Skipped adding a news fragment in line with the MLK Day exercise PR #774 .
The solution is automatically run by pytest. Will also be run by tox if #1015 is merged.

Since master fails

Closes #665 (possibly)

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
