### PR TITLE
Implement ChainParser

### DIFF
--- a/changelog.d/1153.feature.rst
+++ b/changelog.d/1153.feature.rst
@@ -1,0 +1,2 @@
+Add new ChainParser class to facilitate chaining multiple parsers and formats.
+Reported and fixed by @mariocj89 (gh issue #1153).

--- a/docs/parser.rst
+++ b/docs/parser.rst
@@ -11,6 +11,8 @@ Functions
 
 .. automethod:: dateutil.parser.isoparse
 
+.. automethod:: dateutil.parser.ChainParser
+
 
 Classes
 -------
@@ -26,4 +28,3 @@ Warnings and Exceptions
 .. autoclass:: dateutil.parser.ParserError
 
 .. autoclass:: dateutil.parser.UnknownTimezoneWarning
-

--- a/src/dateutil/parser/__init__.py
+++ b/src/dateutil/parser/__init__.py
@@ -7,8 +7,11 @@ from ._parser import __doc__
 
 from .isoparser import isoparser, isoparse
 
+from .chain_parser import ChainParser
+
 __all__ = ['parse', 'parser', 'parserinfo',
            'isoparse', 'isoparser',
+           'ChainParser',
            'ParserError',
            'UnknownTimezoneWarning']
 

--- a/src/dateutil/parser/chain_parser.py
+++ b/src/dateutil/parser/chain_parser.py
@@ -1,0 +1,70 @@
+import datetime as dt
+
+
+class _FixedStrptime(object):
+    """Parses datetime from strings by using a format that will be fed to strptime"""
+    def __init__(self, format_):
+        self._format = format_
+
+    def __call__(self, dt_str):
+        return dt.datetime.strptime(dt_str, self._format)
+
+    def __repr__(self):
+        return "StrptimeParser(%r)" % (self._format)
+
+
+class ChainParser(object):
+    """Parser that is built from combining multiple parsers
+
+    All provided parsers should have a call method that takes a string as input
+    and raise `ValueError` if they cannot parse the datetime.
+
+    If the parser provided is a string, a parser will be constructed which
+    uses :func:`datetime.datetime.strptime` with the provided format.
+
+    This is useful for situations where you know that your dates are in one of a
+    small number of formats, or where you want to specifically prioritize some
+    formats over others. For example, if you want to interpret a 6-digit number as
+    ``YYMMDD``, then ``DDMMYY``, then fall back to `dateutil.parser.parse` for any
+    strings that don't match either of those, you could construct the following
+    ``ChainParser``:
+
+    .. doctest:: chainparser
+
+        >>> parser = ChainParser("%y%m%d",  "%d%m%y", dateutil.parser.parse)
+        >>> print(parser("120101"))
+        2012-01-01 00:00:00
+        >>> print(parser("010199"))
+        1999-01-01 00:00:00
+
+
+    """
+    def __init__(self, *parsers):
+        self._parsers = [
+            _FixedStrptime(parser) if isinstance(parser, str) else parser
+            for parser in parsers
+        ]
+        for parser in self._parsers:
+            if not callable(parser):
+                raise ValueError(
+                    "Invalid parser {0!r}, the parser is not callable."
+                    .format(parser)
+                )
+
+    def __call__(self, dt_str):
+        for parser in self._parsers:
+            try:
+                return parser(dt_str)
+            except ValueError:
+                pass
+        raise ValueError(
+            "Unable to parse string {0!r} with the available parsers"
+            .format(dt_str)
+        )
+
+    def __repr__(self):
+        chain_parser_args = [
+            repr(p._format) if isinstance(p, _FixedStrptime) else repr(p)
+            for p in self._parsers
+        ]
+        return "ChainParser(%s)" % ", ".join(chain_parser_args)

--- a/tests/test_chain_parser.py
+++ b/tests/test_chain_parser.py
@@ -1,0 +1,83 @@
+from dateutil.parser import ChainParser
+import dateutil.parser
+import pytest
+
+import datetime as dt
+
+
+def custom_parser(dt_str):
+    return dt.datetime(1989, 4, 24)
+
+
+@pytest.mark.smoke
+def test_parser_repr():
+    parse = ChainParser(
+        "%Y%m%d",
+        "%Y-%m-%d",
+    )
+    assert repr(parse) == "ChainParser('%Y%m%d', '%Y-%m-%d')"
+
+
+@pytest.mark.parametrize(
+    "dtstr, expected",
+    [
+        ("2019-12-04T00:00:00", dt.datetime(2019, 12, 4)),
+        ("2019/12/04T00:00:00", dt.datetime(2019, 12, 4)),
+    ],
+)
+def test_dateutil_parsers(dtstr, expected):
+    parse = ChainParser(
+        dateutil.parser.isoparse,
+        dateutil.parser.parse,
+    )
+    assert parse(dtstr) == expected
+
+
+@pytest.mark.parametrize(
+    "dtstr, expected",
+    [
+        ("20191204", dt.datetime(2019, 12, 4)),
+        ("WORKS", dt.datetime(1989, 4, 24)),
+    ],
+)
+def test_custom_parser(dtstr, expected):
+    parse = ChainParser(
+        "%Y%m%d",
+        custom_parser,
+    )
+    assert parse(dtstr) == expected
+
+
+def test_build_invalid_parser():
+    with pytest.raises(ValueError):
+        ChainParser(None)
+
+
+def test_impossible_to_parse_dtstr():
+    with pytest.raises(ValueError, match="Unable to parse"):
+        ChainParser("%Y%m%d")("NOTWORK")
+
+
+@pytest.mark.parametrize(
+    "dtstr, expected",
+    [
+        ("120101", dt.datetime(2012, 1, 1)),
+        ("010199", dt.datetime(1999, 1, 1)),
+        ("990101", dt.datetime(1999, 1, 1)),
+    ],
+)
+def test_ymd_fallback(dtstr, expected):
+    parser = ChainParser("%y%m%d", "%d%m%y")
+    assert parser(dtstr) == expected
+
+
+@pytest.mark.parametrize(
+    "parsers, expected",
+    [
+        (["%y%m%d", "%d%m%y"], dt.datetime(2001, 2, 3)),
+        (["%d%m%y", "%y%m%d"], dt.datetime(2003, 2, 1)),
+    ],
+)
+def test_parser_order(parsers, expected):
+    parse = ChainParser(*parsers)
+    assert parse("010203") == expected


### PR DESCRIPTION
## Summary of changes
This will provide users with a new parser type that allows to parse a
string using a list of parsers or string formats to be used in strptime.

This class can be used when users have an idea of potential formats that
the string might have been formatted with and still allows to be
combined with other dateutils parsers.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->

<!-- Summary goes here -->

Closes #1153

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
