### PR TITLE
Pin `setuptools_scm` to <8

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,12 @@
+Version 2.9.0.post0 (2024-03-01)
+================================
+
+Bugfixes
+--------
+
+- Pinned ``setuptools_scm`` to ``<8``, which should make the generated ``_version.py`` file compatible with all supported versions of Python.
+
+
 Version 2.9.0 (2024-02-29)
 ==========================
 

--- a/changelog.d/1346.bugfix.rst
+++ b/changelog.d/1346.bugfix.rst
@@ -1,0 +1,1 @@
+Pinned ``setuptools_scm`` to ``<8``, which should make the generated ``_version.py`` file compatible with all supported versions of Python.

--- a/changelog.d/1346.bugfix.rst
+++ b/changelog.d/1346.bugfix.rst
@@ -1,1 +1,0 @@
-Pinned ``setuptools_scm`` to ``<8``, which should make the generated ``_version.py`` file compatible with all supported versions of Python.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools; python_version != '3.3'",
     "setuptools<40.0; python_version == '3.3'",
     "wheel",
-    "setuptools_scm"
+    "setuptools_scm<8.0"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
There are some breaking changes, and this is making it so that the `_version.py` file generated is not compatible with Python 2 anymore. I don't see an obvious or easy way to figure out what version of `setuptools_scm` is in use, so we'll just pin the version for now.

I recommend removing `setuptools_scm` entirely in the future.

Closes #1344 