### PR TITLE
Throw meaningful error when unsupported format for rrule

### DIFF
--- a/dateutil/rrule.py
+++ b/dateutil/rrule.py
@@ -1697,7 +1697,7 @@ class _rrulestr(object):
                                          value)
                     dtstart = dtvals[0]
                 else:
-                    raise ValueError("unsupported property: "+name)
+                    raise ValueError("unsupported rule: "+s)
             if (forceset or len(rrulevals) > 1 or rdatevals
                     or exrulevals or exdatevals):
                 if not parser and (rdatevals or exdatevals):

--- a/dateutil/test/test_rrule.py
+++ b/dateutil/test/test_rrule.py
@@ -4912,3 +4912,8 @@ class WeekdayTest(unittest.TestCase):
 
         for repstr, wday in zip(with_n_reprs, with_n_wdays):
             self.assertEqual(repr(wday), repstr)
+
+    def testUnsupportedRuleErrorWhenNoMatchFound(self):
+        rule = "FREQ=YEARLY;WKST=MO;UNTIL=2019-03-29T00:59:59+01:00"
+        with self.assertRaises(ValueError, msg="unsupported rule: " + rule):
+            rrulestr(rule, dtstart=datetime(1997, 9, 2, 9, 0))


### PR DESCRIPTION

## Summary of changes

Throw meaningful error when rrule is in unsupported format.

Closes #960

### Pull Request Checklist
- [x] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
