### PR TITLE
Update readthedocs configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,9 +3,13 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.8
   install:
-    - method: pip
-      path: .
-    - requirements: docs/requirements-docs.txt
+    - method: "pip"
+      path: "."
+    - requirements: "docs/requirements-docs.txt"


### PR DESCRIPTION
## Summary of changes

Read the docs CI configuration was broken, seems like `build.os` is now a required attribute.

While I was in there I also bumped the Python version to 3.11.