### PR TITLE
Add two tests for relativedelta(day=31) for February

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -96,6 +96,7 @@ switch, and thus all their contributions are dual-licensed.
 - Quentin Pradet <quentin@MASKED>
 - Raymond Cha (gh: @weatherpattern) **D**
 - Ridhi Mahajan <ridhikmahajan@MASKED> **D**
+- Robin Henriksson Törnström <gh: @MrRawbin> **D**
 - Roy Williams <rwilliams@MASKED>
 - Rustem Saiargaliev (gh: @amureki) **D**
 - Satyabrat Bhol <satyabrat35@MASKED> (gh: @Satyabrat35) **D**

--- a/changelog.d/1104.misc.rst
+++ b/changelog.d/1104.misc.rst
@@ -1,0 +1,3 @@
+Added two explicit tests for ``relativedelta(day=31)`` to test that it really returns the last
+day of the month for February, which doesn't have 31 days, including leap years.
+Reported by @MrRawbin (gh issue #1104). Fixed by @MrRawbin (gh pr #1105)

--- a/dateutil/test/test_relativedelta.py
+++ b/dateutil/test/test_relativedelta.py
@@ -119,6 +119,14 @@ class RelativeDeltaTest(unittest.TestCase):
         self.assertEqual(self.today+relativedelta(day=31, weekday=FR(-1)),
                          date(2003, 9, 26))
 
+    def testLastDayOfFebruary(self):
+        self.assertEqual(date(2021, 2, 1) + relativedelta(day=31),
+                         date(2021, 2, 28))
+
+    def testLastDayOfFebruaryLeapYear(self):
+        self.assertEqual(date(2020, 2, 1) + relativedelta(day=31),
+                         date(2020, 2, 29))
+
     def testNextWednesdayIsToday(self):
         self.assertEqual(self.today+relativedelta(weekday=WE),
                          date(2003, 9, 17))

--- a/dateutil/test/test_relativedelta.py
+++ b/dateutil/test/test_relativedelta.py
@@ -123,7 +123,7 @@ class RelativeDeltaTest(unittest.TestCase):
         self.assertEqual(self.today+relativedelta(weekday=WE),
                          date(2003, 9, 17))
 
-    def testNextWenesdayNotToday(self):
+    def testNextWednesdayNotToday(self):
         self.assertEqual(self.today+relativedelta(days=+1, weekday=WE),
                          date(2003, 9, 24))
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Added two tests to relativedelta to explicitly assert that `relativedelta(day=31)`  returns that last day of the month for February, both for leap years and non-leap years.

Closes [1104](https://github.com/dateutil/dateutil/issues/1104)<!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
