### PR TITLE
Fix tz.gettz() not returning local time for empty string

### DIFF
--- a/changelog.d/1024.misc.rst
+++ b/changelog.d/1024.misc.rst
@@ -1,0 +1,2 @@
+Fixed tz.gettz() not returning local time when passed an empty string.
+Reported by @labrys (gh issues #925, #926). Fixed by @ffe4 (gh pr #1024)

--- a/dateutil/test/property/test_tz_prop.py
+++ b/dateutil/test/property/test_tz_prop.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta
+
+import pytest
+import six
+from hypothesis import assume, given
+from hypothesis import strategies as st
+
+from dateutil import tz as tz
+
+EPOCHALYPSE = datetime.fromtimestamp(2147483647)
+NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
+
+
+@pytest.mark.gettz
+@pytest.mark.parametrize("gettz_arg", [None, ""])
+# TODO: Remove bounds when GH #590 is resolved
+@given(
+    dt=st.datetimes(
+        min_value=NEGATIVE_EPOCHALYPSE, max_value=EPOCHALYPSE, timezones=st.just(tz.UTC),
+    )
+)
+def test_gettz_returns_local(gettz_arg, dt):
+    act_tz = tz.gettz(gettz_arg)
+    if isinstance(act_tz, tz.tzlocal):
+        return
+
+    dt_act = dt.astimezone(tz.gettz(gettz_arg))
+    if six.PY2:
+        dt_exp = dt.astimezone(tz.tzlocal())
+    else:
+        dt_exp = dt.astimezone()
+
+    assert dt_act == dt_exp
+    assert dt_act.tzname() == dt_exp.tzname()
+    assert dt_act.utcoffset() == dt_exp.utcoffset()

--- a/dateutil/test/test_tz.py
+++ b/dateutil/test/test_tz.py
@@ -1080,6 +1080,15 @@ class GettzTest(unittest.TestCase, TzFoldMixin):
 
 
 @pytest.mark.gettz
+def test_gettz_same_result_for_none_and_empty_string():
+    local_from_none = tz.gettz()
+    local_from_empty_string = tz.gettz("")
+    assert local_from_none is not None
+    assert local_from_empty_string is not None
+    assert local_from_none == local_from_empty_string
+
+
+@pytest.mark.gettz
 @pytest.mark.parametrize('badzone', [
     'Fake.Region/Abcdefghijklmnop',  # Violates several tz project name rules
 ])

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1596,7 +1596,7 @@ def __get_gettz():
                     name = os.environ["TZ"]
                 except KeyError:
                     pass
-            if not name or name == ":":
+            if name is None or name in ("", ":"):
                 for filepath in TZFILES:
                     if not os.path.isabs(filepath):
                         filename = filepath

--- a/dateutil/tz/tz.py
+++ b/dateutil/tz/tz.py
@@ -1596,7 +1596,7 @@ def __get_gettz():
                     name = os.environ["TZ"]
                 except KeyError:
                     pass
-            if name is None or name == ":":
+            if not name or name == ":":
                 for filepath in TZFILES:
                     if not os.path.isabs(filepath):
                         filename = filepath


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

- `tz.gettz()` now properly checks for empty string and returns local time
- added test for `tz.gettz()` returning the same result when passed empty string or `None`

`nocache` checks the `gettz(name)` parameter with `if not name` and tries to get the local time from the `TZ` environment variable. When the environment variable does not exist, it only checked for `name is None`, skipping the logic that searches for the local time `tzfile` when passed an empty string.

Closes #925 
Closes #926 

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
