### PR TITLE
Add support for python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9-dev"
   - "nightly"
 env: TOXENV=py
 

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -79,6 +79,7 @@ switch, and thus all their contributions are dual-licensed.
 - Maxime Lorant <maxime.lorant@MASKED>
 - Michael Aquilina <michaelaquilina@MASKED> (gh: @MichaelAquilina)
 - Michael J. Schultz <mjschultz@MASKED>
+- Michael Käufl (gh: @michael-k)
 - Mike Gilbert <floppym@MASKED>
 - Nicholas Herrriot <Nicholas.Herriot@gmail.com> **D**
 - Nicolas Évrard (gh: @nicoe) **D**

--- a/changelog.d/1083.misc.rst
+++ b/changelog.d/1083.misc.rst
@@ -1,0 +1,1 @@
+Added Python 3.9 to the test matrix and trove classifiers.  Fixed by @michael-k (gh pr #1083)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Software Development :: Libraries
 
 [options]


### PR DESCRIPTION
## Summary of changes

Run the tests against Python 3.9 on Travis CI and add the trove classifier for Python 3.9.

3.9.0 final is expected on Monday, 2020-10-05, see https://www.python.org/dev/peps/pep-0596/#schedule

#### Appveyor

Looks like it's also possible to run the tests against Python 3.9 on appveyor, see https://github.com/appveyor/ci/issues/3467#issuecomment-643534726.  I have no experience with appveyor and maybe it's good enough to wait until appveyor supports Python 3.9 without the workaround via a script?  Please let me know if I should add this.

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
