### PR TITLE
Fix country typo in exercises

### DIFF
--- a/docs/exercises/index.rst
+++ b/docs/exercises/index.rst
@@ -194,7 +194,7 @@ To solve this exercise, copy-paste this script into a document, change anything 
 
 Problem 2
 *********
-    Given the context that you will *only* be passed dates from India or Ireland, write a function that correctly parses all *unambiguous* time zone strings to aware datetimes localized to the correct IANA zone, and for *ambiguous* time zone strings default to India.
+    Given the context that you will *only* be passed dates from India or Israel, write a function that correctly parses all *unambiguous* time zone strings to aware datetimes localized to the correct IANA zone, and for *ambiguous* time zone strings default to India.
 
 **Test Script**
 
@@ -211,7 +211,7 @@ To solve this exercise, copy-paste this script into a document, change anything 
     from dateutil.parser import parse
     from dateutil import tz
 
-    def parse_func_ind_ire():
+    def parse_func_ind_isr():
         <<YOUR CODE HERE>>
 
     # ---------------------------------- #
@@ -228,7 +228,7 @@ To solve this exercise, copy-paste this script into a document, change anything 
 
     def test_parse_ixt():
         for dtstr, dt_exp in PARSE_IXT_TEST_CASE:
-            dt_act = parse_func_ind_ire(dtstr)
+            dt_act = parse_func_ind_isr(dtstr)
             assert dt_act == dt_exp, (dt_act, dt_exp)
             assert dt_act.tzinfo is dt_exp.tzinfo, (dt_act, dt_exp)
 


### PR DESCRIPTION
It says Ireland, but the rest of the code says Israel. Fixed accordingly.