### PR TITLE
Fix documentation warning about relative links

### DIFF
--- a/changelog.d/1078.misc.rst
+++ b/changelog.d/1078.misc.rst
@@ -1,0 +1,1 @@
+Changed some relative links in the exercise documentation to refer to the document locations in the input tree, rather than the generated HTML files in the HTML output tree (which presumably will not exist in non-HTML output formats). GH PR #1078.

--- a/docs/exercises/index.rst
+++ b/docs/exercises/index.rst
@@ -19,7 +19,7 @@ Martin Luther King Day
 
     `Martin Luther King, Jr Day <https://en.wikipedia.org/wiki/Martin_Luther_King_Jr._Day>`_ is a US holiday that occurs every year on the third Monday in January?
 
-    How would you generate a `recurrence rule <../rrule.html>`_ that generates Martin Luther King Day, starting from its first observance in 1986?
+    How would you generate a :doc:`recurrence rule <../rrule>` that generates Martin Luther King Day, starting from its first observance in 1986?
 
 
 **Test Script**
@@ -74,7 +74,7 @@ A solution to this problem is provided :doc:`here <solutions/mlk-day-rrule>`.
 Next Monday meeting
 -------------------
 
-    A team has a meeting at 10 AM every Monday and wants a function that tells them, given a ``datetime.datetime`` object, what is the date and time of the *next* Monday meeting? This is probably best accomplished using a `relativedelta <../relativedelta.html>`_.
+    A team has a meeting at 10 AM every Monday and wants a function that tells them, given a ``datetime.datetime`` object, what is the date and time of the *next* Monday meeting? This is probably best accomplished using a :doc:`relativedelta <../relativedelta>`.
 
 **Test Script**
 
@@ -125,7 +125,7 @@ To solve this exercise, copy-paste this script into a document, change anything 
 Parsing a local tzname
 ----------------------
 
-    Three-character time zone abbreviations are *not* unique in that they do not explicitly map to a time zone. A list of time zone abbreviations in use can be found `here <https://www.timeanddate.com/time/zones/>`_. This means that parsing a datetime string such as ``'2018-01-01 12:30:30 CST'`` is ambiguous without context. Using `dateutil.parser <../parser.html>`_ and `dateutil.tz <../tz.html>`_, it is possible to provide a context such that these local names are converted to proper time zones.
+    Three-character time zone abbreviations are *not* unique in that they do not explicitly map to a time zone. A list of time zone abbreviations in use can be found `here <https://www.timeanddate.com/time/zones/>`_. This means that parsing a datetime string such as ``'2018-01-01 12:30:30 CST'`` is ambiguous without context. Using :mod:`dateutil.parser` and :mod:`dateutil.tz`, it is possible to provide a context such that these local names are converted to proper time zones.
 
 Problem 1
 *********


### PR DESCRIPTION
## Summary of changes

It seems that relative links to the generated `.html` files doesn't work anymore, so I've replaced them with either `doc` or `mod` references. This should fix that aspect of the CI.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
