### PR TITLE
Handle non-standard properties in icalendar timezone file parsing

### DIFF
--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -1435,6 +1435,8 @@ class tzical(object):
                         tzname = value
                     elif name == "COMMENT":
                         pass
+                    elif name.startswith("X-"):
+                        pass
                     else:
                         raise ValueError("unsupported property: "+name)
                 else:
@@ -1444,6 +1446,8 @@ class tzical(object):
                                 "unsupported TZID parm: "+parms[0])
                         tzid = value
                     elif name in ("TZURL", "LAST-MODIFIED", "COMMENT"):
+                        pass
+                    elif name.startswith("X-"):
                         pass
                     else:
                         raise ValueError("unsupported property: "+name)

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -1897,6 +1897,21 @@ class TZICalTest(unittest.TestCase, TzFoldMixin):
             for test_type in ('name', 'offset', 'dst'):
                 self._testEST(start=start, test_type=test_type, tzc=tzc)
 
+    def testESTExperimentalProperties(self):
+        # Violating one-test-per-test rule because we're not set up to do
+        # parameterized tests and the manual proliferation is getting a bit
+        # out of hand.
+        tz_str_list = []
+        for line in self._gettz_str_tuple('America/New_York'):
+            tz_str_list.append(line)
+            tz_str_list.append("X-NON-STANDARD-PROPERTY:Value")
+
+        tzc = tz.tzical(StringIO('\n'.join(tz_str_list))).get()
+
+        for start in (True, False):
+            for test_type in ('name', 'offset', 'dst'):
+                self._testEST(start=start, test_type=test_type, tzc=tzc)
+
     def _testMultizone(self, start, test_type):
         tzstrs = (self._gettz_str('America/New_York'),
                   self._gettz_str('America/Los_Angeles'))


### PR DESCRIPTION
## Summary of changes

Ignore non-standard properties (see [RFC 5545](https://www.rfc-editor.org/rfc/rfc5545#section-3.8.8.2)) when parsing icalendar vtimezones with `dateutil.tz.tzical`.

Closes https://github.com/dateutil/dateutil/issues/1185

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
