### PR TITLE
Call .decode() only for binary data

### DIFF
--- a/changelog.d/1060.misc.rst
+++ b/changelog.d/1060.misc.rst
@@ -1,0 +1,1 @@
+Simplify handling of bytes and bytearray in _parser._timelex. Reported and fixed by @frenzymadness (gh issue #1060).

--- a/dateutil/parser/_parser.py
+++ b/dateutil/parser/_parser.py
@@ -60,14 +60,8 @@ class _timelex(object):
     _split_decimal = re.compile("([.,])")
 
     def __init__(self, instream):
-        if six.PY2:
-            # In Python 2, we can't duck type properly because unicode has
-            # a 'decode' function, and we'd be double-decoding
-            if isinstance(instream, (bytes, bytearray)):
-                instream = instream.decode()
-        else:
-            if getattr(instream, 'decode', None) is not None:
-                instream = instream.decode()
+        if isinstance(instream, (bytes, bytearray)):
+            instream = instream.decode()
 
         if isinstance(instream, text_type):
             instream = StringIO(instream)


### PR DESCRIPTION
## Summary of changes

I believe that the `__init__` method might be simplified in this way. In my opinion, it makes sense to call `decode()` method only on bytes/bytearray objects in both major Pythons.

In Python 2, `bytes` is builtin alias for `str` so `decode()` call does not happen for unicode.

Do you know about any corner case this simplified code is not aware of?

### Pull Request Checklist
- [ ] Changes have tests — this class is hopefully tested well enough
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md) — not necessary, nothing really important contributed
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details — not important user-facing change
