### PR TITLE
ci: Move docs, build and tz tox env validation to github actions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,3 +59,58 @@ jobs:
           file: ./.tox/coverage.xml
           name: ${{ matrix.os }}:${{ matrix.python-version }}
           fail_ci_if_error: true
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install tox
+        run: python -m pip install -U tox
+      - name: Run tox
+        run: python -m tox -e docs
+
+  latest-tz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6
+      - name: Install tox
+        run: python -m pip install -U "tox<3.8.0"
+      - name: Run updatezinfo.py
+        run: ./ci_tools/retry.sh python updatezinfo.py
+      - name: Run tox
+        run: python -m tox -e tz
+
+  build-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+      - name: Install tox
+        run: python -m pip install -U tox
+      - name: Run tox
+        run: python -m tox -e build
+      - name: Check generation
+        run: |
+          exactly_one() {
+            value=$(find dist -iname $1 | wc -l)
+            if [ $value -ne 1 ]; then
+              echo "Found $value instances of $1, not 1"
+              return 1
+            else
+              echo "Found exactly 1 instance of $value"
+            fi
+          }
+          # Check that exactly one tarball and one wheel are created
+          exactly_one '*.tar.gz'
+          exactly_one '*.whl'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ matrix:
       # This is required to run Python 3.3 on Travis
       dist: trusty
       env: TOXENV=py33 # Needed because "py" won't invoke testenv:py33
-    - python: 3.6
-      env: TOXENV=docs
-    - python: 3.6
-      env: TOXENV=tz
-    - python: 3.7
-      env: TOXENV=build
   allow_failures:
     - python: "nightly"
 
@@ -36,22 +30,6 @@ install:
 
 script:
   - tox
-  - |
-    if [[ $TOXENV == "build" ]]; then
-      exactly_one() {
-        value=$(find dist -iname $1 | wc -l)
-        if [ $value -ne 1 ]; then
-          echo "Found $value instances of $1, not 1"
-          return 1
-        else
-          echo "Found exactly 1 instance of $value"
-        fi
-      }
-
-      # Check that exactly one tarball and one wheel are created
-      exactly_one '*.tar.gz'
-      exactly_one '*.whl'
-    fi
 
 after_success:
   - if [[ $TOXENV == "py" ]]; then tox -e coverage,codecov; fi


### PR DESCRIPTION
Actions are split across multiple jobs to simplify setup and better
represent their intent.