### PR TITLE
Drop python 2 support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install -U tox six
+        run: python -m pip install -U tox
       - name: Install zic (Windows)
         run: |
           curl https://get.enterprisedb.com/postgresql/postgresql-9.5.21-2-windows-x64-binaries.zip --output $env:GITHUB_WORKSPACE\postgresql9.5.21.zip

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "2.7",
           "3.5",
           "3.6",
           "3.7",
@@ -21,20 +20,15 @@ jobs:
           "3.9",
           "3.10",
           "3.11",
-          "pypy-2.7",
           "pypy-3.8",
         ]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          - python-version: "2.7"
-            os: "ubuntu-latest"
           - python-version: "3.5"
             os: "ubuntu-latest"
           - python-version: "3.6"
             os: "ubuntu-latest"
         include:
-          - python-version: "2.7"
-            os: "ubuntu-20.04"
           - python-version: "3.5"
             os: "ubuntu-20.04"
           - python-version: "3.6"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@ switch, and thus all their contributions are dual-licensed.
 - Andrew Murray <radarhere@MASKED>
 - Arclight <arclight@MASKED> (gh: @arclightslavik)
 - Aritro Nandi <gurgenz221@gmail.com> (gh: @gurgenz221) **D**
+- Ben Brown <ben@demerara.io> (gh: @benjamb) **D**
 - Bernat Gabor <bgabor8@bloomberg.net> (gh: @gaborbernat) **D**
 - Bradlee Speice <bradlee@speice.io> (gh: @bspeice) **D**
 - Brandon W Maister <quodlibetor@MASKED>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,10 +93,10 @@ pip install -r requirements-dev.txt
 
 ## Testing
 
-The best way to test `dateutil` is to run `tox`. By default, `tox` will test against all supported versions of Python installed on your system. To limit the number of tests, run a specific subset of environments. For example, to run only on Python 2.7 and Python 3.6:
+The best way to test `dateutil` is to run `tox`. By default, `tox` will test against all supported versions of Python installed on your system. To limit the number of tests, run a specific subset of environments. For example, to run only on Python 3.6:
 
 ```bash
-tox -e py27,py36
+tox -e py36
 ```
 
 You can also pass arguments to `pytest` through `tox` by placing them after `--`:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ install:
 
   # This frequently fails with network errors, so we'll retry it up to 5 times
   # with a 1 minute rate limit.
-  - "%PYTHON% -m pip install six"
   - "ci_tools/retry.bat %PYTHON% updatezinfo.py"
   # This environment variable tells the test suite it's OK to mess with the time zone.
   - set DATEUTIL_MAY_CHANGE_TZ=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,6 @@ pool:
 
 strategy:
   matrix:
-    Python27:
-      python.version: '2.7'
     Python34:
       python.version: '3.4'
     Python35:
@@ -26,14 +24,8 @@ strategy:
       python.version: '3.6'
       POOL_IMAGE: vs2017-win2016
       installzic: 'windows'
-    PyPy:
-      python.version: 'pypy2'
     PyPy3:
       python.version: 'pypy3'
-    WindowsPyPy2:
-      python.version: 'pypy2'
-      POOL_IMAGE: vs2017-win2016
-      installzic: 'windows'
     WindowsPyPy3:
       python.version: 'pypy3'
       POOL_IMAGE: vs2017-win2016

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ steps:
     versionSpec: $(python.version)
 
 - bash: |
-    python -m pip install -U six && python -m pip install -U 'tox < 3.8.0'
+    python -m pip install -U 'tox < 3.8.0'
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   displayName: Ensure prereqs

--- a/changelog.d/653.deprecation.rst
+++ b/changelog.d/653.deprecation.rst
@@ -1,0 +1,4 @@
+Drop python 2 support. Removes all python 2 code, along with compatability code,
+and any CI or test configuration that may still test against python 2
+environments.
+Reported by @pganssle (gh issue #653). Fixed by @benjamb (gh pr #1304).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -187,10 +187,12 @@ htmlhelp_basename = 'dateutildoc'
 
 # -- Options for autodoc -------------------------------------------------
 
-autodoc_mock_imports = ['ctypes.wintypes', 'six.moves.winreg']
+autodoc_mock_imports = ["ctypes.wintypes", "winreg"]
 
 # Need to mock this out specifically to avoid errors
 import ctypes
+
+
 def pointer_mock(*args, **kwargs):
     try:
         return ctypes.POINTER(*args, **kwargs)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # dateutil documentation build configuration file, created by
 # sphinx-quickstart on Thu Nov 20 23:18:41 2014.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ known_first_party = ["dateutil"]
 known_third_party=[
     "pytest",
     "hypothesis",
-    "six",
     "freezegun",
     "mock",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-six
 pytest >= 3.0; python_version != '3.3'
 pytest-cov >= 2.0.0
 freezegun ; python_version != '3.3'

--- a/requirements/3.3/constraints.txt
+++ b/requirements/3.3/constraints.txt
@@ -10,6 +10,5 @@ py==1.4.34
 pytest==3.2.5
 pytest-cov==2.5.1
 setuptools==39.2.0
-six==1.12.0
 tox==2.9.1
 virtualenv==15.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
@@ -40,7 +38,7 @@ zip_safe = True
 setup_requires = setuptools_scm
 package_dir=
     =src
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*
+python_requires = >=3.3
 packages = find:
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ classifiers =
 [options]
 zip_safe = True
 setup_requires = setuptools_scm
-install_requires = six >= 1.5
 package_dir=
     =src
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,13 @@
 #!/usr/bin/python
-from os.path import isfile
 import os
+import sys
+import warnings
+from distutils.version import LooseVersion
+from os.path import isfile
 
 import setuptools
-from setuptools import setup, find_packages
+from setuptools import setup
 from setuptools.command.test import test as TestCommand
-
-from distutils.version import LooseVersion
-import warnings
-
-import io
-import sys
 
 if isfile("MANIFEST"):
     os.unlink("MANIFEST")

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ class Unsupported(TestCommand):
 # Load metadata
 
 def README():
-    with io.open('README.rst', encoding='utf-8') as f:
+    with open("README.rst", encoding="utf-8") as f:
         readme_lines = f.readlines()
 
     # The .. doctest directive is not supported by PyPA

--- a/src/dateutil/__init__.py
+++ b/src/dateutil/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 
 try:

--- a/src/dateutil/_common.py
+++ b/src/dateutil/_common.py
@@ -3,7 +3,7 @@ Common code used in multiple modules.
 """
 
 
-class weekday(object):
+class weekday:
     __slots__ = ["weekday", "n"]
 
     def __init__(self, weekday, n=None):

--- a/src/dateutil/easter.py
+++ b/src/dateutil/easter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers a generic Easter computing method for any given year, using
 Western, Orthodox or Julian algorithms.

--- a/src/dateutil/parser/__init__.py
+++ b/src/dateutil/parser/__init__.py
@@ -1,11 +1,14 @@
-# -*- coding: utf-8 -*-
-from ._parser import parse, parser, parserinfo, ParserError
-from ._parser import DEFAULTPARSER, DEFAULTTZPARSER
-from ._parser import UnknownTimezoneWarning
-
-from ._parser import __doc__
-
-from .isoparser import isoparser, isoparse
+from ._parser import (
+    DEFAULTPARSER,
+    DEFAULTTZPARSER,
+    ParserError,
+    UnknownTimezoneWarning,
+    __doc__,
+    parse,
+    parser,
+    parserinfo,
+)
+from .isoparser import isoparse, isoparser
 
 __all__ = ['parse', 'parser', 'parserinfo',
            'isoparse', 'isoparser',
@@ -19,8 +22,8 @@ __all__ = ['parse', 'parser', 'parserinfo',
 
 
 def __deprecated_private_func(f):
-    from functools import wraps
     import warnings
+    from functools import wraps
 
     msg = ('{name} is a private function and may break without warning, '
            'it will be moved and or renamed in future versions.')
@@ -45,15 +48,14 @@ def __deprecate_private_class(c):
 
         def __init__(self, *args, **kwargs):
             warnings.warn(msg, DeprecationWarning)
-            super(private_class, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     private_class.__name__ = c.__name__
 
     return private_class
 
 
-from ._parser import _timelex, _resultbase
-from ._parser import _tzparser, _parsetz
+from ._parser import _parsetz, _resultbase, _timelex, _tzparser
 
 _timelex = __deprecate_private_class(_timelex)
 _tzparser = __deprecate_private_class(_tzparser)

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers a generic date/time string parser which is able to parse
 most known formats to represent a date and/or time.
@@ -28,7 +27,6 @@ Additional resources about date/time string formats can be found below:
 - `Java SimpleDateFormat Class
   <https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html>`_
 """
-from __future__ import unicode_literals
 
 import datetime
 import re
@@ -55,7 +53,7 @@ __all__ = ["parse", "parserinfo", "ParserError"]
 # TODO: pandas.core.tools.datetimes imports this explicitly.  Might be worth
 # making public and/or figuring out if there is something we can
 # take off their plate.
-class _timelex(object):
+class _timelex:
     # Fractional seconds are sometimes split by a comma
     _split_decimal = re.compile("([.,])")
 
@@ -63,7 +61,7 @@ class _timelex(object):
         if isinstance(instream, (bytes, bytearray)):
             instream = instream.decode()
 
-        if isinstance(instream, text_type):
+        if isinstance(instream, str):
             instream = StringIO(instream)
         elif getattr(instream, 'read', None) is None:
             raise TypeError('Parser must be a string or character stream, not '
@@ -216,7 +214,7 @@ class _timelex(object):
         return nextchar.isspace()
 
 
-class _resultbase(object):
+class _resultbase:
 
     def __init__(self):
         for attr in self.__slots__:
@@ -227,8 +225,8 @@ class _resultbase(object):
         for attr in self.__slots__:
             value = getattr(self, attr)
             if value is not None:
-                l.append("%s=%s" % (attr, repr(value)))
-        return "%s(%s)" % (classname, ", ".join(l))
+                l.append("{}={}".format(attr, repr(value)))
+        return "{}({})".format(classname, ", ".join(l))
 
     def __len__(self):
         return (sum(getattr(self, attr) is not None
@@ -238,7 +236,7 @@ class _resultbase(object):
         return self._repr(self.__class__.__name__)
 
 
-class parserinfo(object):
+class parserinfo:
     """
     Class which handles what inputs are accepted. Subclass this to customize
     the language and acceptable values for each parameter.
@@ -565,7 +563,7 @@ class _ymd(list):
         return year, month, day
 
 
-class parser(object):
+class parser:
     def __init__(self, info=None):
         self.info = info or parserinfo()
 
@@ -648,7 +646,7 @@ class parser(object):
         try:
             ret = self._build_naive(res, default)
         except ValueError as e:
-            six.raise_from(ParserError(str(e) + ": %s", timestr), e)
+            raise ParserError(str(e) + ": %s", timestr) from e
 
         if not ignoretz:
             ret = self._build_tzaware(ret, res, tzinfos)
@@ -878,7 +876,7 @@ class parser(object):
         try:
             value = self._to_decimal(value_repr)
         except Exception as e:
-            six.raise_from(ValueError('Unknown numeric token'), e)
+            raise ValueError("Unknown numeric token") from e
 
         len_li = len(value_repr)
 
@@ -1147,7 +1145,7 @@ class parser(object):
                 raise ValueError("Converted decimal value is infinite or NaN")
         except Exception as e:
             msg = "Could not convert %s to decimal" % val
-            six.raise_from(ValueError(msg), e)
+            raise ValueError(msg) from e
         else:
             return decimal_value
 
@@ -1165,9 +1163,9 @@ class parser(object):
         # eg tzinfos = {'BRST' : None}
         if isinstance(tzdata, datetime.tzinfo) or tzdata is None:
             tzinfo = tzdata
-        elif isinstance(tzdata, text_type):
+        elif isinstance(tzdata, str):
             tzinfo = tz.tzstr(tzdata)
-        elif isinstance(tzdata, integer_types):
+        elif isinstance(tzdata, int):
             tzinfo = tz.tzoffset(tzname, tzdata)
         else:
             raise TypeError("Offset must be tzinfo subclass, tz string, "
@@ -1368,7 +1366,7 @@ def parse(timestr, parserinfo=None, **kwargs):
         return DEFAULTPARSER.parse(timestr, **kwargs)
 
 
-class _tzparser(object):
+class _tzparser:
 
     class _result(_resultbase):
 
@@ -1598,11 +1596,11 @@ class ParserError(ValueError):
         try:
             return self.args[0] % self.args[1:]
         except (TypeError, IndexError):
-            return super(ParserError, self).__str__()
+            return super().__str__()
 
     def __repr__(self):
         args = ", ".join("'%s'" % arg for arg in self.args)
-        return "%s(%s)" % (self.__class__.__name__, args)
+        return "{}({})".format(self.__class__.__name__, args)
 
 
 class UnknownTimezoneWarning(RuntimeWarning):

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -188,9 +188,6 @@ class _timelex:
 
         return token
 
-    def next(self):
-        return self.__next__()  # Python 2.x support
-
     @classmethod
     def split(cls, s):
         return list(cls(s))

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -37,9 +37,6 @@ import warnings
 from calendar import monthrange
 from io import StringIO
 
-import six
-from six import integer_types, text_type
-
 from decimal import Decimal
 
 from warnings import warn

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers a parser for ISO-8601 strings
 
@@ -26,20 +25,20 @@ def _takes_ascii(f):
         str_in = getattr(str_in, 'read', lambda: str_in)()
 
         # If it's unicode, turn it into bytes, since ISO-8601 only covers ASCII
-        if isinstance(str_in, six.text_type):
+        if isinstance(str_in, str):
             # ASCII is the same in UTF-8
             try:
                 str_in = str_in.encode('ascii')
             except UnicodeEncodeError as e:
                 msg = 'ISO-8601 strings should contain only ASCII characters'
-                six.raise_from(ValueError(msg), e)
+                raise ValueError(msg) from e
 
         return f(self, str_in, *args, **kwargs)
 
     return func
 
 
-class isoparser(object):
+class isoparser:
     def __init__(self, sep=None):
         """
         :param sep:

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -13,7 +13,6 @@ from dateutil import tz
 from functools import wraps
 
 import re
-import six
 
 __all__ = ["isoparse", "isoparser"]
 

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -487,8 +487,6 @@ class relativedelta:
                     self.minute is None and
                     self.second is None and
                     self.microsecond is None)
-    # Compatibility with Python 2.x
-    __nonzero__ = __bool__
 
     def __mul__(self, other):
         try:

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -4,7 +4,6 @@ import calendar
 import operator
 from math import copysign
 
-from six import integer_types
 from warnings import warn
 
 from ._common import weekday

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import calendar
 
@@ -15,7 +14,7 @@ MO, TU, WE, TH, FR, SA, SU = weekdays = tuple(weekday(x) for x in range(7))
 __all__ = ["relativedelta", "MO", "TU", "WE", "TH", "FR", "SA", "SU"]
 
 
-class relativedelta(object):
+class relativedelta:
     """
     The relativedelta type is designed to be applied to an existing datetime and
     can replace specific components of that datetime, or represents an interval
@@ -200,7 +199,7 @@ class relativedelta(object):
                      "This is not a well-defined condition and will raise " +
                      "errors in future versions.", DeprecationWarning)
 
-            if isinstance(weekday, integer_types):
+            if isinstance(weekday, int):
                 self.weekday = weekdays[weekday]
             else:
                 self.weekday = weekday

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -15,8 +15,6 @@ from functools import wraps
 # For warning about deprecation of until and count
 from warnings import warn
 
-from six import advance_iterator, integer_types
-
 from ._common import weekday as weekdaybase
 
 try:

--- a/src/dateutil/tz/__init__.py
+++ b/src/dateutil/tz/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .tz import *
 from .tz import __doc__
 

--- a/src/dateutil/tz/_common.py
+++ b/src/dateutil/tz/_common.py
@@ -5,16 +5,7 @@ from datetime import datetime, timedelta, tzinfo
 
 ZERO = timedelta(0)
 
-__all__ = ['tzname_in_python2', 'enfold']
-
-
-def tzname_in_python2(namefunc):
-    """Change unicode output into bytestrings in Python 2
-
-    tzname() API changed in Python 3. It used to return bytes, but was changed
-    to unicode strings
-    """
-    return namefunc
+__all__ = ["enfold"]
 
 
 # The following is adapted from Alexander Belopolsky's tz library
@@ -296,7 +287,6 @@ class tzrangebase(_tzinfo):
         else:
             return ZERO
 
-    @tzname_in_python2
     def tzname(self, dt):
         if self._isdst(dt):
             return self._dst_abbr

--- a/src/dateutil/tz/_common.py
+++ b/src/dateutil/tz/_common.py
@@ -16,18 +16,7 @@ def tzname_in_python2(namefunc):
     tzname() API changed in Python 3. It used to return bytes, but was changed
     to unicode strings
     """
-    if PY2:
-        @wraps(namefunc)
-        def adjust_encoding(*args, **kwargs):
-            name = namefunc(*args, **kwargs)
-            if name is not None:
-                name = name.encode()
-
-            return name
-
-        return adjust_encoding
-    else:
-        return namefunc
+    return namefunc
 
 
 # The following is adapted from Alexander Belopolsky's tz library

--- a/src/dateutil/tz/_common.py
+++ b/src/dateutil/tz/_common.py
@@ -1,5 +1,3 @@
-from six import PY2
-
 from functools import wraps
 
 from datetime import datetime, timedelta, tzinfo

--- a/src/dateutil/tz/_factories.py
+++ b/src/dateutil/tz/_factories.py
@@ -1,18 +1,17 @@
-from datetime import timedelta
+import _thread
 import weakref
 from collections import OrderedDict
-
-from six.moves import _thread
+from datetime import timedelta
 
 
 class _TzSingleton(type):
     def __init__(cls, *args, **kwargs):
         cls.__instance = None
-        super(_TzSingleton, cls).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __call__(cls):
         if cls.__instance is None:
-            cls.__instance = super(_TzSingleton, cls).__call__()
+            cls.__instance = super().__call__()
         return cls.__instance
 
 

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -1634,8 +1634,7 @@ def __get_gettz():
                         if tzwin is not None:
                             try:
                                 tz = tzwin(name)
-                            except (OSError, UnicodeEncodeError):
-                                # UnicodeEncodeError is for Python 2.7 compat
+                            except OSError:
                                 tz = None
 
                         if not tz:

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -16,9 +16,6 @@ import time
 import weakref
 from collections import OrderedDict
 
-import six
-from six import string_types
-
 from ._common import (
     _tzinfo,
     _validate_fromutc_inputs,
@@ -32,9 +29,6 @@ try:
     from .win import tzwin, tzwinlocal
 except ImportError:
     tzwin = tzwinlocal = None
-
-# For warning about rounding tzinfo
-from warnings import warn
 
 ZERO = datetime.timedelta(0)
 EPOCH = datetime.datetime(1970, 1, 1, 0, 0)

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -16,13 +16,7 @@ import time
 import weakref
 from collections import OrderedDict
 
-from ._common import (
-    _tzinfo,
-    _validate_fromutc_inputs,
-    enfold,
-    tzname_in_python2,
-    tzrangebase,
-)
+from ._common import _tzinfo, _validate_fromutc_inputs, enfold, tzrangebase
 from ._factories import _TzOffsetFactory, _TzSingleton, _TzStrFactory
 
 try:
@@ -73,7 +67,6 @@ class tzutc(datetime.tzinfo, metaclass=_TzSingleton):
     def dst(self, dt):
         return ZERO
 
-    @tzname_in_python2
     def tzname(self, dt):
         return "UTC"
 
@@ -152,7 +145,6 @@ class tzoffset(datetime.tzinfo, metaclass=_TzOffsetFactory):
     def dst(self, dt):
         return ZERO
 
-    @tzname_in_python2
     def tzname(self, dt):
         return self._name
 
@@ -230,7 +222,6 @@ class tzlocal(_tzinfo):
         else:
             return ZERO
 
-    @tzname_in_python2
     def tzname(self, dt):
         return self._tznames[self._isdst(dt)]
 
@@ -840,7 +831,6 @@ class tzfile(_tzinfo):
         # be constant for every dt.
         return tti.dstoffset
 
-    @tzname_in_python2
     def tzname(self, dt):
         if not self._ttinfo_std or dt is None:
             return None
@@ -1236,7 +1226,6 @@ class _tzicalvtz(_tzinfo):
         else:
             return ZERO
 
-    @tzname_in_python2
     def tzname(self, dt):
         return self._find_comp(dt).tzname
 

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers timezone implementations subclassing the abstract
 :py:class:`datetime.tzinfo` type. There are classes to handle tzfile format
@@ -7,24 +6,28 @@ etc), TZ environment string (in all known formats), given ranges (with help
 from relative deltas), local machine timezone, fixed offset timezone, and UTC
 timezone.
 """
-import datetime
-import struct
-import time
-import sys
-import os
+import _thread
 import bisect
+import datetime
+import os
+import struct
+import sys
+import time
 import weakref
 from collections import OrderedDict
 
 import six
 from six import string_types
-from six.moves import _thread
-from ._common import tzname_in_python2, _tzinfo
-from ._common import tzrangebase, enfold
-from ._common import _validate_fromutc_inputs
 
-from ._factories import _TzSingleton, _TzOffsetFactory
-from ._factories import _TzStrFactory
+from ._common import (
+    _tzinfo,
+    _validate_fromutc_inputs,
+    enfold,
+    tzname_in_python2,
+    tzrangebase,
+)
+from ._factories import _TzOffsetFactory, _TzSingleton, _TzStrFactory
+
 try:
     from .win import tzwin, tzwinlocal
 except ImportError:
@@ -38,8 +41,7 @@ EPOCH = datetime.datetime(1970, 1, 1, 0, 0)
 EPOCHORDINAL = EPOCH.toordinal()
 
 
-@six.add_metaclass(_TzSingleton)
-class tzutc(datetime.tzinfo):
+class tzutc(datetime.tzinfo, metaclass=_TzSingleton):
     """
     This is a tzinfo object that represents the UTC time zone.
 
@@ -129,8 +131,7 @@ class tzutc(datetime.tzinfo):
 UTC = tzutc()
 
 
-@six.add_metaclass(_TzOffsetFactory)
-class tzoffset(datetime.tzinfo):
+class tzoffset(datetime.tzinfo, metaclass=_TzOffsetFactory):
     """
     A simple class for representing a fixed offset from UTC.
 
@@ -191,9 +192,11 @@ class tzoffset(datetime.tzinfo):
         return not (self == other)
 
     def __repr__(self):
-        return "%s(%s, %s)" % (self.__class__.__name__,
-                               repr(self._name),
-                               int(self._offset.total_seconds()))
+        return "{}({}, {})".format(
+            self.__class__.__name__,
+            repr(self._name),
+            int(self._offset.total_seconds()),
+        )
 
     __reduce__ = object.__reduce__
 
@@ -203,7 +206,7 @@ class tzlocal(_tzinfo):
     A :class:`tzinfo` subclass built around the ``time`` timezone functions.
     """
     def __init__(self):
-        super(tzlocal, self).__init__()
+        super().__init__()
 
         self._std_offset = datetime.timedelta(seconds=-time.timezone)
         if time.daylight:
@@ -325,7 +328,7 @@ class tzlocal(_tzinfo):
     __reduce__ = object.__reduce__
 
 
-class _ttinfo(object):
+class _ttinfo:
     __slots__ = ["offset", "delta", "isdst", "abbr",
                  "isstd", "isgmt", "dstoffset"]
 
@@ -338,8 +341,8 @@ class _ttinfo(object):
         for attr in self.__slots__:
             value = getattr(self, attr)
             if value is not None:
-                l.append("%s=%s" % (attr, repr(value)))
-        return "%s(%s)" % (self.__class__.__name__, ", ".join(l))
+                l.append("{}={}".format(attr, repr(value)))
+        return "{}({})".format(self.__class__.__name__, ", ".join(l))
 
     def __eq__(self, other):
         if not isinstance(other, _ttinfo):
@@ -370,7 +373,7 @@ class _ttinfo(object):
                 setattr(self, name, state[name])
 
 
-class _tzfile(object):
+class _tzfile:
     """
     Lightweight class for holding the relevant transition and time zone
     information read from binary tzfiles.
@@ -456,10 +459,10 @@ class tzfile(_tzinfo):
     """
 
     def __init__(self, fileobj, filename=None):
-        super(tzfile, self).__init__()
+        super().__init__()
 
         file_opened_here = False
-        if isinstance(fileobj, string_types):
+        if isinstance(fileobj, str):
             self._filename = fileobj
             fileobj = open(fileobj, 'rb')
             file_opened_here = True
@@ -862,7 +865,7 @@ class tzfile(_tzinfo):
         return not (self == other)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._filename))
+        return "{}({})".format(self.__class__.__name__, repr(self._filename))
 
     def __reduce__(self):
         return self.__reduce_ex__(None)
@@ -1033,8 +1036,7 @@ class tzrange(tzrangebase):
         return self._dst_base_offset_
 
 
-@six.add_metaclass(_TzStrFactory)
-class tzstr(tzrange):
+class tzstr(tzrange, metaclass=_TzStrFactory):
     """
     ``tzstr`` objects are time zone objects specified by a time-zone string as
     it would be passed to a ``TZ`` variable on POSIX-style systems (see
@@ -1150,10 +1152,10 @@ class tzstr(tzrange):
         return relativedelta.relativedelta(**kwargs)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._s))
+        return "{}({})".format(self.__class__.__name__, repr(self._s))
 
 
-class _tzicalvtzcomp(object):
+class _tzicalvtzcomp:
     def __init__(self, tzoffsetfrom, tzoffsetto, isdst,
                  tzname=None, rrule=None):
         self.tzoffsetfrom = datetime.timedelta(seconds=tzoffsetfrom)
@@ -1166,7 +1168,7 @@ class _tzicalvtzcomp(object):
 
 class _tzicalvtz(_tzinfo):
     def __init__(self, tzid, comps=[]):
-        super(_tzicalvtz, self).__init__()
+        super().__init__()
 
         self._tzid = tzid
         self._comps = comps
@@ -1250,7 +1252,7 @@ class _tzicalvtz(_tzinfo):
     __reduce__ = object.__reduce__
 
 
-class tzical(object):
+class tzical:
     """
     This object is designed to parse an iCalendar-style ``VTIMEZONE`` structure
     as set out in `RFC 5545`_ Section 4.6.5 into one or more `tzinfo` objects.
@@ -1265,10 +1267,10 @@ class tzical(object):
         global rrule
         from dateutil import rrule
 
-        if isinstance(fileobj, string_types):
+        if isinstance(fileobj, str):
             self._s = fileobj
             # ical should be encoded in UTF-8 with CRLF
-            fileobj = open(fileobj, 'r')
+            fileobj = open(fileobj)
         else:
             self._s = getattr(fileobj, 'name', repr(fileobj))
             fileobj = _nullcontext(fileobj)
@@ -1421,7 +1423,10 @@ class tzical(object):
                     elif name == "TZOFFSETFROM":
                         if parms:
                             raise ValueError(
-                                "unsupported %s parm: %s " % (name, parms[0]))
+                                "unsupported {} parm: {} ".format(
+                                    name, parms[0]
+                                )
+                            )
                         tzoffsetfrom = self._parse_offset(value)
                     elif name == "TZOFFSETTO":
                         if parms:
@@ -1453,7 +1458,7 @@ class tzical(object):
                 invtz = True
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._s))
+        return "{}({})".format(self.__class__.__name__, repr(self._s))
 
 
 if sys.platform != "win32":
@@ -1472,7 +1477,7 @@ def __get_gettz():
     if tzwinlocal is not None:
         tzlocal_classes += (tzwinlocal,)
 
-    class GettzFunc(object):
+    class GettzFunc:
         """
         Retrieve a time zone object from a string representation
 
@@ -1610,7 +1615,7 @@ def __get_gettz():
                         try:
                             tz = tzfile(filepath)
                             break
-                        except (IOError, OSError, ValueError):
+                        except (OSError, ValueError):
                             pass
                 else:
                     tz = tzlocal()
@@ -1621,7 +1626,7 @@ def __get_gettz():
                 except TypeError as e:
                     if isinstance(name, bytes):
                         new_msg = "gettz argument should be str, not bytes"
-                        six.raise_from(TypeError(new_msg), e)
+                        raise TypeError(new_msg) from e
                     else:
                         raise
                 if os.path.isabs(name):
@@ -1639,14 +1644,14 @@ def __get_gettz():
                         try:
                             tz = tzfile(filepath)
                             break
-                        except (IOError, OSError, ValueError):
+                        except (OSError, ValueError):
                             pass
                     else:
                         tz = None
                         if tzwin is not None:
                             try:
                                 tz = tzwin(name)
-                            except (WindowsError, UnicodeEncodeError):
+                            except (OSError, UnicodeEncodeError):
                                 # UnicodeEncodeError is for Python 2.7 compat
                                 tz = None
 
@@ -1832,7 +1837,8 @@ try:
     # Python 3.7 feature
     from contextlib import nullcontext as _nullcontext
 except ImportError:
-    class _nullcontext(object):
+
+    class _nullcontext:
         """
         Class for wrapping contexts so that they are passed through in a
         with statement.

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -8,8 +8,7 @@ Attempting to import this module on a non-Windows platform will raise an
 # This code was originally contributed by Jeffrey Harris.
 import datetime
 import struct
-
-from six.moves import winreg
+import winreg
 
 try:
     import ctypes

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module provides an interface to the native time zone data on Windows,
 including :py:class:`datetime.tzinfo` implementations.
@@ -36,7 +35,7 @@ def _settzkeyname():
     try:
         winreg.OpenKey(handle, TZKEYNAMENT).Close()
         TZKEYNAME = TZKEYNAMENT
-    except WindowsError:
+    except OSError:
         TZKEYNAME = TZKEYNAME9X
     handle.Close()
     return TZKEYNAME
@@ -45,7 +44,7 @@ def _settzkeyname():
 TZKEYNAME = _settzkeyname()
 
 
-class tzres(object):
+class tzres:
     """
     Class for accessing ``tzres.dll``, which contains timezone name related
     resources.
@@ -216,7 +215,7 @@ class tzwin(tzwinbase):
         self._name = name
 
         with winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE) as handle:
-            tzkeyname = text_type("{kn}\\{name}").format(kn=TZKEYNAME, name=name)
+            tzkeyname = "{kn}\\{name}".format(kn=TZKEYNAME, name=name)
             with winreg.OpenKey(handle, tzkeyname) as tzkey:
                 keydict = valuestodict(tzkey)
 
@@ -282,8 +281,7 @@ class tzwinlocal(tzwinbase):
             self._dst_abbr = keydict["DaylightName"]
 
             try:
-                tzkeyname = text_type('{kn}\\{sn}').format(kn=TZKEYNAME,
-                                                          sn=self._std_abbr)
+                tzkeyname = "{kn}\\{sn}".format(kn=TZKEYNAME, sn=self._std_abbr)
                 with winreg.OpenKey(handle, tzkeyname) as tzkey:
                     _keydict = valuestodict(tzkey)
                     self._display = _keydict["Display"]

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -10,7 +10,6 @@ import datetime
 import struct
 
 from six.moves import winreg
-from six import text_type
 
 try:
     import ctypes

--- a/src/dateutil/utils.py
+++ b/src/dateutil/utils.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 This module offers general convenience and utility functions for dealing with
 datetimes.
 
 .. versionadded:: 2.7.0
 """
-from __future__ import unicode_literals
 
 from datetime import datetime, time
 

--- a/src/dateutil/zoneinfo/__init__.py
+++ b/src/dateutil/zoneinfo/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import warnings
 import json
 
@@ -22,12 +21,12 @@ class tzfile(_tzfile):
 def getzoneinfofile_stream():
     try:
         return BytesIO(get_data(__name__, ZONEFILENAME))
-    except IOError as e:  # TODO  switch to FileNotFoundError?
-        warnings.warn("I/O error({0}): {1}".format(e.errno, e.strerror))
+    except OSError as e:  # TODO  switch to FileNotFoundError?
+        warnings.warn("I/O error({}): {}".format(e.errno, e.strerror))
         return None
 
 
-class ZoneInfoFile(object):
+class ZoneInfoFile:
     def __init__(self, zonefile_stream=None):
         if zonefile_stream is not None:
             with TarFile.open(fileobj=zonefile_stream) as tf:

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import os
 import time
 import subprocess
@@ -9,7 +8,7 @@ import pickle
 import pytest
 
 
-class PicklableMixin(object):
+class PicklableMixin:
     def _get_nobj_bytes(self, obj, dump_kwargs, load_kwargs):
         """
         Pickle and unpickle an object using ``pickle.dumps`` / ``pickle.loads``
@@ -46,7 +45,7 @@ class PicklableMixin(object):
         self.assertEqual(obj, nobj)
 
 
-class TZContextBase(object):
+class TZContextBase:
     """
     Base class for a context manager which allows changing of time zones.
 
@@ -164,7 +163,7 @@ class TZWinContext(TZContextBase):
 
 ###
 # Utility classes
-class NotAValueClass(object):
+class NotAValueClass:
     """
     A class analogous to NaN that has operations defined for any type.
     """
@@ -191,7 +190,7 @@ class NotAValueClass(object):
 NotAValue = NotAValueClass()
 
 
-class ComparesEqualClass(object):
+class ComparesEqualClass:
     """
     A class that is always equal to whatever you compare it to.
     """
@@ -225,7 +224,7 @@ class ComparesEqualClass(object):
 ComparesEqual = ComparesEqualClass()
 
 
-class UnsetTzClass(object):
+class UnsetTzClass:
     """ Sentinel class for unset time zone variable """
     pass
 

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,7 +1,6 @@
 import os
 import time
 import subprocess
-import warnings
 import tempfile
 import pickle
 

--- a/tests/property/test_isoparse_prop.py
+++ b/tests/property/test_isoparse_prop.py
@@ -20,7 +20,7 @@ def test_timespec_auto(dt, sep):
         # Assume offset has no sub-second components
         assume(dt.utcoffset().total_seconds() % 60 == 0)
 
-    sep = str(sep)          # Python 2.7 requires bytes
+    sep = str(sep)
     dtstr = dt.isoformat(sep=sep)
     dt_rt = isoparse(dtstr)
 

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -25,10 +25,7 @@ def test_gettz_returns_local(gettz_arg, dt):
         return
 
     dt_act = dt.astimezone(tz.gettz(gettz_arg))
-    if six.PY2:
-        dt_exp = dt.astimezone(tz.tzlocal())
-    else:
-        dt_exp = dt.astimezone()
+    dt_exp = dt.astimezone()
 
     assert dt_act == dt_exp
     assert dt_act.tzname() == dt_exp.tzname()

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -1,8 +1,7 @@
 from datetime import datetime, timedelta
 
 import pytest
-import six
-from hypothesis import assume, given
+from hypothesis import given
 from hypothesis import strategies as st
 
 from dateutil import tz as tz

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,15 +5,6 @@ import pytest
 MODULE_TYPE = type(sys)
 
 
-# Tests live in datetutil/test which cause a RuntimeWarning for Python2 builds.
-# But since we expect lazy imports tests to fail for Python < 3.7  we'll ignore those
-# warnings with this filter.
-
-
-def filter_import_warning(f):
-    return f
-
-
 @pytest.fixture(scope="function")
 def clean_import():
     """Create a somewhat clean import base for lazy import tests"""
@@ -42,7 +33,6 @@ def clean_import():
         sys.modules[mod_name] = mod
 
 
-@filter_import_warning
 @pytest.mark.parametrize(
     "module",
     ["easter", "parser", "relativedelta", "rrule", "tz", "utils", "zoneinfo"],

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,8 +1,6 @@
 import sys
-import unittest
 
 import pytest
-import six
 
 MODULE_TYPE = type(sys)
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+
 import pytest
 import six
 
@@ -10,12 +11,9 @@ MODULE_TYPE = type(sys)
 # But since we expect lazy imports tests to fail for Python < 3.7  we'll ignore those
 # warnings with this filter.
 
-if six.PY2:
-    filter_import_warning = pytest.mark.filterwarnings("ignore::RuntimeWarning")
-else:
 
-    def filter_import_warning(f):
-        return f
+def filter_import_warning(f):
+    return f
 
 
 @pytest.fixture(scope="function")
@@ -54,7 +52,9 @@ def clean_import():
 def test_lazy_import(clean_import, module):
     """Test that dateutil.[submodule] works for py version > 3.7"""
 
-    import dateutil, importlib
+    import importlib
+
+    import dateutil
 
     if sys.version_info < (3, 7):
         pytest.xfail("Lazy loading does not work for Python < 3.7")
@@ -103,11 +103,8 @@ def test_import_parser_from():
 
 def test_import_parser_all():
     # All interface
-    from dateutil.parser import parse
-    from dateutil.parser import parserinfo
-
     # Other public classes
-    from dateutil.parser import parser
+    from dateutil.parser import parse, parser, parserinfo
 
     for var in (parse, parserinfo, parser):
         assert var is not None
@@ -122,8 +119,7 @@ def test_import_relative_delta_from():
     from dateutil import relativedelta
 
 def test_import_relative_delta_all():
-    from dateutil.relativedelta import relativedelta
-    from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU
+    from dateutil.relativedelta import FR, MO, SA, SU, TH, TU, WE, relativedelta
 
     for var in (relativedelta, MO, TU, WE, TH, FR, SA, SU):
         assert var is not None
@@ -143,12 +139,25 @@ def test_import_rrule_from():
 
 
 def test_import_rrule_all():
-    from dateutil.rrule import rrule
-    from dateutil.rrule import rruleset
-    from dateutil.rrule import rrulestr
-    from dateutil.rrule import YEARLY, MONTHLY, WEEKLY, DAILY
-    from dateutil.rrule import HOURLY, MINUTELY, SECONDLY
-    from dateutil.rrule import MO, TU, WE, TH, FR, SA, SU
+    from dateutil.rrule import (
+        DAILY,
+        FR,
+        HOURLY,
+        MINUTELY,
+        MO,
+        MONTHLY,
+        SA,
+        SECONDLY,
+        SU,
+        TH,
+        TU,
+        WE,
+        WEEKLY,
+        YEARLY,
+        rrule,
+        rruleset,
+        rrulestr,
+    )
 
     rr_all = (rrule, rruleset, rrulestr,
               YEARLY, MONTHLY, WEEKLY, DAILY,
@@ -173,20 +182,22 @@ def test_import_tz_from():
 
 
 def test_import_tz_all():
-    from dateutil.tz import tzutc
-    from dateutil.tz import tzoffset
-    from dateutil.tz import tzlocal
-    from dateutil.tz import tzfile
-    from dateutil.tz import tzrange
-    from dateutil.tz import tzstr
-    from dateutil.tz import tzical
-    from dateutil.tz import gettz
-    from dateutil.tz import tzwin
-    from dateutil.tz import tzwinlocal
-    from dateutil.tz import UTC
-    from dateutil.tz import datetime_ambiguous
-    from dateutil.tz import datetime_exists
-    from dateutil.tz import resolve_imaginary
+    from dateutil.tz import (
+        UTC,
+        datetime_ambiguous,
+        datetime_exists,
+        gettz,
+        resolve_imaginary,
+        tzfile,
+        tzical,
+        tzlocal,
+        tzoffset,
+        tzrange,
+        tzstr,
+        tzutc,
+        tzwin,
+        tzwinlocal,
+    )
 
     tz_all = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
               "tzstr", "tzical", "gettz", "datetime_ambiguous",
@@ -211,8 +222,7 @@ def test_import_tz_windows_from():
 
 @pytest.mark.skipif(not HOST_IS_WINDOWS, reason="Requires Windows")
 def test_import_tz_windows_star():
-    from dateutil.tzwin import tzwin
-    from dateutil.tzwin import tzwinlocal
+    from dateutil.tzwin import tzwin, tzwinlocal
 
     tzwin_all = [tzwin, tzwinlocal]
 
@@ -230,9 +240,7 @@ def test_import_zone_info_from():
 
 
 def test_import_zone_info_star():
-    from dateutil.zoneinfo import gettz
-    from dateutil.zoneinfo import gettz_db_metadata
-    from dateutil.zoneinfo import rebuild
+    from dateutil.zoneinfo import gettz, gettz_db_metadata, rebuild
 
     zi_all = (gettz, gettz_db_metadata, rebuild)
 

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for implementation details, not necessarily part of the user-facing
 API.

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta, date, time
 import itertools as it
 
@@ -300,7 +297,7 @@ def test_isoparser_invalid_sep(sep):
 @pytest.mark.xfail(not six.PY2, reason="Fails on Python 3 only")
 def test_isoparser_byte_sep():
     dt = datetime(2017, 12, 6, 12, 30, 45)
-    dt_str = dt.isoformat(sep=str('T'))
+    dt_str = dt.isoformat(sep="T")
 
     dt_rt = isoparser(sep=b'T').isoparse(dt_str)
 
@@ -347,9 +344,8 @@ def __make_date_examples():
         date(2016, 2, 1)
     ]
 
-    if not six.PY2:
-        # strftime does not support dates before 1900 in Python 2
-        dates_no_day.append(date(1000, 11, 1))
+    # strftime does not support dates before 1900 in Python 2
+    dates_no_day.append(date(1000, 11, 1))
 
     # Only one supported format for dates with no day
     o = zip(dates_no_day, it.repeat('%Y-%m'))
@@ -371,7 +367,7 @@ def __make_date_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_parse_isodate(d, dt_fmt, as_bytes):
     d_str = d.strftime(dt_fmt)
-    if isinstance(d_str, six.text_type) and as_bytes:
+    if isinstance(d_str, str) and as_bytes:
         d_str = d_str.encode('ascii')
     elif isinstance(d_str, bytes) and not as_bytes:
         d_str = d_str.decode('ascii')
@@ -400,10 +396,7 @@ def test_parse_isodate_error_text():
         isoparser().parse_isodate('2014-0423')
 
     # ensure the error message does not contain b' prefixes
-    if six.PY2:
-        expected_error = "String contains unknown ISO components: u'2014-0423'"
-    else:
-        expected_error = "String contains unknown ISO components: '2014-0423'"
+    expected_error = "String contains unknown ISO components: '2014-0423'"
     assert expected_error == str(excinfo.value)
 
 
@@ -458,7 +451,7 @@ def __make_time_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_isotime(time_val, time_fmt, as_bytes):
     tstr = time_val.strftime(time_fmt)
-    if isinstance(tstr, six.text_type) and as_bytes:
+    if isinstance(tstr, str) and as_bytes:
         tstr = tstr.encode('ascii')
     elif isinstance(tstr, bytes) and not as_bytes:
         tstr = tstr.decode('ascii')

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -337,13 +337,7 @@ def test_parse_tzstr_fails(tzstr, exception):
 ###
 # Test parse_isodate
 def __make_date_examples():
-    dates_no_day = [
-        date(1999, 12, 1),
-        date(2016, 2, 1)
-    ]
-
-    # strftime does not support dates before 1900 in Python 2
-    dates_no_day.append(date(1000, 11, 1))
+    dates_no_day = [date(1999, 12, 1), date(2016, 2, 1), date(1000, 11, 1)]
 
     # Only one supported format for dates with no day
     o = zip(dates_no_day, it.repeat('%Y-%m'))

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -6,7 +6,6 @@ from dateutil.tz import UTC
 from dateutil.parser import isoparser, isoparse
 
 import pytest
-import six
 
 
 def _generate_tzoffsets(limited):
@@ -293,8 +292,7 @@ def test_isoparser_invalid_sep(sep):
         isoparser(sep=sep)
 
 
-# This only fails on Python 3
-@pytest.mark.xfail(not six.PY2, reason="Fails on Python 3 only")
+@pytest.mark.xfail
 def test_isoparser_byte_sep():
     dt = datetime(2017, 12, 6, 12, 30, 45)
     dt_str = dt.isoformat(sep="T")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,23 +1,22 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
-from six import assertRaisesRegex, PY2
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+from six import PY2, assertRaisesRegex
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -102,7 +101,7 @@ PARSER_TEST_CASES = [
     ("2016-12-21 04.2h", datetime(2016, 12, 21, 4, 12), "Fractional Hours"),
 ]
 # Check that we don't have any duplicates
-assert len(set([x[0] for x in PARSER_TEST_CASES])) == len(PARSER_TEST_CASES)
+assert len({x[0] for x in PARSER_TEST_CASES}) == len(PARSER_TEST_CASES)
 
 
 @pytest.mark.parametrize("parsable_text,expected_datetime,assertion_message", PARSER_TEST_CASES)
@@ -159,7 +158,9 @@ PARSER_DEFAULT_TEST_CASES = [
     ("2004 10 Apr 11h30m", datetime(2004, 4, 10, 11, 30), "random format")
 ]
 # Check that we don't have any duplicates
-assert len(set([x[0] for x in PARSER_DEFAULT_TEST_CASES])) == len(PARSER_DEFAULT_TEST_CASES)
+assert len({x[0] for x in PARSER_DEFAULT_TEST_CASES}) == len(
+    PARSER_DEFAULT_TEST_CASES
+)
 
 
 @pytest.mark.parametrize("parsable_text,expected_datetime,assertion_message", PARSER_DEFAULT_TEST_CASES)
@@ -223,7 +224,7 @@ def test_parse_with_tzoffset(dstr, expected):
     assert result == expected
 
 
-class TestFormat(object):
+class TestFormat:
 
     def test_ybd(self):
         # If we have a 4-digit year, a non-numeric month (abbreviated or not),
@@ -291,7 +292,7 @@ class TestFormat(object):
         assert res == expected
 
 
-class TestInputTypes(object):
+class TestInputTypes:
     def test_empty_string_invalid(self):
         with pytest.raises(ParserError):
             parse('')
@@ -308,7 +309,7 @@ class TestInputTypes(object):
         # We want to support arbitrary classes that implement the stream
         # interface.
 
-        class StringPassThrough(object):
+        class StringPassThrough:
             def __init__(self, stream):
                 self.stream = stream
 
@@ -349,7 +350,7 @@ class TestInputTypes(object):
         assert res == expected
 
 
-class TestTzinfoInputTypes(object):
+class TestTzinfoInputTypes:
     def assert_equal_same_tz(self, dt1, dt2):
         assert dt1 == dt2
         assert dt1.tzinfo is dt2.tzinfo
@@ -382,7 +383,7 @@ class TestTzinfoInputTypes(object):
 
     def test_valid_tzinfo_unicode_input(self):
         dstr = "2014 January 19 09:00 UTC"
-        tzinfos = {u"UTC": u"UTC+0"}
+        tzinfos = {"UTC": "UTC+0"}
         expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzstr("UTC+0"))
         res = parse(dstr, tzinfos=tzinfos)
         self.assert_equal_same_tz(res, expected)
@@ -391,7 +392,7 @@ class TestTzinfoInputTypes(object):
         dstr = "2014 January 19 09:00 UTC"
 
         def tzinfos(*args, **kwargs):
-            return u"UTC+0"
+            return "UTC+0"
 
         expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzstr("UTC+0"))
         res = parse(dstr, tzinfos=tzinfos)
@@ -399,8 +400,8 @@ class TestTzinfoInputTypes(object):
 
     def test_valid_tzinfo_int_input(self):
         dstr = "2014 January 19 09:00 UTC"
-        tzinfos = {u"UTC": -28800}
-        expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzoffset(u"UTC", -28800))
+        tzinfos = {"UTC": -28800}
+        expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzoffset("UTC", -28800))
         res = parse(dstr, tzinfos=tzinfos)
         self.assert_equal_same_tz(res, expected)
 
@@ -570,12 +571,27 @@ class ParserTest(unittest.TestCase):
             parse('shouldfail')
 
     def testCorrectErrorOnFuzzyWithTokens(self):
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/32/423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/04 +32423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/0d4', fuzzy_with_tokens=True)
+        self.assertRaisesRegex(
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/32/423",
+            fuzzy_with_tokens=True,
+        )
+        self.assertRaisesRegex(
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/04 +32423",
+            fuzzy_with_tokens=True,
+        )
+        self.assertRaisesRegex(
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/0d4",
+            fuzzy_with_tokens=True,
+        )
 
     def testIncreasingCTime(self):
         # This test will check 200 different years, every month, every day,
@@ -614,7 +630,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -627,7 +643,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [("Mo", "Montag"),
@@ -734,7 +750,7 @@ class ParserTest(unittest.TestCase):
             pytest.fail("Failed to raise ParserError")
 
 
-class TestOutOfBounds(object):
+class TestOutOfBounds:
 
     def test_no_year_zero(self):
         with pytest.raises(ParserError):
@@ -769,7 +785,7 @@ class TestOutOfBounds(object):
             parse(dstr, fuzzy=fuzzy)
 
 
-class TestParseUnimplementedCases(object):
+class TestParseUnimplementedCases:
     @pytest.mark.xfail
     def test_somewhat_ambiguous_string(self):
         # Ref: github issue #487
@@ -887,7 +903,7 @@ class TestParseUnimplementedCases(object):
 
 
 @pytest.mark.skipif(IS_WIN, reason="Windows does not use TZ var")
-class TestTZVar(object):
+class TestTZVar:
     def test_parse_unambiguous_nonexistent_local(self):
         # When dates are specified "EST" even when they should be "EDT" in the
         # local time zone, we should still assign the local time zone

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
-from six import PY2, assertRaisesRegex
+from six import PY2
 
 from dateutil import tz
 from dateutil.parser import (

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
-from six import PY2
 
 from dateutil import tz
 from dateutil.parser import (
@@ -462,13 +461,6 @@ class ParserTest(unittest.TestCase):
                                tzinfos=self.tzinfos),
                          datetime(2003, 9, 25, 10, 36, 28,
                                   tzinfo=self.brsttz))
-
-    def testDateCommandFormatWithLong(self):
-        if PY2:
-            self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
-                                   tzinfos={"BRST": long(-10800)}),
-                             datetime(2003, 9, 25, 10, 36, 28,
-                                      tzinfo=self.brsttz))
 
     def testISOFormatStrip2(self):
         self.assertEqual(parse("2003-09-25T10:49:41+03:00"),

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from ._common import NotAValue
 
 import calendar

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -2317,7 +2317,6 @@ class RRuleTest(unittest.TestCase):
         raise a :exception:`ValueError`.
         """
 
-        # In Python 2.7 you can use a context manager for this.
         def make_bad_rrule():
             list(rrule(MINUTELY, interval=120, byhour=(10, 12, 14, 16),
                  count=2, dtstart=datetime(1997, 9, 2, 9, 0)))
@@ -2329,7 +2328,6 @@ class RRuleTest(unittest.TestCase):
         See :func:`testMinutelyBadComboRRule' for details.
         """
 
-        # In Python 2.7 you can use a context manager for this.
         def make_bad_minute_rrule():
             list(rrule(SECONDLY, interval=360, byminute=(10, 28, 49),
                  count=4, dtstart=datetime(1997, 9, 2, 9, 0)))

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime, date
 import unittest
 from six import PY2
@@ -4876,13 +4873,13 @@ class WeekdayTest(unittest.TestCase):
     def testWeekdayEqualitySubclass(self):
         # Two weekday objects equal if their "weekday" and "n" attributes are
         # available and the same
-        class BasicWeekday(object):
+        class BasicWeekday:
             def __init__(self, weekday):
                 self.weekday = weekday
 
         class BasicNWeekday(BasicWeekday):
             def __init__(self, weekday, n=None):
-                super(BasicNWeekday, self).__init__(weekday)
+                super().__init__(weekday)
                 self.n = n
 
         MO_Basic = BasicWeekday(0)

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -1,6 +1,5 @@
 from datetime import datetime, date
 import unittest
-from six import PY2
 
 from dateutil import tz
 from dateutil.rrule import (
@@ -2279,27 +2278,6 @@ class RRuleTest(unittest.TestCase):
                           datetime(2010, 3, 22, 13, 1),
                           datetime(2010, 3, 22, 14, 1)])
 
-    def testLongIntegers(self):
-        if PY2:  # There are no longs in python3
-            self.assertEqual(list(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 2, 5, 6, 6, 6),
-                              datetime(1998, 2, 12, 6, 6, 6)])
-            self.assertEqual(list(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 1, 5, 9, 0),
-                              datetime(2004, 1, 5, 9, 0)])
-
     def testHourlyBadRRule(self):
         """
         When `byhour` is specified with `freq=HOURLY`, there are certain
@@ -4573,24 +4551,6 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               wkst=SU,
                               dtstart=datetime(1997, 9, 2, 9, 0)))
-
-    def testToStrLongIntegers(self):
-        if PY2:  # There are no longs in python3
-            self._rrulestr_reverse_test(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
-
-            self._rrulestr_reverse_test(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testReplaceIfSet(self):
         rr = rrule(YEARLY,

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -5,7 +5,6 @@ from ._common import ComparesEqual
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from datetime import tzinfo
-from six import PY2
 from io import BytesIO, StringIO
 import unittest
 
@@ -1112,11 +1111,6 @@ def test_gettz_badzone_unicode():
             b"America/New_York",
             ".*should be str, not bytes.*",
             id="bytes on Python 3",
-            marks=[
-                pytest.mark.skipif(
-                    PY2, reason="bytes arguments accepted in Python 2"
-                )
-            ],
         ),
         pytest.param(
             object(),

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from ._common import PicklableMixin
 from ._common import TZEnvContext, TZWinContext
 from ._common import ComparesEqual
@@ -168,7 +166,7 @@ def get_timezone_tuple(dt):
 
 ###
 # Mix-ins
-class context_passthrough(object):
+class context_passthrough:
     def __init__(*args, **kwargs):
         pass
 
@@ -179,7 +177,7 @@ class context_passthrough(object):
         pass
 
 
-class TzFoldMixin(object):
+class TzFoldMixin:
     """ Mix-in class for testing ambiguous times """
     def gettz(self, tzname):
         raise NotImplementedError
@@ -434,11 +432,11 @@ class TzFoldMixin(object):
             self.assertEqual(t0_syd0, t0_syd1)
 
 
-class TzWinFoldMixin(object):
+class TzWinFoldMixin:
     def get_args(self, tzname):
         return (tzname, )
 
-    class context(object):
+    class context:
         def __init__(*args, **kwargs):
             pass
 
@@ -1427,10 +1425,14 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
     def testStrStr(self):
         # Test that tz.tzstr() won't throw an error if given a str instead
         # of a unicode literal.
-        self.assertEqual(datetime(2003, 4, 6, 1, 59,
-                                  tzinfo=tz.tzstr(str("EST5EDT"))).tzname(), "EST")
-        self.assertEqual(datetime(2003, 4, 6, 2, 00,
-                                  tzinfo=tz.tzstr(str("EST5EDT"))).tzname(), "EDT")
+        self.assertEqual(
+            datetime(2003, 4, 6, 1, 59, tzinfo=tz.tzstr("EST5EDT")).tzname(),
+            "EST",
+        )
+        self.assertEqual(
+            datetime(2003, 4, 6, 2, 00, tzinfo=tz.tzstr("EST5EDT")).tzname(),
+            "EDT",
+        )
 
     def testStrInequality(self):
         TZS1 = tz.tzstr('EST5EDT4')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import timedelta, datetime
 
 from dateutil import tz

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py27,
-          py33,
+envlist = py33,
           py34,
           py35,
           py36,

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-import os
 import hashlib
-import json
 import io
-
-from six.moves.urllib import request
-from six.moves.urllib import error as urllib_error
+import json
+import os
+from urllib import error as urllib_error
+from urllib import request
 
 try:
     import dateutil
@@ -22,7 +21,7 @@ METADATA_FILE = "zonefile_metadata.json"
 
 
 def main(metadata_file):
-    with io.open(metadata_file, 'r') as f:
+    with open(metadata_file) as f:
         metadata = json.load(f)
 
     releases_urls = metadata['releases_url']

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 import hashlib
-import io
 import json
 import os
 from urllib import error as urllib_error


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Removes all python 2 and compat code, with some initial help from https://github.com/asottile/pyupgrade.

As per the comment here: https://github.com/dateutil/dateutil/issues/653#issuecomment-1396133222

Other than the initial commit where I committed the changes made automatically by `pyupgrade` (including changes made by the darker pre-commit hook), I've tried to maintain smaller commits to make reviewing a little easier.

Part of https://github.com/dateutil/dateutil/issues/653.

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
