### PR TITLE
Particularize licensing types

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,6 +25,7 @@ switch, and thus all their contributions are dual-licensed.
 - Andrew Bennett (gh: @andrewcbennett) **D**
 - Andrew Murray <radarhere@MASKED>
 - Aritro Nandi <gurgenz221@gmail.com> (gh: @gurgenz221) **D**
+- Bartłomiej Kurzeja (gh: @b3ql)
 - Bernat Gabor <bgabor8@bloomberg.net> (gh: @gaborbernat) **D**
 - Bradlee Speice <bradlee@speice.io> (gh: @bspeice) **D**
 - Brandon W Maister <quodlibetor@MASKED>

--- a/changelog.d/1107.misc.rst
+++ b/changelog.d/1107.misc.rst
@@ -1,0 +1,1 @@
+Particularize package licensing types. Fixed by @b3ql (gh pr #1107)

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ maintainer = Paul Ganssle
 maintainer_email = dateutil@python.org
 url = https://dateutil.readthedocs.io
 long_description_content_type = text/x-rst
-license = Dual License
+license = BSD 3-Clause or Apache 2.0
 license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes
Particularize package licensing types in order to remove `Dual licensing` ambiguity.

### Pull Request Checklist
- [x] ~Changes have tests~ - not required
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
