### PR TITLE
isoparse: Fail with inconsistent time separators

### DIFF
--- a/changelog.d/1125.bugfix.rst
+++ b/changelog.d/1125.bugfix.rst
@@ -1,0 +1,1 @@
+Make `isoparse` raise when trying to parse times with inconsistent use of `:` separator. Reported and fixed by @mariocj89 (gh pr #1125).

--- a/dateutil/parser/isoparser.py
+++ b/dateutil/parser/isoparser.py
@@ -336,7 +336,7 @@ class isoparser(object):
         if len(timestr) < 2:
             raise ValueError('ISO time too short')
 
-        has_sep = len_str >= 3 and timestr[2:3] == self._TIME_SEP
+        has_sep = False
 
         while pos < len_str and comp < 5:
             comp += 1
@@ -347,13 +347,18 @@ class isoparser(object):
                 pos = len_str
                 break
 
+            if comp == 1 and timestr[pos:pos+1] == self._TIME_SEP:
+                has_sep = True
+                pos += 1
+            elif comp == 2 and has_sep:
+                if timestr[pos:pos+1] != self._TIME_SEP:
+                    raise ValueError('Inconsistent use of colon separator')
+                pos += 1
+
             if comp < 3:
                 # Hour, minute, second
                 components[comp] = int(timestr[pos:pos + 2])
                 pos += 2
-                if (has_sep and pos < len_str and
-                        timestr[pos:pos + 1] == self._TIME_SEP):
-                    pos += 1
 
             if comp == 3:
                 # Fraction of a second

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -388,6 +388,7 @@ def test_parse_isodate(d, dt_fmt, as_bytes):
     ('2013-02-29', ValueError),                 # Not a leap year
     ('2014/12/03', ValueError),                 # Wrong separators
     ('2014-04-19T', ValueError),                # Unknown components
+    ('201202', ValueError),                     # Invalid format
 ])
 def test_isodate_raises(isostr, exception):
     with pytest.raises(exception):
@@ -491,16 +492,6 @@ def test_isotime_midnight(isostr):
     ('24:00:00.000001', ValueError),            # 24 used for non-midnight time
 ])
 def test_isotime_raises(isostr, exception):
-    iparser = isoparser()
-    with pytest.raises(exception):
-        iparser.parse_isotime(isostr)
-
-
-@pytest.mark.xfail() 
-@pytest.mark.parametrize('isostr,exception', [  # pragma: nocover
-    ('201202', ValueError)                      # Invalid ISO format
-])
-def test_isotime_raises_xfail(isostr, exception):
     iparser = isoparser()
     with pytest.raises(exception):
         iparser.parse_isotime(isostr)

--- a/dateutil/test/test_isoparser.py
+++ b/dateutil/test/test_isoparser.py
@@ -244,6 +244,8 @@ def test_bytes(isostr, dt):
     ('2012-0425', ValueError),                  # Inconsistent date separators
     ('201204-25', ValueError),                  # Inconsistent date separators
     ('20120425T0120:00', ValueError),           # Inconsistent time separators
+    ('20120425T01:2000', ValueError),           # Inconsistent time separators
+    ('14:3015', ValueError),                    # Inconsistent time separator
     ('20120425T012500-334', ValueError),        # Wrong microsecond separator
     ('2001-1', ValueError),                     # YYYY-M not valid
     ('2012-04-9', ValueError),                  # YYYY-MM-D not valid
@@ -284,17 +286,6 @@ def test_iso_with_sep_raises(sep_act, valid_sep, exception):
     isostr = '2012-04-25' + sep_act + '01:25:00'
     with pytest.raises(exception):
         parser.isoparse(isostr)
-
-
-@pytest.mark.xfail() 
-@pytest.mark.parametrize('isostr,exception', [  # pragma: nocover
-    ('20120425T01:2000', ValueError),           # Inconsistent time separators
-])
-def test_iso_raises_failing(isostr, exception):
-    # These are test cases where the current implementation is too lenient
-    # and need to be fixed
-    with pytest.raises(exception):
-        isoparse(isostr)
 
 
 ###
@@ -507,7 +498,6 @@ def test_isotime_raises(isostr, exception):
 
 @pytest.mark.xfail() 
 @pytest.mark.parametrize('isostr,exception', [  # pragma: nocover
-    ('14:3015', ValueError),                    # Inconsistent separator use
     ('201202', ValueError)                      # Invalid ISO format
 ])
 def test_isotime_raises_xfail(isostr, exception):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Fail when separators are used inconsistently to split the time porting
of a string. Even if more restrictive, we have warned that we were going
to fail on invalid cases of ISO formatted strings. This will prevent
invalid iso formatted strings from being unexpectedly parsed.

This Pr also fixes an xfail that was xfailing due to a typo. IIUC, 201202 is a valid ISO time but not a valid iso date, which is what was intended to be tested.

Closes None

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
