### PR TITLE
Use "fat" zic binaries in CI tests

### DIFF
--- a/changelog.d/1076.misc.rst
+++ b/changelog.d/1076.misc.rst
@@ -1,0 +1,1 @@
+Changed the tests against the upstream tz database to always generate fat binaries, since until GH-590 and GH-1059 are resolved, "slim" zic binaries will cause problems in many zones, causing the tests to fail. This also updates ``zoneinfo.rebuild`` to always generate fat binaries. GH PR #1076.

--- a/ci_tools/run_tz_master_env.sh
+++ b/ci_tools/run_tz_master_env.sh
@@ -69,7 +69,7 @@ set -e
 mv $TARBALL_NAME $ORIG_DIR
 
 # Install everything else
-make TOPDIR=$TMP_DIR/tzdir install
+make ZFLAGS='-b fat' TOPDIR="$TMP_DIR/tzdir" install
 
 #
 # Make the zoneinfo tarball

--- a/dateutil/zoneinfo/rebuild.py
+++ b/dateutil/zoneinfo/rebuild.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import shutil
 import json
-from subprocess import check_call
+from subprocess import check_call, check_output
 from tarfile import TarFile
 
 from dateutil.zoneinfo import METADATA_FN, ZONEFILENAME
@@ -23,11 +23,9 @@ def rebuild(filename, tag=None, format="gz", zonegroups=[], metadata=None):
             for name in zonegroups:
                 tf.extract(name, tmpdir)
             filepaths = [os.path.join(tmpdir, n) for n in zonegroups]
-            try:
-                check_call(["zic", "-d", zonedir] + filepaths)
-            except OSError as e:
-                _print_on_nosuchfile(e)
-                raise
+
+            _run_zic(zonedir, filepaths)
+
         # write metadata file
         with open(os.path.join(zonedir, METADATA_FN), 'w') as f:
             json.dump(metadata, f, indent=4, sort_keys=True)
@@ -38,6 +36,30 @@ def rebuild(filename, tag=None, format="gz", zonegroups=[], metadata=None):
                 tf.add(entrypath, entry)
     finally:
         shutil.rmtree(tmpdir)
+
+
+def _run_zic(zonedir, filepaths):
+    """Calls the ``zic`` compiler in a compatible way to get a "fat" binary.
+
+    Recent versions of ``zic`` default to ``-b slim``, while older versions
+    don't even have the ``-b`` option (but default to "fat" binaries). The
+    current version of dateutil does not support Version 2+ TZif files, which
+    causes problems when used in conjunction with "slim" binaries, so this
+    function is used to ensure that we always get a "fat" binary.
+    """
+
+    try:
+        help_text = check_output(["zic", "--help"])
+    except OSError as e:
+        _print_on_nosuchfile(e)
+        raise
+
+    if b"-b " in help_text:
+        bloat_args = ["-b", "fat"]
+    else:
+        bloat_args = []
+
+    check_call(["zic"] + bloat_args + ["-d", zonedir] + filepaths)
 
 
 def _print_on_nosuchfile(e):


### PR DESCRIPTION
## Summary of changes

The CI failures are basically manifestations of #1059 (which can be resolved along with #590 when we backport the logic from `zoneinfo`).

I don't want this to continue blocking things and it's a known issue, so I've changed the test to always use the "fat" binaries until #590 is resolved.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
