### PR TITLE
ci: Pin virtualenv when running 3.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ install:
   - "ci_tools/retry.bat %PYTHON% updatezinfo.py"
   # This environment variable tells the test suite it's OK to mess with the time zone.
   - set DATEUTIL_MAY_CHANGE_TZ=1
-  - C:\Python36\python -m pip install -U tox
+  - C:\Python36\python -m pip install -U tox virtualenv==20.4.7
 
 test_script:
   - C:\Python36\scripts\tox


### PR DESCRIPTION
The latest release of virtualenv broke the CI, given that we are
offering limiting support for 3.4 and we plan to drop it in after the
next release, pin the version in CI.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
