### PR TITLE
Bugfix: Plus/Minus logic failed in the month way when the last day of the month was involved.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ switch, and thus all their contributions are dual-licensed.
 - Adrien Cossa <cossa@MASKED>
 - Alec Nikolas Reiter <alecreiter@MASKED>
 - Alec Reiter <areiter@MASKED>
+- Aleksei Strizhak <alexei.mifrill.strizhak@MASKED> (gh: @Mifrill)
 - Alex Chamberlain (gh: @alexchamberlain) **D**
 - Alex Verdyan <verdyan@MASKED>
 - Alex Willmer <alex@moreati.org.uk> (gh: @moreati) **R**

--- a/changelog.d/1167.bugfix.rst
+++ b/changelog.d/1167.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed issue where relativedelta would erroneously returns wrong last day of the month
+if passed argument is a last day of the month. Reported by @hawkEye-01 (gh issue #1167).
+Fixed by @Mifrill (gh pr #1168)

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -48,7 +48,7 @@ class relativedelta(object):
             the corresponding arithmetic operation on the original datetime value
             with the information in the relativedelta.
 
-        weekday: 
+        weekday:
             One of the weekday instances (MO, TU, etc) available in the
             relativedelta module. These instances may receive a parameter N,
             specifying the Nth weekday, which could be positive or negative
@@ -374,8 +374,12 @@ class relativedelta(object):
             elif month < 1:
                 year -= 1
                 month += 12
-        day = min(calendar.monthrange(year, month)[1],
-                  self.day or other.day)
+        monthlastday = calendar.monthrange(year, month)[1]
+        if other.month and other.day == calendar.monthrange(year, other.month)[1]:
+            day = monthlastday
+        else:
+            day = min(monthlastday, self.day or other.day)
+
         repl = {"year": year, "month": month, "day": day}
         for attr in ["hour", "minute", "second", "microsecond"]:
             value = getattr(self, attr)

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -650,6 +650,11 @@ class RelativeDeltaTest(unittest.TestCase):
         except:
             self.fail("relativedelta() failed to hash!")
 
+    def testLastDayOfMonthPlus(self):
+        self.assertEqual(date(2021, 2, 28) + relativedelta(months=1), date(2021, 3, 31))
+        self.assertEqual(date(2021, 4, 30) + relativedelta(months=1), date(2021, 5, 31))
+        self.assertEqual(date(2021, 5, 31) + relativedelta(months=1), date(2021, 6, 30))
+
 
 class RelativeDeltaWeeksPropertyGetterTest(unittest.TestCase):
     """Test the weeks property getter"""

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -651,11 +651,13 @@ class RelativeDeltaTest(unittest.TestCase):
             self.fail("relativedelta() failed to hash!")
 
     def testLastDayOfMonthPlus(self):
+        self.assertEqual(date(2021, 1, 31) + relativedelta(months=1), date(2021, 2, 28))
         self.assertEqual(date(2021, 2, 28) + relativedelta(months=1), date(2021, 3, 31))
         self.assertEqual(date(2021, 4, 30) + relativedelta(months=1), date(2021, 5, 31))
         self.assertEqual(date(2021, 5, 31) + relativedelta(months=1), date(2021, 6, 30))
 
     def testLastDayOfMonthMinus(self):
+        self.assertEqual(date(2021, 2, 28) - relativedelta(months=1), date(2021, 1, 31))
         self.assertEqual(date(2021, 3, 31) - relativedelta(months=1), date(2021, 2, 28))
         self.assertEqual(date(2021, 5, 31) - relativedelta(months=1), date(2021, 4, 30))
         self.assertEqual(date(2021, 6, 30) - relativedelta(months=1), date(2021, 5, 31))

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -650,11 +650,28 @@ class RelativeDeltaTest(unittest.TestCase):
         except:
             self.fail("relativedelta() failed to hash!")
 
+    def testDayOfMonthPlus(self):
+        self.assertEqual(date(2021, 1, 28) + relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 2, 27) + relativedelta(months=1), date(2021, 3, 27))
+        self.assertEqual(date(2021, 4, 29) + relativedelta(months=1), date(2021, 5, 29))
+        self.assertEqual(date(2021, 5, 30) + relativedelta(months=1), date(2021, 6, 30))
+
     def testLastDayOfMonthPlus(self):
         self.assertEqual(date(2021, 1, 31) + relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 1, 30) + relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 1, 29) + relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 1, 28) + relativedelta(months=1), date(2021, 2, 28))
         self.assertEqual(date(2021, 2, 28) + relativedelta(months=1), date(2021, 3, 31))
         self.assertEqual(date(2021, 4, 30) + relativedelta(months=1), date(2021, 5, 31))
         self.assertEqual(date(2021, 5, 31) + relativedelta(months=1), date(2021, 6, 30))
+
+    def testDayOfMonthMinus(self):
+        self.assertEqual(date(2021, 2, 27) - relativedelta(months=1), date(2021, 1, 27))
+        self.assertEqual(date(2021, 3, 30) - relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 3, 29) - relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 3, 28) - relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 5, 30) - relativedelta(months=1), date(2021, 4, 30))
+        self.assertEqual(date(2021, 6, 29) - relativedelta(months=1), date(2021, 5, 29))
 
     def testLastDayOfMonthMinus(self):
         self.assertEqual(date(2021, 2, 28) - relativedelta(months=1), date(2021, 1, 31))

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -655,6 +655,11 @@ class RelativeDeltaTest(unittest.TestCase):
         self.assertEqual(date(2021, 4, 30) + relativedelta(months=1), date(2021, 5, 31))
         self.assertEqual(date(2021, 5, 31) + relativedelta(months=1), date(2021, 6, 30))
 
+    def testLastDayOfMonthMinus(self):
+        self.assertEqual(date(2021, 3, 31) - relativedelta(months=1), date(2021, 2, 28))
+        self.assertEqual(date(2021, 5, 31) - relativedelta(months=1), date(2021, 4, 30))
+        self.assertEqual(date(2021, 6, 30) - relativedelta(months=1), date(2021, 5, 31))
+
 
 class RelativeDeltaWeeksPropertyGetterTest(unittest.TestCase):
     """Test the weeks property getter"""


### PR DESCRIPTION
## Summary of changes

Fixed issue where compare with `relativedelta` would erroneously return the wrong last day of the month if the passed argument is the last day of the month.

Closes #1167

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
