### PR TITLE
Document methods in `rrule` module

### DIFF
--- a/changelog.d/1025.doc.rst
+++ b/changelog.d/1025.doc.rst
@@ -1,0 +1,1 @@
+Fixed methods in the ``rrule`` module not being displayed in the docs. (gh pr #1025)

--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -5,25 +5,26 @@ the recurrence rules documented in the
 `iCalendar RFC <https://tools.ietf.org/html/rfc5545>`_,
 including support for caching of results.
 """
-import itertools
-import datetime
 import calendar
+import datetime
+import heapq
+import itertools
 import re
 import sys
+from functools import wraps
+# For warning about deprecation of until and count
+from warnings import warn
+
+from six import advance_iterator, integer_types
+
+from six.moves import _thread, range
+
+from ._common import weekday as weekdaybase
 
 try:
     from math import gcd
 except ImportError:
     from fractions import gcd
-
-from six import advance_iterator, integer_types
-from six.moves import _thread, range
-import heapq
-
-from ._common import weekday as weekdaybase
-
-# For warning about deprecation of until and count
-from warnings import warn
 
 __all__ = ["rrule", "rruleset", "rrulestr",
            "YEARLY", "MONTHLY", "WEEKLY", "DAILY",
@@ -81,6 +82,7 @@ def _invalidates_cache(f):
     Decorator for rruleset methods which may invalidate the
     cached length.
     """
+    @wraps(f)
     def inner_func(self, *args, **kwargs):
         rv = f(self, *args, **kwargs)
         self._invalidate_cache()

--- a/docs/rrule.rst
+++ b/docs/rrule.rst
@@ -9,7 +9,13 @@ Classes
 -------
 
 .. autoclass:: rrule
+   :members:
+   :undoc-members:
+   :inherited-members:
 .. autoclass:: rruleset
+   :members:
+   :undoc-members:
+   :inherited-members:
 
 Functions
 ---------


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

The [current documentation](https://dateutil.readthedocs.io/en/latest/rrule.html) on RTD does not display any of the already documented methods in the `rrule` module.

- Added options to automatically document members of `rrule` and `rruleset`
- Used `functools.wraps` on decorator to preserve `__doc__` attribute of `ruleset` methods.

The imports were unintentionally reorganized with `isort` by my editor, but I'd prefer keeping them that way.

### Pull Request Checklist
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
