### PR TITLE
Parse hour with hyphen

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -808,7 +808,7 @@ class parser(object):
                             res.tzname = None
 
                 # Check for a numbered timezone
-                elif res.hour is not None and l[i] in ('+', '-'):
+                elif res.hour is not None and l[i] in ('+', '-') and len(l) > i + 1:
                     signal = (-1, 1)[l[i] == '+']
                     len_li = len(l[i + 1])
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -541,6 +541,11 @@ class ParserTest(unittest.TestCase):
             res = parse(s1, fuzzy=True)
         self.assertEqual(res, datetime(1945, 1, 29, 14, 45))
 
+    def testFuzzyDashError(self):
+        r = parse("12:34 -", fuzzy=True)
+        self.assertEqual(r.hour, 12)
+        self.assertEqual(r.minute, 34)
+
     def testRandomFormat24(self):
         self.assertEqual(parse("0:00 PM, PST", default=self.default,
                                ignoretz=True),


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Fix parsing to handle `-` at the end of fuzzy string .  

The logic change looks at the length of the token list before accessing the next value to avoid reading past the end of the list.


<!-- Summary goes here -->

Closes #256 

### Pull Request Checklist
- [x] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
