### PR TITLE
docs: YYYYMM is not supported

### DIFF
--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -72,7 +72,7 @@ class isoparser(object):
         Common:
 
         - ``YYYY``
-        - ``YYYY-MM`` or ``YYYYMM``
+        - ``YYYY-MM``
         - ``YYYY-MM-DD`` or ``YYYYMMDD``
 
         Uncommon:


### PR DESCRIPTION
Remove "YYYYMM" from the docs, as it is not actually supported (https://github.com/dateutil/dateutil/issues/251).

To keep it simple, I do not need to be added to AUTHORS.md.

I don't think a docs fix requires a news fragment.
