### PR TITLE
GH#1191 Fixed parsing of no space after comma

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -986,7 +986,13 @@ class parser(object):
                 idx += 1
             else:
                 # Year, month or day
-                ymd.append(value)
+                dot_idx = value_repr.find('.')
+                if dot_idx != -1 and dot_idx != len_li - 1:
+                    ymd.append(value_repr[:dot_idx])
+                    ymd.append(value_repr[dot_idx+1:])
+                else:
+                    ymd.append(value)
+
             idx += 1
 
         elif info.ampm(tokens[idx + 1]) is not None and (0 <= value < 24):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -38,7 +38,7 @@ def fuzzy(request):
 
 # Parser test cases using no keyword arguments. Format: (parsable_text, expected_datetime, assertion_message)
 PARSER_TEST_CASES = [
-    ("Thu Sep 25 10:36:28 2003", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),
+    ("Thu Sep 25 10:36:28 2003", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),    
     ("Thu Sep 25 2003", datetime(2003, 9, 25), "date command format strip"),
     ("2003-09-25T10:49:41", datetime(2003, 9, 25, 10, 49, 41), "iso format strip"),
     ("2003-09-25T10:49", datetime(2003, 9, 25, 10, 49), "iso format strip"),
@@ -100,6 +100,9 @@ PARSER_TEST_CASES = [
 
     # Cases with legacy h/m/s format, candidates for deprecation (GH#886)
     ("2016-12-21 04.2h", datetime(2016, 12, 21, 4, 12), "Fractional Hours"),
+    
+    # Case with no space after comma (GH#1191)
+    ("may15,2021", datetime(2021, 5, 15, 0, 0), "random format"),
 ]
 # Check that we don't have any duplicates
 assert len(set([x[0] for x in PARSER_TEST_CASES])) == len(PARSER_TEST_CASES)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

The lexing of a date like may15,2021 with no space after the common yielded the second token as '15.2021'.  This special case is now handled in the parser.

A test case was added that failed before the fix and now works.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ X] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
