### PR TITLE
Fix ignoretz support when parsing EXDATE rrules with TZID parameters

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -15,6 +15,7 @@ switch, and thus all their contributions are dual-licensed.
 - Adrien Cossa <cossa@MASKED>
 - Alec Nikolas Reiter <alecreiter@MASKED>
 - Alec Reiter <areiter@MASKED>
+- Alec Rosenbaum (gh: @AlecRosenbaum)
 - Aleksei Strizhak <alexei.mifrill.strizhak@MASKED> (gh: @Mifrill)
 - Alex Chamberlain (gh: @alexchamberlain) **D**
 - Alex Verdyan <verdyan@MASKED>

--- a/changelog.d/1219.bugfix.rst
+++ b/changelog.d/1219.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where rrulestr did not respect the ignoretz parameter when parsing EXDATE parameters. Reported and fixed by @AlecRosenbaum (gh issue #1218) (gh pr #1219)

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -1572,6 +1572,8 @@ class _rrulestr(object):
 
         for parm in parms:
             if parm.startswith("TZID="):
+                if ignoretz:
+                    continue
                 try:
                     tzkey = rule_tzids[parm.split('TZID=')[-1]]
                 except KeyError:

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -2874,6 +2874,18 @@ class RRuleTest(unittest.TestCase):
                             datetime(1997, 9, 9, 9, 0, tzinfo=BXL),
                             datetime(1997, 9, 16, 9, 0, tzinfo=BXL)]
 
+    def testStrSetExDateWithTZIDIgnoreTZ(self):
+        rr = rrulestr("DTSTART;TZID=Europe/Brussels:19970902T090000\n"
+                      "RRULE:FREQ=YEARLY;COUNT=6;BYDAY=TU,TH\n"
+                      "EXDATE;TZID=Europe/Brussels:19970904T090000\n"
+                      "EXDATE;TZID=Europe/Brussels:19970911T090000\n"
+                      "EXDATE;TZID=Europe/Brussels:19970918T090000\n",
+                      ignoretz=True)
+
+        assert list(rr) == [datetime(1997, 9, 2, 9, 0),
+                            datetime(1997, 9, 9, 9, 0),
+                            datetime(1997, 9, 16, 9, 0)]
+
     def testStrSetExDateValueDateTimeNoTZID(self):
         rrstr = '\n'.join([
             "DTSTART:19970902T090000",


### PR DESCRIPTION
## Summary of changes

This change fixes `ignoretz` support when parsing `EXDATE` parameters within RRULE strings, specifically the `TZID` parameter.

Closes https://github.com/dateutil/dateutil/issues/1218

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
