### PR TITLE
ci: Remove the need of upgrading pip/setuptools

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,8 +32,6 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Update pip and setuptools
-        run: python -m pip install -U pip setuptools
       - name: Install dependencies
         run: python -m pip install -U tox
       - name: Install zic (Windows)

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,12 @@ envlist = py27,
           docs
 minversion = 2.9.0
 skip_missing_interpreters = true
+isolated_build = true
+
+[testenv:.package]
+# no additional dependencies besides PEP 517 for building the package
+# Needed as we are running with an old version of tox.
+deps =
 
 [testenv]
 description = run the unit tests with pytest under {basepython}


### PR DESCRIPTION
We were running tox without enabling isolated environment, this was
therefore resulting in tox not using `pyproject.toml`.

The commit enables isolated environment, and to make it work it also
needs to mark that the building of the tox `.package` env does not have
any dependency. This is needed as otherwise tox will attempt to install
the dependencies in `deps` when building the package as those will be
passed to PEP517, which does not support requirements files.


There you go :). @pganssle do you want me to add a news entry type misc for this kind of changes?