### PR TITLE
Fix parser using tzlocal() instead of tzutc() if both accurate

### DIFF
--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -1186,6 +1186,9 @@ class parser(object):
             aware = naive.replace(tzinfo=tzinfo)
             aware = self._assign_tzname(aware, res.tzname)
 
+        elif res.tzoffset == 0:
+            aware = naive.replace(tzinfo=tz.UTC)
+
         elif res.tzname and res.tzname in time.tzname:
             aware = naive.replace(tzinfo=tz.tzlocal())
 
@@ -1196,9 +1199,6 @@ class parser(object):
             if (aware.tzname() != res.tzname and
                     res.tzname in self.info.UTCZONE):
                 aware = aware.replace(tzinfo=tz.UTC)
-
-        elif res.tzoffset == 0:
-            aware = naive.replace(tzinfo=tz.UTC)
 
         elif res.tzoffset:
             aware = naive.replace(tzinfo=tz.tzoffset(res.tzname, res.tzoffset))

--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -914,6 +914,25 @@ class TestTZVar(object):
             assert dt.astimezone(tz.UTC) == dt_exp.astimezone(tz.UTC)
 
 
+@pytest.mark.skipif(IS_WIN, reason="Windows does not use TZ var")
+@pytest.mark.parametrize("dtstr", [
+    "2015-08-20T00:20:45.000000+00:00",
+    "2015-08-20T00:20:45Z",
+])
+def test_use_utc_over_tzlocal(dtstr):
+    """
+    Parser should use tzutc() instead of tzlocal() in cases where both are accurate.
+
+    see: https://github.com/dateutil/dateutil/issues/349
+         https://github.com/dateutil/dateutil/issues/842
+    """
+    with TZEnvContext("UTC"):
+        dt_exp = datetime(2015, 8, 20, 0, 20, 45, tzinfo=tz.tzutc())
+        dt_act = parse(dtstr)
+        assert dt_act == dt_exp
+        assert dt_act.tzinfo is dt_exp.tzinfo
+
+
 def test_parse_tzinfos_fold():
     NYC = tz.gettz('America/New_York')
     tzinfos = {'EST': NYC, 'EDT': NYC}


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

I changed the order of if-statements as suggested by @jbrockmendel in #842 to return tzutc() over tzlocal().

Closes #349
Closes #842

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
