### PR TITLE
zoneinfo.rebuild: Extract using tarfile data filter (PEP 706) if available

### DIFF
--- a/changelog.d/1295.misc.rst
+++ b/changelog.d/1295.misc.rst
@@ -1,0 +1,4 @@
+On Python versions that support it, ``zoneinfo.rebuild`` now uses the
+tarfile ``data`` filter to limit damage in case it's used with a
+malicious tarball, and to avoid a deprecation warning on Python 3.12.
+Reported and fixed by @encukou (gh pr #1295)

--- a/src/dateutil/zoneinfo/rebuild.py
+++ b/src/dateutil/zoneinfo/rebuild.py
@@ -4,6 +4,7 @@ import tempfile
 import shutil
 import json
 from subprocess import check_call, check_output
+import tarfile
 from tarfile import TarFile
 
 from dateutil.zoneinfo import METADATA_FN, ZONEFILENAME
@@ -20,6 +21,13 @@ def rebuild(filename, tag=None, format="gz", zonegroups=[], metadata=None):
     moduledir = os.path.dirname(__file__)
     try:
         with TarFile.open(filename) as tf:
+
+            # Limit extraction to safe, plain data files, if this Python
+            # allows it easily. If not, just trust the input.
+            # See: https://docs.python.org/3/library/tarfile.html#supporting-older-python-versions
+            tf.extraction_filter = getattr(tarfile, 'data_filter',
+                                           (lambda member, path: member))
+
             for name in zonegroups:
                 tf.extract(name, tmpdir)
             filepaths = [os.path.join(tmpdir, n) for n in zonegroups]


### PR DESCRIPTION
## Summary of changes

In new versions of Python, `tarfile` allows *filters* (PEP-706), a mechanism to limit allowed features when extracting tarballs. The `data` filter, suggested here, is intended for pure data files. A cross-platform tarball like a `tzdata` release definitely should not need more. Details on what it does are [here](https://docs.python.org/3/library/tarfile.html#tarfile.data_filter).

This uses the mechanism if it's available.

The incantation, a bit convoluted in order to be backwards-compatible, is taken from the [docs](https://docs.python.org/3/library/tarfile.html#supporting-older-python-versions).

### Pull Request Checklist
- [ ] Changes have tests

   The can be reproduced using `python3.12 -Werror updatezinfo.py`, which fails with a `DeprecationWarning` error.
   The code is called in the release process/test setup, rather than tests themselves. Also, 3.12 is not in the CI matrix yet.
   If you think manual testing isn't enough, I'd appreciate pointers on how to test this.

- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)

   I'm fine without that, if it's OK with you.

- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
