### PR TITLE
Set GitHub Workflow Permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ on:
       - '*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,15 +28,11 @@ jobs:
         ]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          - python-version: "2.7"
-            os: "ubuntu-latest"
           - python-version: "3.5"
             os: "ubuntu-latest"
           - python-version: "3.6"
             os: "ubuntu-latest"
         include:
-          - python-version: "2.7"
-            os: "ubuntu-20.04"
           - python-version: "3.5"
             os: "ubuntu-20.04"
           - python-version: "3.6"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "2.7",
           "3.5",
           "3.6",
           "3.7",

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -67,6 +67,7 @@ switch, and thus all their contributions are dual-licensed.
 - John Purviance <jpurviance@MASKED> (gh @jpurviance) **D**
 - Jon Dufresne <jon.dufresne@MASKED> (gh: @jdufresne) **R**
 - Jonas Neubert <jonas@MASKED> (gh: @jonemo) **R**
+- Joyce Brum <joycebrum@google.com> (gh: @joycebrum) **D**
 - Kevin Nguyen <kvn219@MASKED> **D**
 - Kirit Thadaka <kirit.thadaka@gmail.com> (gh: @kirit93) **D**
 - Kubilay Kocak <koobs@MASKED>

--- a/changelog.d/1266.misc.rst
+++ b/changelog.d/1266.misc.rst
@@ -1,0 +1,1 @@
+Set GitHub Workflow permissions and fixed breaking CI


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes #1266 

I've concluded that both workflows only need contents read permission because:

- publish.yml uses its own token, not relying on GITHUB_TOKEN for any action or execution
- validate.yml actions does not need any additional permission as it seems. I've double checked if that would be the case for codecov and it didn't need any permission at all (https://github.com/codecov/codecov-action/issues/739). 

I also tried to make the validate.yml pass by fixing the error due to setup-python not supporting python 2.7 anymore (https://github.com/actions/setup-python/issues/672). See example error https://github.com/dateutil/dateutil/actions/runs/5773236384/job/15648971477.

Even though it was not breaking due to setup-python, I wasn't able to get a success output because it wasn't possible to publish to codecov (which makes sense) but now should be working on dateutil repo.

### Pull Request Checklist
- [ ] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
