### PR TITLE
Pytest warnings fix

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -60,6 +60,7 @@ switch, and thus all their contributions are dual-licensed.
 - Ionuț Ciocîrlan <jdxlark@MASKED>
 - Jacqueline Chen <jacqueline415@outlook.com> (gh: @jachen20) **D**
 - Jake Chorley (gh: @jakec-github) **D**
+- Jakub Kulík (gh: @kulikjak) **D**
 - Jan Studený <jendas1@MASKED>
 - Jay Weisskopf <jay@jayschwa.net> (gh: @jayschwa) **D**
 - Jitesh <jitesh@MASKED>

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -9,6 +9,7 @@ code that may be difficult to reach through the standard API calls.
 
 import sys
 import pytest
+import warnings
 
 from dateutil.parser._parser import _ymd
 from dateutil import tz
@@ -65,18 +66,17 @@ def test_parser_parser_private_not_warns():
     from dateutil.parser._parser import _timelex, _tzparser
     from dateutil.parser._parser import _parsetz
 
-    with pytest.warns(None) as recorder:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         _tzparser()
-        assert len(recorder) == 0
 
-    with pytest.warns(None) as recorder:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         _timelex('2014-03-03')
 
-        assert len(recorder) == 0
-
-    with pytest.warns(None) as recorder:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         _parsetz('+05:00')
-        assert len(recorder) == 0
 
 
 @pytest.mark.tzstr


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Pytest recently deprecated passing `None` as `pytest.warns` argument. As per the documentation [1], new preferred way of ensuring that no warnings are emitted is:
```python
with warnings.catch_warnings():
    warnings.simplefilter("error")
```

I verified that this change doesn't work only with the latest Pytest (7.0.0 at this time) but also with much older 4.4.0.

[1] https://docs.pytest.org/en/latest/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests

### Pull Request Checklist
- [X] Changes have tests (changes are tests!)
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details - _I presume it's not necessary in this case?_
