### PR TITLE
Use SPDX license expression in project metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ project_urls =
     Documentation = https://dateutil.readthedocs.io/en/stable/
     Source = https://github.com/dateutil/dateutil
 long_description_content_type = text/x-rst
-license = Dual License
+license = Apache-2.0 AND BSD-3-Clause
 license_file = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

As a downstream user it is desirable to be able to programmatically determine the precise licenses used by our dependencies. The emerging convention for this is the [SPDX License List](https://spdx.org/licenses/). SPDX License Expressions are already used in the JavaScript (npm) and Rust (crates.io) ecosystems, for example.

In Python, there is [PEP 639](https://peps.python.org/pep-0639/) which would add a standard 'License-Expression' metadata field. The discussion around this PEP seems to have gone stale in 2021.

This merge request is in lieu of that PEP coming soon. Unless you as project maintainers think the proposed change in this PR has downsides (which you are entitled to!), I would ask that you accept this change so that it's possible for users to attempt to parse your license metadata as an SPDX License Expression.

It's my understanding that old contributions are not available under the Apache-2.0 license and therefore the license expression must be `Apache-2.0 AND BSD-3-Clause` rather than `Apache-2.0 OR BSD-3-Clause`.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details

(I don't think this metadata change needs an AUTHORS change or requires a news fragment, but let me know if so)
