### PR TITLE
Do not require setuptools.command.test as it may not be available

### DIFF
--- a/changelog.d/1043.bugfix.rst
+++ b/changelog.d/1043.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed not requiring `setuptools.command.test` in setup.py and use the `setuptools.Command` class instead,
+as the former one may not be available. (gh issue #1043, gh pr #1044). Reported and fixed by @eldruin

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 import setuptools
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
+from setuptools import Command
 
 from distutils.version import LooseVersion
 import warnings
@@ -20,7 +20,13 @@ if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
                   UserWarning)
 
 
-class Unsupported(TestCommand):
+class Unsupported(Command):
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
     def run(self):
         sys.stderr.write("Running 'test' with setup.py is not supported. "
                          "Use 'pytest' or 'tox' to run the tests.\n")


### PR DESCRIPTION
## Summary of changes

Use `setuptools.Command` class instead of `setuptools.command.test` since this may not be available in certain cases.

Closes #1043 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
