### PR TITLE
ENH: disable_durations in parse

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -962,3 +962,10 @@ def test_parsererror_repr():
     s = repr(ParserError("Problem with string: %s", "2019-01-01"))
 
     assert s == "ParserError('Problem with string: %s', '2019-01-01')"
+
+
+def test_disable_durations():
+    with pytest.raises(ValueError, match="Unknown string format"):
+        parse("t2m", disable_durations=True)
+    with pytest.raises(ValueError, match="Unknown string format"):
+        parse("t2m1", disable_durations=True)


### PR DESCRIPTION
## Summary of changes

Add a parameter "disable_durations" to disable parsing components e.g. "2m1" as parts of datetimes.

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
