### PR TITLE
Migrate PyPy CI to GitHub Actions

### DIFF
--- a/.github/workflows/test_pypy.yml
+++ b/.github/workflows/test_pypy.yml
@@ -1,0 +1,50 @@
+name: PyPy
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: [pypy2, pypy3]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      TOXENV: py
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: python -m pip install -U tox
+      - name: Install zic (Windows)
+        run: |
+          curl https://get.enterprisedb.com/postgresql/postgresql-9.5.21-2-windows-x64-binaries.zip --output $env:GITHUB_WORKSPACE\postgresql9.5.21.zip
+          unzip -oq $env:GITHUB_WORKSPACE\postgresql9.5.21.zip -d .postgresql
+        if: runner.os == 'Windows'
+      - name: Run updatezinfo.py (Windows)
+        run: |
+          $env:Path += ";$env:GITHUB_WORKSPACE\.postgresql\pgsql\bin"
+          ci_tools/retry.bat python updatezinfo.py
+        if: runner.os == 'Windows'
+      - name: Run updatezinfo.py (Unix)
+        run: ./ci_tools/retry.sh python updatezinfo.py
+        if: runner.os != 'Windows'
+      - name: Run tox
+        run: python -m tox
+      - name: Generate coverage.xml
+        run: python -m tox -e coverage
+      - name: Report coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./.tox/coverage.xml
+          name: ${{ matrix.os }}:${{ matrix.python-version }}
+          fail_ci_if_error: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,7 @@ python:
   - "3.7"
   - "3.8"
   - "nightly"
-  - "pypy"
-  - "pypy3.5"
-  - "pypy3.6"
-env:
-  TOXENV=py
+env: TOXENV=py
 
 matrix:
   fast_finish: true
@@ -20,7 +16,7 @@ matrix:
     - python: 3.3
       # This is required to run Python 3.3 on Travis
       dist: trusty
-      env: TOXENV=py33   # Needed because "py" won't invoke testenv:py33
+      env: TOXENV=py33 # Needed because "py" won't invoke testenv:py33
     - python: 3.6
       env: TOXENV=docs
     - python: 3.6
@@ -29,7 +25,6 @@ matrix:
       env: TOXENV=build
   allow_failures:
     - python: "nightly"
-    - python: "pypy3.6"
 
 install:
   - |

--- a/changelog.d/1020.misc.rst
+++ b/changelog.d/1020.misc.rst
@@ -1,0 +1,1 @@
+Migrate PyPy CI from Travis to Github Actions. (gh issue #1019)

--- a/tox.ini
+++ b/tox.ini
@@ -34,16 +34,16 @@ deps = coverage
 skip_install = True
 changedir = {toxworkdir}
 setenv = COVERAGE_FILE=.coverage
-commands = coverage erase
-           coverage combine
-           coverage report --rcfile={toxinidir}/tox.ini
-           coverage xml
+commands = python -m coverage erase
+           python -m coverage combine
+           python -m coverage report --rcfile={toxinidir}/tox.ini
+           python -m coverage xml
 
 [testenv:codecov]
 description = [only run on CI]: upload coverage data to codecov (depends on coverage running first)
 deps = codecov
 skip_install = True
-commands = codecov --file {toxworkdir}/coverage.xml
+commands = python -m codecov --file {toxworkdir}/coverage.xml
 
 [testenv:dev]
 description = DEV environment


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

As discussed in #1019, here is a PR for migrating the PyPy tests over to GHA.

- Add GHA workflow for PyPy tests
  I have used the official Codecov action for coverage reporting, and I think you shouldn’t even need to set the token for it to work. I have also unpinned tox, since it seems to work for these tests. Otherwise I have mostly reused what was already in the other pipelines, with a slight version bump on Postgres.
- Update `tox.ini` to run on Windows
  Just added `python -m` before commands.
- Remove PyPy jobs from Travis
  Note that I am not running a pypy3.5 test since it’s not installed on the GHA runner.

It would also be nice if you could have a look at whether the warnings for `updatezinfo.py` are expected on macos.

Assuming everything works satisfactory, could I also remove the `azure-pipelines.yml`? From your comments it didn't seem likely that it's ever gonna be used again. It'll still be in the commit history if it's needed later.

Closes #888, closes #889

### Pull Request Checklist
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
