### PR TITLE
Fix failing build by removing broken mirror in README.rst

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,6 +38,7 @@ switch, and thus all their contributions are dual-licensed.
 - Claudio Canepa <ccanepacc@MASKED>
 - Corey Girard <corey.r.girard@gmail.com> (gh: @coreygirard) **D**
 - Cosimo Lupo <cosimo@anthrotype.com> (gh: @anthrotype) **D**
+- Daniel Lemm (gh: @ffe4) **D**
 - Daniel Lepage <dplepage@MASKED>
 - David Lehrian <david@MASKED>
 - Dean Allsopp (gh: @daplantagenet) **D**

--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,7 @@ previous release. A table of release signing keys can be found below:
 ===========  ============================
 Releases     Signing key fingerprint
 ===========  ============================
-2.4.1-       `6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB`_ (|pgp_mirror|_)
+2.4.1-       `6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB`_ 
 ===========  ============================
 
 
@@ -163,6 +163,3 @@ All contributions after December 1, 2017 released under dual license - either `A
 
 .. _6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB:
    https://pgp.mit.edu/pks/lookup?op=vindex&search=0xCD54FCE3D964BEFB
-
-.. |pgp_mirror| replace:: mirror
-.. _pgp_mirror: https://sks-keyservers.net/pks/lookup?op=vindex&search=0xCD54FCE3D964BEFB

--- a/changelog.d/1017.misc.rst
+++ b/changelog.d/1017.misc.rst
@@ -1,0 +1,2 @@
+Removed broken link to pgp mirror that made the travis build fail.
+Reported and fixed by @ffe4 (gh pr #1017)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Build has been failing for a month due to the pgp mirror link being broken (502 Bad Gateway). The site seems defunct, since even a link on the homepage returns a 502.

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
