### PR TITLE
release: Move to `python-build`

### DIFF
--- a/changelog.d/1133.misc.rst
+++ b/changelog.d/1133.misc.rst
@@ -1,0 +1,1 @@
+Move sdist and wheel generation to use `python-build`. Reported and fixed by @mariocj89 (gh pr #1133).

--- a/release.py
+++ b/release.py
@@ -25,8 +25,10 @@ def build():
             click.echo('Aborting')
             sys.exit(1)
 
-    subprocess.check_call(['python', '-m', 'pep517.build',
-                           '--binary', '--source', '.'])
+    subprocess.check_call(['python', '-m', 'build',
+                           '--wheel', '--sdist',
+                           '--outdir', DIST_PATH,
+                           '.'])
 
 @cli.command()
 def sign():

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,5 @@ freezegun ; python_version != '3.3'
 hypothesis >= 3.30
 coverage
 mock ; python_version < '3.0'
-pep517 >= 0.5.0
+build >= 0.3.0 ; python_version >= '3.6'
 attrs!=21.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ basepython = python3.7
 skip_install = true
 passenv = *
 deps = click >= 7.0
-      pep517 >= 0.5.0
+      build[virtualenv] >= 0.3.0
 commands =
     python release.py build
 


### PR DESCRIPTION
PEP517 is deprecated, move to `python-build`. This will additionally
validate the build dependencies, enhancing the CI.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
