### PR TITLE
Change single quote to double in dateutil version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Bug reports are an important type of contribution - it's important to get feedba
 1. A minimal, reproducible example - a small, self-contained script that can reproduce the behavior is the best way to get your bug fixed. For more information and tips on how to structure these, read [Stack Overflow's guide to creating a minimal, complete, verified example](https://stackoverflow.com/help/mcve).
 
 2. The platform and versions of everything involved, at a minimum please include operating system, `python` version and `dateutil` version. Instructions on getting your versions:
-    - `dateutil`: `python -c 'import dateutil; print(dateutil.__version__)'`
+    - `dateutil`: `python -c "import dateutil; print(dateutil.__version__)"`
     - `Python`: `python --version`
 
 3. A description of the problem - what *is* happening and what *should* happen.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Changed single quotes around `import dateutil; print(dateutil.__version__)` to double quotes, because single quotes do not work in command prompt whereas double quotes do.

Though single and double quote works find in PowerShell and GitBash, single quote in Command Prompt return "SytaxError: EOL while scanning string literal"


### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details


I did not take above actions in the checklist because they didn't seem relevant for a minor change to the `contribution.md` file.