### PR TITLE
Update Github Actions configuration for old Pythons

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,6 +25,20 @@ jobs:
           "pypy-3.8",
         ]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - python-version: "2.7"
+            os: "ubuntu-latest"
+          - python-version: "3.5"
+            os: "ubuntu-latest"
+          - python-version: "3.6"
+            os: "ubuntu-latest"
+        include:
+          - python-version: "2.7"
+            os: "ubuntu-20.04"
+          - python-version: "3.5"
+            os: "ubuntu-20.04"
+          - python-version: "3.6"
+            os: "ubuntu-20.04"
     runs-on: ${{ matrix.os }}
     env:
       TOXENV: py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: "3.10"
       - name: Install tox
         run: python -m pip install -U tox
       - name: Run tox
@@ -94,7 +94,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.6
+          python-version: "3.10"
       - name: Install tox
         run: python -m pip install -U "tox<3.8.0"
       - name: Run updatezinfo.py
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
       - name: Install tox
         run: python -m pip install -U tox
       - name: Run tox

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,9 +37,7 @@ jobs:
             os: "ubuntu-20.04"
           - python-version: "3.5"
             os: "ubuntu-20.04"
-          - python-version: "3.6"
-            os: "ubuntu-20.04"
-    runs-on: ${{ matrix.os }}
+          - python-version: "3.6" os: "ubuntu-20.04" runs-on: ${{ matrix.os }}
     env:
       TOXENV: py
     steps:
@@ -74,33 +72,33 @@ jobs:
           name: ${{ matrix.os }}:${{ matrix.python-version }}
           fail_ci_if_error: true
 
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: "3.10"
-      - name: Install tox
-        run: python -m pip install -U tox
-      - name: Run tox
-        run: python -m tox -e docs
+  other:
+    runs-on: "ubuntu-latest"
+    strategy:
+      matrix:
+        toxenv: ["docs", "tz"]
+    env:
+      TOXENV: ${{ matrix.toxenv }}
 
-  latest-tz:
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v3
+      - name: ${{ matrix.toxenv }}
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
       - name: Install tox
-        run: python -m pip install -U "tox<3.8.0"
+        run: |
+          python -m pip install --upgrade pip
+          if [[ $TOXENV == "tz" ]]; then
+            python -m pip install -U "tox<3.8.0"
+          else
+            python -m pip install -U tox
+          fi
       - name: Run updatezinfo.py
         run: ./ci_tools/retry.sh python updatezinfo.py
-      - name: Run tox
-        run: python -m tox -e tz
+        if: matrix.toxenv == 'tox'
+      - name: Run action
+        run: tox
 
   build-dist:
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -99,7 +99,6 @@ commands =
 
 [testenv:build]
 description = Build an sdist and bdist
-basepython = python3.9
 skip_install = true
 passenv = *
 deps = build[virtualenv] >= 0.3.0


### PR DESCRIPTION
The latest version of ubuntu no longer supports 3.6 or 2.7, so we need to explicitly pin those versions to 20.04