### PR TITLE
Drop support for Python 2.7

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "2.7",
           "3.5",
           "3.6",
           "3.7",
@@ -21,24 +20,15 @@ jobs:
           "3.9",
           "3.10",
           "3.11",
-          "pypy-2.7",
           "pypy-3.8",
         ]
         os: [ubuntu-latest, windows-latest, macos-latest]
         exclude:
-          - python-version: "2.7"
-            os: "ubuntu-latest"
-          - python-version: "2.7"
-            os: "windows-latest"
-          - python-version: "2.7"
-            os: "macos-latest"
           - python-version: "3.5"
             os: "ubuntu-latest"
           - python-version: "3.6"
             os: "ubuntu-latest"
         include:
-          - python-version: "2.7"
-            os: "ubuntu-20.04"
           - python-version: "3.5"
             os: "ubuntu-20.04"
           - python-version: "3.6"
@@ -48,19 +38,12 @@ jobs:
       TOXENV: py
     steps:
       - uses: actions/checkout@v3
-      - if: ${{ matrix.python-version == '2.7' }}
-        run: |
-          sudo apt-get install python-is-python2
-          curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
-          python get-pip.py
-        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      - if: ${{ matrix.python-version != '2.7' }}
-        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+      - name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: python -m pip install -U tox six
+        run: python -m pip install -U tox
       - name: Install zic (Windows)
         run: |
           curl https://get.enterprisedb.com/postgresql/postgresql-9.5.21-2-windows-x64-binaries.zip --output $env:GITHUB_WORKSPACE\postgresql9.5.21.zip

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -95,7 +95,7 @@ switch, and thus all their contributions are dual-licensed.
 - Pavel Ponomarev <comrad.awsum@MASKED>
 - Peter Bieringer <pb@MASKED>
 - Pierre Gergondet <pierre.gergondet@MASKED> (gh: @gergondet) **D**
-- Quentin Pradet <quentin@MASKED>
+- Quentin Pradet (gh: @pquentin) **D**
 - Raymond Cha (gh: @weatherpattern) **D**
 - Ridhi Mahajan <ridhikmahajan@MASKED> **D**
 - Robin Henriksson Törnström <gh: @MrRawbin> **D**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,10 +93,10 @@ pip install -r requirements-dev.txt
 
 ## Testing
 
-The best way to test `dateutil` is to run `tox`. By default, `tox` will test against all supported versions of Python installed on your system. To limit the number of tests, run a specific subset of environments. For example, to run only on Python 2.7 and Python 3.6:
+The best way to test `dateutil` is to run `tox`. By default, `tox` will test against all supported versions of Python installed on your system. To limit the number of tests, run a specific subset of environments. For example, to run only on Python 3.6 and Python 3.12:
 
 ```bash
-tox -e py27,py36
+tox -e py36,py12
 ```
 
 You can also pass arguments to `pytest` through `tox` by placing them after `--`:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ install:
 
   # This frequently fails with network errors, so we'll retry it up to 5 times
   # with a 1 minute rate limit.
-  - "%PYTHON% -m pip install six"
   - "ci_tools/retry.bat %PYTHON% updatezinfo.py"
   # This environment variable tells the test suite it's OK to mess with the time zone.
   - set DATEUTIL_MAY_CHANGE_TZ=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,6 @@ pool:
 
 strategy:
   matrix:
-    Python27:
-      python.version: '2.7'
     Python34:
       python.version: '3.4'
     Python35:
@@ -26,14 +24,8 @@ strategy:
       python.version: '3.6'
       POOL_IMAGE: vs2017-win2016
       installzic: 'windows'
-    PyPy:
-      python.version: 'pypy2'
     PyPy3:
       python.version: 'pypy3'
-    WindowsPyPy2:
-      python.version: 'pypy2'
-      POOL_IMAGE: vs2017-win2016
-      installzic: 'windows'
     WindowsPyPy3:
       python.version: 'pypy3'
       POOL_IMAGE: vs2017-win2016
@@ -49,7 +41,7 @@ steps:
     versionSpec: $(python.version)
 
 - bash: |
-    python -m pip install -U six && python -m pip install -U 'tox < 3.8.0'
+    python -m pip install -U 'tox < 3.8.0'
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   displayName: Ensure prereqs

--- a/changelog.d/1344.deprecation.rst
+++ b/changelog.d/1344.deprecation.rst
@@ -1,0 +1,1 @@
+Dropped support for Python 2.7. Fixed by @pquentin.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,7 +188,7 @@ htmlhelp_basename = 'dateutildoc'
 
 # -- Options for autodoc -------------------------------------------------
 
-autodoc_mock_imports = ['ctypes.wintypes', 'six.moves.winreg']
+autodoc_mock_imports = ['ctypes.wintypes']
 
 # Need to mock this out specifically to avoid errors
 import ctypes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -188,9 +188,11 @@ htmlhelp_basename = 'dateutildoc'
 
 # -- Options for autodoc -------------------------------------------------
 
-autodoc_mock_imports = ['ctypes.wintypes']
+autodoc_mock_imports = ["ctypes.wintypes"]
 
 # Need to mock this out specifically to avoid errors
+
+
 import ctypes
 def pointer_mock(*args, **kwargs):
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ known_first_party = ["dateutil"]
 known_third_party=[
     "pytest",
     "hypothesis",
-    "six",
     "freezegun",
     "mock",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-six
 pytest >= 3.0; python_version != '3.3'
 pytest-cov >= 2.0.0
 freezegun ; python_version != '3.3'

--- a/requirements/3.3/constraints.txt
+++ b/requirements/3.3/constraints.txt
@@ -10,6 +10,5 @@ py==1.4.34
 pytest==3.2.5
 pytest-cov==2.5.1
 setuptools==39.2.0
-six==1.12.0
 tox==2.9.1
 virtualenv==15.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
@@ -39,10 +37,9 @@ classifiers =
 [options]
 zip_safe = True
 setup_requires = setuptools_scm
-install_requires = six >= 1.5
 package_dir=
     =src
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*
+python_requires = >=3.3
 packages = find:
 
 [options.packages.find]

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -872,7 +872,7 @@ class parser(object):
         try:
             value = self._to_decimal(value_repr)
         except Exception as e:
-            raise ValueError('Unknown numeric token') from e
+            raise ValueError("Unknown numeric token") from e
 
         len_li = len(value_repr)
 

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -39,9 +39,6 @@ import warnings
 from calendar import monthrange
 from io import StringIO
 
-import six
-from six import integer_types, text_type
-
 from decimal import Decimal
 
 from warnings import warn
@@ -63,7 +60,7 @@ class _timelex(object):
         if isinstance(instream, (bytes, bytearray)):
             instream = instream.decode()
 
-        if isinstance(instream, text_type):
+        if isinstance(instream, str):
             instream = StringIO(instream)
         elif getattr(instream, 'read', None) is None:
             raise TypeError('Parser must be a string or character stream, not '
@@ -192,9 +189,6 @@ class _timelex(object):
             raise StopIteration
 
         return token
-
-    def next(self):
-        return self.__next__()  # Python 2.x support
 
     @classmethod
     def split(cls, s):
@@ -648,7 +642,7 @@ class parser(object):
         try:
             ret = self._build_naive(res, default)
         except ValueError as e:
-            six.raise_from(ParserError(str(e) + ": %s", timestr), e)
+            raise ParserError(str(e) + ": %s", timestr) from e
 
         if not ignoretz:
             ret = self._build_tzaware(ret, res, tzinfos)
@@ -878,7 +872,7 @@ class parser(object):
         try:
             value = self._to_decimal(value_repr)
         except Exception as e:
-            six.raise_from(ValueError('Unknown numeric token'), e)
+            raise ValueError('Unknown numeric token') from e
 
         len_li = len(value_repr)
 
@@ -1147,7 +1141,7 @@ class parser(object):
                 raise ValueError("Converted decimal value is infinite or NaN")
         except Exception as e:
             msg = "Could not convert %s to decimal" % val
-            six.raise_from(ValueError(msg), e)
+            raise ValueError(msg) from e
         else:
             return decimal_value
 
@@ -1165,9 +1159,9 @@ class parser(object):
         # eg tzinfos = {'BRST' : None}
         if isinstance(tzdata, datetime.tzinfo) or tzdata is None:
             tzinfo = tzdata
-        elif isinstance(tzdata, text_type):
+        elif isinstance(tzdata, str):
             tzinfo = tz.tzstr(tzdata)
-        elif isinstance(tzdata, integer_types):
+        elif isinstance(tzdata, int):
             tzinfo = tz.tzoffset(tzname, tzdata)
         else:
             raise TypeError("Offset must be tzinfo subclass, tz string, "

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -14,7 +14,6 @@ from dateutil import tz
 from functools import wraps
 
 import re
-import six
 
 __all__ = ["isoparse", "isoparser"]
 
@@ -26,13 +25,13 @@ def _takes_ascii(f):
         str_in = getattr(str_in, 'read', lambda: str_in)()
 
         # If it's unicode, turn it into bytes, since ISO-8601 only covers ASCII
-        if isinstance(str_in, six.text_type):
+        if isinstance(str_in, str):
             # ASCII is the same in UTF-8
             try:
                 str_in = str_in.encode('ascii')
             except UnicodeEncodeError as e:
                 msg = 'ISO-8601 strings should contain only ASCII characters'
-                six.raise_from(ValueError(msg), e)
+                raise ValueError(msg) from e
 
         return f(self, str_in, *args, **kwargs)
 

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -5,7 +5,6 @@ import calendar
 import operator
 from math import copysign
 
-from six import integer_types
 from warnings import warn
 
 from ._common import weekday
@@ -200,7 +199,7 @@ class relativedelta(object):
                      "This is not a well-defined condition and will raise " +
                      "errors in future versions.", DeprecationWarning)
 
-            if isinstance(weekday, integer_types):
+            if isinstance(weekday, int):
                 self.weekday = weekdays[weekday]
             else:
                 self.weekday = weekday
@@ -489,8 +488,6 @@ class relativedelta(object):
                     self.minute is None and
                     self.second is None and
                     self.microsecond is None)
-    # Compatibility with Python 2.x
-    __nonzero__ = __bool__
 
     def __mul__(self, other):
         try:

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -5,6 +5,7 @@ the recurrence rules documented in the
 `iCalendar RFC <https://tools.ietf.org/html/rfc5545>`_,
 including support for caching of results.
 """
+import _thread
 import calendar
 import datetime
 import heapq
@@ -14,7 +15,6 @@ import sys
 from functools import wraps
 # For warning about deprecation of until and count
 from warnings import warn
-import _thread
 
 from ._common import weekday as weekdaybase
 

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -14,10 +14,7 @@ import sys
 from functools import wraps
 # For warning about deprecation of until and count
 from warnings import warn
-
-from six import advance_iterator, integer_types
-
-from six.moves import _thread, range
+import _thread
 
 from ._common import weekday as weekdaybase
 
@@ -134,7 +131,7 @@ class rrulebase(object):
                     break
                 try:
                     for j in range(10):
-                        cache.append(advance_iterator(gen))
+                        cache.append(next(gen))
                 except StopIteration:
                     self._cache_gen = gen = None
                     self._cache_complete = True
@@ -161,7 +158,7 @@ class rrulebase(object):
             gen = iter(self)
             try:
                 for i in range(item+1):
-                    res = advance_iterator(gen)
+                    res = next(gen)
             except StopIteration:
                 raise IndexError
             return res
@@ -479,14 +476,14 @@ class rrule(rrulebase):
 
         if wkst is None:
             self._wkst = calendar.firstweekday()
-        elif isinstance(wkst, integer_types):
+        elif isinstance(wkst, int):
             self._wkst = wkst
         else:
             self._wkst = wkst.weekday
 
         if bysetpos is None:
             self._bysetpos = None
-        elif isinstance(bysetpos, integer_types):
+        elif isinstance(bysetpos, int):
             if bysetpos == 0 or not (-366 <= bysetpos <= 366):
                 raise ValueError("bysetpos must be between 1 and 366, "
                                  "or between -366 and -1")
@@ -520,7 +517,7 @@ class rrule(rrulebase):
         if bymonth is None:
             self._bymonth = None
         else:
-            if isinstance(bymonth, integer_types):
+            if isinstance(bymonth, int):
                 bymonth = (bymonth,)
 
             self._bymonth = tuple(sorted(set(bymonth)))
@@ -532,7 +529,7 @@ class rrule(rrulebase):
         if byyearday is None:
             self._byyearday = None
         else:
-            if isinstance(byyearday, integer_types):
+            if isinstance(byyearday, int):
                 byyearday = (byyearday,)
 
             self._byyearday = tuple(sorted(set(byyearday)))
@@ -542,7 +539,7 @@ class rrule(rrulebase):
         if byeaster is not None:
             if not easter:
                 from dateutil import easter
-            if isinstance(byeaster, integer_types):
+            if isinstance(byeaster, int):
                 self._byeaster = (byeaster,)
             else:
                 self._byeaster = tuple(sorted(byeaster))
@@ -556,7 +553,7 @@ class rrule(rrulebase):
             self._bymonthday = ()
             self._bynmonthday = ()
         else:
-            if isinstance(bymonthday, integer_types):
+            if isinstance(bymonthday, int):
                 bymonthday = (bymonthday,)
 
             bymonthday = set(bymonthday)            # Ensure it's unique
@@ -573,7 +570,7 @@ class rrule(rrulebase):
         if byweekno is None:
             self._byweekno = None
         else:
-            if isinstance(byweekno, integer_types):
+            if isinstance(byweekno, int):
                 byweekno = (byweekno,)
 
             self._byweekno = tuple(sorted(set(byweekno)))
@@ -588,13 +585,13 @@ class rrule(rrulebase):
             # If it's one of the valid non-sequence types, convert to a
             # single-element sequence before the iterator that builds the
             # byweekday set.
-            if isinstance(byweekday, integer_types) or hasattr(byweekday, "n"):
+            if isinstance(byweekday, int) or hasattr(byweekday, "n"):
                 byweekday = (byweekday,)
 
             self._byweekday = set()
             self._bynweekday = set()
             for wday in byweekday:
-                if isinstance(wday, integer_types):
+                if isinstance(wday, int):
                     self._byweekday.add(wday)
                 elif not wday.n or freq > MONTHLY:
                     self._byweekday.add(wday.weekday)
@@ -629,7 +626,7 @@ class rrule(rrulebase):
             else:
                 self._byhour = None
         else:
-            if isinstance(byhour, integer_types):
+            if isinstance(byhour, int):
                 byhour = (byhour,)
 
             if freq == HOURLY:
@@ -649,7 +646,7 @@ class rrule(rrulebase):
             else:
                 self._byminute = None
         else:
-            if isinstance(byminute, integer_types):
+            if isinstance(byminute, int):
                 byminute = (byminute,)
 
             if freq == MINUTELY:
@@ -669,7 +666,7 @@ class rrule(rrulebase):
             else:
                 self._bysecond = None
         else:
-            if isinstance(bysecond, integer_types):
+            if isinstance(bysecond, int):
                 bysecond = (bysecond,)
 
             self._bysecond = set(bysecond)
@@ -1062,7 +1059,7 @@ class rrule(rrulebase):
         cset = set()
 
         # Support a single byxxx value.
-        if isinstance(byxxx, integer_types):
+        if isinstance(byxxx, int):
             byxxx = (byxxx, )
 
         for num in byxxx:
@@ -1315,7 +1312,7 @@ class rruleset(rrulebase):
     class _genitem(object):
         def __init__(self, genlist, gen):
             try:
-                self.dt = advance_iterator(gen)
+                self.dt = next(gen)
                 genlist.append(self)
             except StopIteration:
                 pass
@@ -1324,7 +1321,7 @@ class rruleset(rrulebase):
 
         def __next__(self):
             try:
-                self.dt = advance_iterator(self.gen)
+                self.dt = next(self.gen)
             except StopIteration:
                 if self.genlist[0] is self:
                     heapq.heappop(self.genlist)
@@ -1400,14 +1397,14 @@ class rruleset(rrulebase):
             if not lastdt or lastdt != ritem.dt:
                 while exlist and exlist[0] < ritem:
                     exitem = exlist[0]
-                    advance_iterator(exitem)
+                    next(exitem)
                     if exlist and exlist[0] is exitem:
                         heapq.heapreplace(exlist, exitem)
                 if not exlist or ritem != exlist[0]:
                     total += 1
                     yield ritem.dt
                 lastdt = ritem.dt
-            advance_iterator(ritem)
+            next(ritem)
             if rlist and rlist[0] is ritem:
                 heapq.heapreplace(rlist, ritem)
         self._len = total

--- a/src/dateutil/tz/_common.py
+++ b/src/dateutil/tz/_common.py
@@ -1,5 +1,3 @@
-from six import PY2
-
 from functools import wraps
 
 from datetime import datetime, timedelta, tzinfo
@@ -7,27 +5,7 @@ from datetime import datetime, timedelta, tzinfo
 
 ZERO = timedelta(0)
 
-__all__ = ['tzname_in_python2', 'enfold']
-
-
-def tzname_in_python2(namefunc):
-    """Change unicode output into bytestrings in Python 2
-
-    tzname() API changed in Python 3. It used to return bytes, but was changed
-    to unicode strings
-    """
-    if PY2:
-        @wraps(namefunc)
-        def adjust_encoding(*args, **kwargs):
-            name = namefunc(*args, **kwargs)
-            if name is not None:
-                name = name.encode()
-
-            return name
-
-        return adjust_encoding
-    else:
-        return namefunc
+__all__ = ['enfold']
 
 
 # The following is adapted from Alexander Belopolsky's tz library
@@ -309,7 +287,6 @@ class tzrangebase(_tzinfo):
         else:
             return ZERO
 
-    @tzname_in_python2
     def tzname(self, dt):
         if self._isdst(dt):
             return self._dst_abbr

--- a/src/dateutil/tz/_common.py
+++ b/src/dateutil/tz/_common.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, tzinfo
 
 ZERO = timedelta(0)
 
-__all__ = ['enfold']
+__all__ = ["enfold"]
 
 
 # The following is adapted from Alexander Belopolsky's tz library

--- a/src/dateutil/tz/_factories.py
+++ b/src/dateutil/tz/_factories.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 import weakref
 from collections import OrderedDict
-
-from six.moves import _thread
+import _thread
 
 
 class _TzSingleton(type):
@@ -41,7 +40,7 @@ class _TzOffsetFactory(_TzFactory):
             instance = cls.__instances.setdefault(key,
                                                   cls.instance(name, offset))
 
-        # This lock may not be necessary in Python 3. See GH issue #901
+        # This lock may not be necessary. See GH issue #901
         with cls._cache_lock:
             cls.__strong_cache[key] = cls.__strong_cache.pop(key, instance)
 
@@ -68,7 +67,7 @@ class _TzStrFactory(_TzFactory):
             instance = cls.__instances.setdefault(key,
                 cls.instance(s, posix_offset))
 
-        # This lock may not be necessary in Python 3. See GH issue #901
+        # This lock may not be necessary. See GH issue #901
         with cls.__cache_lock:
             cls.__strong_cache[key] = cls.__strong_cache.pop(key, instance)
 

--- a/src/dateutil/tz/_factories.py
+++ b/src/dateutil/tz/_factories.py
@@ -1,7 +1,7 @@
-from datetime import timedelta
+import _thread
 import weakref
 from collections import OrderedDict
-import _thread
+from datetime import timedelta
 
 
 class _TzSingleton(type):

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -7,22 +7,19 @@ etc), TZ environment string (in all known formats), given ranges (with help
 from relative deltas), local machine timezone, fixed offset timezone, and UTC
 timezone.
 """
-import datetime
-import struct
-import time
-import sys
-import os
+import _thread
 import bisect
+import datetime
+import os
+import struct
+import sys
+import time
 import weakref
 from collections import OrderedDict
-import _thread
 
-from ._common import _tzinfo
-from ._common import tzrangebase, enfold
-from ._common import _validate_fromutc_inputs
+from ._common import _tzinfo, _validate_fromutc_inputs, enfold, tzrangebase
+from ._factories import _TzOffsetFactory, _TzSingleton, _TzStrFactory
 
-from ._factories import _TzSingleton, _TzOffsetFactory
-from ._factories import _TzStrFactory
 try:
     from .win import tzwin, tzwinlocal
 except ImportError:
@@ -1636,7 +1633,7 @@ def __get_gettz():
                         if tzwin is not None:
                             try:
                                 tz = tzwin(name)
-                            except (WindowsError):
+                            except WindowsError:
                                 tz = None
 
                         if not tz:

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -9,9 +9,7 @@ Attempting to import this module on a non-Windows platform will raise an
 # This code was originally contributed by Jeffrey Harris.
 import datetime
 import struct
-
-from six.moves import winreg
-from six import text_type
+import winreg
 
 try:
     import ctypes
@@ -216,7 +214,7 @@ class tzwin(tzwinbase):
         self._name = name
 
         with winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE) as handle:
-            tzkeyname = text_type("{kn}\\{name}").format(kn=TZKEYNAME, name=name)
+            tzkeyname = str("{kn}\\{name}").format(kn=TZKEYNAME, name=name)
             with winreg.OpenKey(handle, tzkeyname) as tzkey:
                 keydict = valuestodict(tzkey)
 
@@ -282,8 +280,8 @@ class tzwinlocal(tzwinbase):
             self._dst_abbr = keydict["DaylightName"]
 
             try:
-                tzkeyname = text_type('{kn}\\{sn}').format(kn=TZKEYNAME,
-                                                          sn=self._std_abbr)
+                tzkeyname = str('{kn}\\{sn}').format(kn=TZKEYNAME,
+                                                     sn=self._std_abbr)
                 with winreg.OpenKey(handle, tzkeyname) as tzkey:
                     _keydict = valuestodict(tzkey)
                     self._display = _keydict["Display"]

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -280,8 +280,9 @@ class tzwinlocal(tzwinbase):
             self._dst_abbr = keydict["DaylightName"]
 
             try:
-                tzkeyname = str('{kn}\\{sn}').format(kn=TZKEYNAME,
-                                                     sn=self._std_abbr)
+                tzkeyname = "'{kn}\\{sn}'".format(
+                    kn=TZKEYNAME, sn=self._std_abbr
+                )
                 with winreg.OpenKey(handle, tzkeyname) as tzkey:
                     _keydict = valuestodict(tzkey)
                     self._display = _keydict["Display"]

--- a/tests/property/test_isoparse_prop.py
+++ b/tests/property/test_isoparse_prop.py
@@ -20,7 +20,6 @@ def test_timespec_auto(dt, sep):
         # Assume offset has no sub-second components
         assume(dt.utcoffset().total_seconds() % 60 == 0)
 
-    sep = str(sep)          # Python 2.7 requires bytes
     dtstr = dt.isoformat(sep=sep)
     dt_rt = isoparse(dtstr)
 

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 import pytest
-import six
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
@@ -25,10 +24,7 @@ def test_gettz_returns_local(gettz_arg, dt):
         return
 
     dt_act = dt.astimezone(tz.gettz(gettz_arg))
-    if six.PY2:
-        dt_exp = dt.astimezone(tz.tzlocal())
-    else:
-        dt_exp = dt.astimezone()
+    dt_exp = dt.astimezone()
 
     assert dt_act == dt_exp
     assert dt_act.tzname() == dt_exp.tzname()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,5 +1,6 @@
 import sys
 import unittest
+
 import pytest
 
 MODULE_TYPE = type(sys)
@@ -45,7 +46,9 @@ def clean_import():
 def test_lazy_import(clean_import, module):
     """Test that dateutil.[submodule] works for py version > 3.7"""
 
-    import dateutil, importlib
+    import importlib
+
+    import dateutil
 
     if sys.version_info < (3, 7):
         pytest.xfail("Lazy loading does not work for Python < 3.7")
@@ -93,12 +96,8 @@ def test_import_parser_from():
 
 
 def test_import_parser_all():
-    # All interface
-    from dateutil.parser import parse
-    from dateutil.parser import parserinfo
-
-    # Other public classes
-    from dateutil.parser import parser
+    # Interfaces and public classes
+    from dateutil.parser import parse, parser, parserinfo
 
     for var in (parse, parserinfo, parser):
         assert var is not None
@@ -114,7 +113,8 @@ def test_import_relative_delta_from():
 
 def test_import_relative_delta_all():
     from dateutil.relativedelta import relativedelta
-    from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU
+
+    from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU  # isort:skip
 
     for var in (relativedelta, MO, TU, WE, TH, FR, SA, SU):
         assert var is not None
@@ -134,12 +134,11 @@ def test_import_rrule_from():
 
 
 def test_import_rrule_all():
-    from dateutil.rrule import rrule
-    from dateutil.rrule import rruleset
-    from dateutil.rrule import rrulestr
-    from dateutil.rrule import YEARLY, MONTHLY, WEEKLY, DAILY
-    from dateutil.rrule import HOURLY, MINUTELY, SECONDLY
-    from dateutil.rrule import MO, TU, WE, TH, FR, SA, SU
+    from dateutil.rrule import rrule, rruleset, rrulestr
+
+    from dateutil.rrule import YEARLY, MONTHLY, WEEKLY, DAILY  # isort:skip
+    from dateutil.rrule import HOURLY, MINUTELY, SECONDLY  # isort:skip
+    from dateutil.rrule import MO, TU, WE, TH, FR, SA, SU  # isort:skip
 
     rr_all = (rrule, rruleset, rrulestr,
               YEARLY, MONTHLY, WEEKLY, DAILY,
@@ -164,20 +163,22 @@ def test_import_tz_from():
 
 
 def test_import_tz_all():
-    from dateutil.tz import tzutc
-    from dateutil.tz import tzoffset
-    from dateutil.tz import tzlocal
-    from dateutil.tz import tzfile
-    from dateutil.tz import tzrange
-    from dateutil.tz import tzstr
-    from dateutil.tz import tzical
-    from dateutil.tz import gettz
-    from dateutil.tz import tzwin
-    from dateutil.tz import tzwinlocal
-    from dateutil.tz import UTC
-    from dateutil.tz import datetime_ambiguous
-    from dateutil.tz import datetime_exists
-    from dateutil.tz import resolve_imaginary
+    from dateutil.tz import (
+        UTC,
+        datetime_ambiguous,
+        datetime_exists,
+        gettz,
+        resolve_imaginary,
+        tzfile,
+        tzical,
+        tzlocal,
+        tzoffset,
+        tzrange,
+        tzstr,
+        tzutc,
+        tzwin,
+        tzwinlocal,
+    )
 
     tz_all = ["tzutc", "tzoffset", "tzlocal", "tzfile", "tzrange",
               "tzstr", "tzical", "gettz", "datetime_ambiguous",
@@ -202,8 +203,7 @@ def test_import_tz_windows_from():
 
 @pytest.mark.skipif(not HOST_IS_WINDOWS, reason="Requires Windows")
 def test_import_tz_windows_star():
-    from dateutil.tzwin import tzwin
-    from dateutil.tzwin import tzwinlocal
+    from dateutil.tzwin import tzwin, tzwinlocal
 
     tzwin_all = [tzwin, tzwinlocal]
 
@@ -221,9 +221,7 @@ def test_import_zone_info_from():
 
 
 def test_import_zone_info_star():
-    from dateutil.zoneinfo import gettz
-    from dateutil.zoneinfo import gettz_db_metadata
-    from dateutil.zoneinfo import rebuild
+    from dateutil.zoneinfo import gettz, gettz_db_metadata, rebuild
 
     zi_all = (gettz, gettz_db_metadata, rebuild)
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,21 +1,12 @@
 import sys
 import unittest
 import pytest
-import six
 
 MODULE_TYPE = type(sys)
 
 
-# Tests live in datetutil/test which cause a RuntimeWarning for Python2 builds.
-# But since we expect lazy imports tests to fail for Python < 3.7  we'll ignore those
-# warnings with this filter.
-
-if six.PY2:
-    filter_import_warning = pytest.mark.filterwarnings("ignore::RuntimeWarning")
-else:
-
-    def filter_import_warning(f):
-        return f
+def filter_import_warning(f):
+    return f
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -46,7 +46,6 @@ def test_YMD_could_be_day():
 
 ###
 # Test that private interfaces in _parser are deprecated properly
-@pytest.mark.skipif(IS_PY32, reason='pytest.warns not supported on Python 3.2')
 def test_parser_private_warns():
     from dateutil.parser import _timelex, _tzparser
     from dateutil.parser import _parsetz
@@ -61,7 +60,6 @@ def test_parser_private_warns():
         _parsetz('+05:00')
 
 
-@pytest.mark.skipif(IS_PY32, reason='pytest.warns not supported on Python 3.2')
 def test_parser_parser_private_not_warns():
     from dateutil.parser._parser import _timelex, _tzparser
     from dateutil.parser._parser import _parsetz

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -9,7 +9,6 @@ from dateutil.tz import UTC
 from dateutil.parser import isoparser, isoparse
 
 import pytest
-import six
 
 
 def _generate_tzoffsets(limited):
@@ -296,8 +295,7 @@ def test_isoparser_invalid_sep(sep):
         isoparser(sep=sep)
 
 
-# This only fails on Python 3
-@pytest.mark.xfail(not six.PY2, reason="Fails on Python 3 only")
+@pytest.mark.xfail()
 def test_isoparser_byte_sep():
     dt = datetime(2017, 12, 6, 12, 30, 45)
     dt_str = dt.isoformat(sep=str('T'))
@@ -347,9 +345,7 @@ def __make_date_examples():
         date(2016, 2, 1)
     ]
 
-    if not six.PY2:
-        # strftime does not support dates before 1900 in Python 2
-        dates_no_day.append(date(1000, 11, 1))
+    dates_no_day.append(date(1000, 11, 1))
 
     # Only one supported format for dates with no day
     o = zip(dates_no_day, it.repeat('%Y-%m'))
@@ -371,7 +367,7 @@ def __make_date_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_parse_isodate(d, dt_fmt, as_bytes):
     d_str = d.strftime(dt_fmt)
-    if isinstance(d_str, six.text_type) and as_bytes:
+    if isinstance(d_str, str) and as_bytes:
         d_str = d_str.encode('ascii')
     elif isinstance(d_str, bytes) and not as_bytes:
         d_str = d_str.decode('ascii')
@@ -400,10 +396,7 @@ def test_parse_isodate_error_text():
         isoparser().parse_isodate('2014-0423')
 
     # ensure the error message does not contain b' prefixes
-    if six.PY2:
-        expected_error = "String contains unknown ISO components: u'2014-0423'"
-    else:
-        expected_error = "String contains unknown ISO components: '2014-0423'"
+    expected_error = "String contains unknown ISO components: '2014-0423'"
     assert expected_error == str(excinfo.value)
 
 
@@ -458,7 +451,7 @@ def __make_time_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_isotime(time_val, time_fmt, as_bytes):
     tstr = time_val.strftime(time_fmt)
-    if isinstance(tstr, six.text_type) and as_bytes:
+    if isinstance(tstr, str) and as_bytes:
         tstr = tstr.encode('ascii')
     elif isinstance(tstr, bytes) and not as_bytes:
         tstr = tstr.decode('ascii')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,7 +15,6 @@ from dateutil.parser import (
     parse,
     parserinfo,
 )
-
 from dateutil.tz import tzoffset
 
 from ._common import TZEnvContext

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 
 import itertools
 from datetime import datetime, timedelta
@@ -14,7 +13,6 @@ from dateutil.parser import UnknownTimezoneWarning
 
 from ._common import TZEnvContext
 
-from six import assertRaisesRegex, PY2
 from io import StringIO
 
 import pytest
@@ -443,9 +441,6 @@ class ParserTest(unittest.TestCase):
         assert res  == expected
 
     def testParseWithNulls(self):
-        # This relies on the from __future__ import unicode_literals, because
-        # explicitly specifying a unicode literal is a syntax error in Py 3.2
-        # May want to switch to u'...' if we ever drop Python 3.2 support.
         pstring = '\x00\x00August 29, 1924'
 
         assert parse(pstring) == datetime(1924, 8, 29)
@@ -461,13 +456,6 @@ class ParserTest(unittest.TestCase):
                                tzinfos=self.tzinfos),
                          datetime(2003, 9, 25, 10, 36, 28,
                                   tzinfo=self.brsttz))
-
-    def testDateCommandFormatWithLong(self):
-        if PY2:
-            self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
-                                   tzinfos={"BRST": long(-10800)}),
-                             datetime(2003, 9, 25, 10, 36, 28,
-                                      tzinfo=self.brsttz))
 
     def testISOFormatStrip2(self):
         self.assertEqual(parse("2003-09-25T10:49:41+03:00"),
@@ -570,12 +558,12 @@ class ParserTest(unittest.TestCase):
             parse('shouldfail')
 
     def testCorrectErrorOnFuzzyWithTokens(self):
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/32/423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/04 +32423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/0d4', fuzzy_with_tokens=True)
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
+                               parse, '04/04/32/423', fuzzy_with_tokens=True)
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
+                               parse, '04/04/04 +32423', fuzzy_with_tokens=True)
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
+                               parse, '04/04/0d4', fuzzy_with_tokens=True)
 
     def testIncreasingCTime(self):
         # This test will check 200 different years, every month, every day,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,21 +1,24 @@
 # -*- coding: utf-8 -*-
 
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -558,12 +561,27 @@ class ParserTest(unittest.TestCase):
             parse('shouldfail')
 
     def testCorrectErrorOnFuzzyWithTokens(self):
-        self.assertRaisesRegex(ParserError, 'Unknown string format',
-                               parse, '04/04/32/423', fuzzy_with_tokens=True)
-        self.assertRaisesRegex(ParserError, 'Unknown string format',
-                               parse, '04/04/04 +32423', fuzzy_with_tokens=True)
-        self.assertRaisesRegex(ParserError, 'Unknown string format',
-                               parse, '04/04/0d4', fuzzy_with_tokens=True)
+        self.assertRaisesRegex(
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/32/423",
+            fuzzy_with_tokens=True,
+        )
+        self.assertRaisesRegex(
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/04 +32423",
+            fuzzy_with_tokens=True,
+        )
+        self.assertRaisesRegex(
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/0d4",
+            fuzzy_with_tokens=True,
+        )
 
     def testIncreasingCTime(self):
         # This test will check 200 different years, every month, every day,
@@ -602,7 +620,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -615,7 +633,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [("Mo", "Montag"),

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from datetime import datetime, date
 import unittest
-from six import PY2
 
 from dateutil import tz
 from dateutil.rrule import (
@@ -2282,27 +2281,6 @@ class RRuleTest(unittest.TestCase):
                           datetime(2010, 3, 22, 13, 1),
                           datetime(2010, 3, 22, 14, 1)])
 
-    def testLongIntegers(self):
-        if PY2:  # There are no longs in python3
-            self.assertEqual(list(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 2, 5, 6, 6, 6),
-                              datetime(1998, 2, 12, 6, 6, 6)])
-            self.assertEqual(list(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 1, 5, 9, 0),
-                              datetime(2004, 1, 5, 9, 0)])
-
     def testHourlyBadRRule(self):
         """
         When `byhour` is specified with `freq=HOURLY`, there are certain
@@ -2342,29 +2320,22 @@ class RRuleTest(unittest.TestCase):
         raise a :exception:`ValueError`.
         """
 
-        # In Python 2.7 you can use a context manager for this.
-        def make_bad_rrule():
+        with pytest.raises(ValueError):
             list(rrule(MINUTELY, interval=120, byhour=(10, 12, 14, 16),
                  count=2, dtstart=datetime(1997, 9, 2, 9, 0)))
-
-        self.assertRaises(ValueError, make_bad_rrule)
 
     def testSecondlyBadComboRRule(self):
         """
         See :func:`testMinutelyBadComboRRule' for details.
         """
 
-        # In Python 2.7 you can use a context manager for this.
-        def make_bad_minute_rrule():
+        with pytest.raises(ValueError):
             list(rrule(SECONDLY, interval=360, byminute=(10, 28, 49),
                  count=4, dtstart=datetime(1997, 9, 2, 9, 0)))
 
-        def make_bad_hour_rrule():
+        with pytest.raises(ValueError):
             list(rrule(SECONDLY, interval=43200, byhour=(2, 10, 18, 23),
                  count=4, dtstart=datetime(1997, 9, 2, 9, 0)))
-
-        self.assertRaises(ValueError, make_bad_minute_rrule)
-        self.assertRaises(ValueError, make_bad_hour_rrule)
 
     def testBadUntilCountRRule(self):
         """
@@ -4576,24 +4547,6 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               wkst=SU,
                               dtstart=datetime(1997, 9, 2, 9, 0)))
-
-    def testToStrLongIntegers(self):
-        if PY2:  # There are no longs in python3
-            self._rrulestr_reverse_test(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
-
-            self._rrulestr_reverse_test(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testReplaceIfSet(self):
         rr = rrule(YEARLY,

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -7,7 +7,6 @@ from ._common import ComparesEqual
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from datetime import tzinfo
-from six import PY2
 from io import BytesIO, StringIO
 import unittest
 
@@ -1113,12 +1112,7 @@ def test_gettz_badzone_unicode():
         pytest.param(
             b"America/New_York",
             ".*should be str, not bytes.*",
-            id="bytes on Python 3",
-            marks=[
-                pytest.mark.skipif(
-                    PY2, reason="bytes arguments accepted in Python 2"
-                )
-            ],
+            id="bytes",
         ),
         pytest.param(
             object(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py27,
-          py33,
+envlist = py33,
           py34,
           py35,
           py36,
@@ -9,7 +8,6 @@ envlist = py27,
           py39,
           py310,
           py311,
-          pypy,
           pypy3,
           coverage,
           docs

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -3,9 +3,8 @@ import os
 import hashlib
 import json
 import io
-
-from six.moves.urllib import request
-from six.moves.urllib import error as urllib_error
+from urllib import request
+from urllib import error as urllib_error
 
 try:
     import dateutil

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
-import os
 import hashlib
-import json
 import io
-from urllib import request
+import json
+import os
 from urllib import error as urllib_error
+from urllib import request
 
 try:
     import dateutil


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

dateutil 2.9.0 accidentally dropped support for Python<3.6 support because setuptools-scm included a type hint in `_version.py`. This seemed like a good opportunity to remove Python 2.7 support.

 * I've removed six in the process, which has 90% of the downloads of dateutil, suggesting dateutil is currently the main package keeping six popular.
 * I'm happy to include follow-up pull requests for later versions of Python.
 * Should I run pyupgrade, even if this will make the diff more verbose?

Closes #1344 (but the type hint will have to be removed for Python 3.3 to 3.5 for the issue to be really closed).

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
