### PR TITLE
Add pre commit

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,9 @@ jobs:
             os: "ubuntu-20.04"
           - python-version: "3.5"
             os: "ubuntu-20.04"
-          - python-version: "3.6" os: "ubuntu-20.04" runs-on: ${{ matrix.os }}
+          - python-version: "3.6"
+            os: "ubuntu-20.04"
+    runs-on: ${{ matrix.os }}
     env:
       TOXENV: py
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,8 +81,6 @@ jobs:
         toxenv: ["docs", "tz", "precommit"]
     env:
       TOXENV: ${{ matrix.toxenv }}
-      PRE_COMMIT_FROM_REF: ${{ github.base_ref }}
-      PRE_COMMIT_TO_REF: "HEAD"
 
     steps:
       - uses: actions/checkout@v3
@@ -105,6 +103,19 @@ jobs:
         if: matrix.toxenv == 'tox'
       - name: Run action
         run: tox
+
+  darker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+      - uses: akaihola/darker@1.5.1
+        with:
+          options: "--check --diff --color --isort"
+          src: "."
+          version: "1.5.1"
 
   build-dist:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -78,12 +78,16 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        toxenv: ["docs", "tz"]
+        toxenv: ["docs", "tz", "precommit"]
     env:
       TOXENV: ${{ matrix.toxenv }}
+      PRE_COMMIT_FROM_REF: ${{ github.base_ref }}
+      PRE_COMMIT_TO_REF: "HEAD"
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: ${{ matrix.toxenv }}
         uses: actions/setup-python@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/akaihola/darker
+    rev: 1.5.1
+    hooks:
+    -   id: darker
+        args: [--isort]
+        additional_dependencies:
+            - "isort>5.9"
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: debug-statements

--- a/README.rst
+++ b/README.rst
@@ -147,7 +147,7 @@ keys can be found below:
 ===========  ============================
 Releases     Signing key fingerprint
 ===========  ============================
-2.4.1-2.8.2  `6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB`_ 
+2.4.1-2.8.2  `6B49 ACBA DCF6 BD1C A206 67AB CD54 FCE3 D964 BEFB`_
 ===========  ============================
 
 New releases *may* have signed tags, but binary and source distributions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,3 +46,21 @@ build-backend = "setuptools.build_meta"
         name = "Misc"
         showcontent = true
 
+[tool.black]
+line-length = 80
+
+[tool.isort]
+atomic=true
+force_grid_wrap=0
+include_trailing_comma=true
+known_first_party = ["dateutil"]
+known_third_party=[
+    "pytest",
+    "hypothesis",
+    "six",
+    "freezegun",
+    "mock",
+]
+multi_line_output=3
+use_parentheses=true
+

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -48,7 +48,7 @@ class relativedelta(object):
             the corresponding arithmetic operation on the original datetime value
             with the information in the relativedelta.
 
-        weekday: 
+        weekday:
             One of the weekday instances (MO, TU, etc) available in the
             relativedelta module. These instances may receive a parameter N,
             specifying the Nth weekday, which could be positive or negative

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -80,10 +80,10 @@ def _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset,
         if not fmt.endswith('%f'):  # pragma: nocover
             raise ValueError('Time format has no microseconds!')
 
-        if microsecond_precision != 6: 
-            dtstr = dtstr[:-(6 - microsecond_precision)]
-        elif microsecond_precision > 6: # pragma: nocover
-            raise ValueError('Precision must be 1-6') 
+        if microsecond_precision != 6:
+            dtstr = dtstr[: -(6 - microsecond_precision)]
+        elif microsecond_precision > 6:  # pragma: nocover
+            raise ValueError("Precision must be 1-6")
 
     dtstr += offset_str
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,16 @@ source = dateutil
 skip_covered = True
 show_missing = True
 
+[testenv:precommit]
+description = Run the pre-commit hooks on all files
+passenv =
+    PRE_COMMIT*
+deps =
+    pre-commit
+commands =
+    pre-commit install -f --install-hooks
+    pre-commit run --all-files
+
 [testenv:tz]
 # Warning: This will modify the repository and is only intended to be run
 #          as part of the CI process, not locally.


### PR DESCRIPTION
## Summary of changes

This creates a `pre-commit` configuration that adds `darken` with `isort` to the pre-commit hooks, and enforces those hooks on GHA.
