### PR TITLE
add empty slots to _resultbase, whose subclasses have slots

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -218,6 +218,8 @@ class _timelex(object):
 
 class _resultbase(object):
 
+    __slots__ = ()
+
     def __init__(self):
         for attr in self.__slots__:
             setattr(self, attr, None)


### PR DESCRIPTION
## Summary of changes

Closes #1186 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details

## Questions

- regarding tests: probably not needed. I discovered the slots issue with [slotscheck](https://github.com/ariebovenberg/slotscheck), a tool I wrote. Of course, If you like, I can add it to tox/CI as I've done for [instagram/LibCST](https://github.com/Instagram/LibCST/pull/615) and [dry-python/returns](https://github.com/dry-python/returns/pull/1233).
- Is this change worth adding to `AUTHORS.md`? 😅 
