### PR TITLE
tests: Fix logic on detecting platform support for `-d`

### DIFF
--- a/dateutil/test/test_parser.py
+++ b/dateutil/test/test_parser.py
@@ -22,11 +22,12 @@ import pytest
 # Platform info
 IS_WIN = sys.platform.startswith('win')
 
+PLATFORM_HAS_DASH_D = False
 try:
-    datetime.now().strftime('%-d')
-    PLATFORM_HAS_DASH_D = True
+    if datetime.now().strftime('%-d'):
+        PLATFORM_HAS_DASH_D = True
 except ValueError:
-    PLATFORM_HAS_DASH_D = False
+    pass
 
 
 @pytest.fixture(params=[True, False])


### PR DESCRIPTION
Tests are failing in CI on pypi for windows. The function is returning
an empty string rather than raising. This commit adapts the logic to
skip those cases.

A bug should be reported upstream for pypy for consistency with cpyhton. I think returning an empty string is not expected. I do not have a windows setup to reproduce it though.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
