### PR TITLE
Add caution to dateutil.parser.parse

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -107,6 +107,7 @@ switch, and thus all their contributions are dual-licensed.
 - Sherry Zhou (gh: @cssherry) **D**
 - Siping Meng (gh: @smeng10) **D**
 - Stefan Bonchev **D**
+- Theodore Dias (gh: @madt2709) **D**
 - Thierry Bastian <thierryb@MASKED>
 - Thomas A Caswell <tcaswell@MASKED> (gh: @tacaswell) **R**
 - Thomas Achtemichuk <tom@MASKED>

--- a/changelog.d/1270.doc.rst
+++ b/changelog.d/1270.doc.rst
@@ -1,0 +1,3 @@
+Added note into docs to be more explicit that passing a non-datetime strings into
+``dateutil.parser.parse`` has undefined behavior.
+Reported by @pganssle (gh issue #1270). Fixed by @madt2709 (gh pr #1281)

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -631,6 +631,12 @@ class parser(object):
         :raises OverflowError:
             Raised if the parsed date exceeds the largest valid C integer on
             your system.
+
+        .. caution::
+
+            If you parse a string which is not representing a :class:`datetime.datetime` object
+            then it may parse to something or fail outright.
+            
         """
 
         if default is None:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Add explicit warning to documentation that datetime.parser.parse does not support strings which are not in a valid date time format.

Closes https://github.com/dateutil/dateutil/issues/1270

### Pull Request Checklist
- [ ] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
