### PR TITLE
pass .py code over `pyupgrade --py38`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ install:
 
   # This frequently fails with network errors, so we'll retry it up to 5 times
   # with a 1 minute rate limit.
-  - "%PYTHON% -m pip install six"
   - "ci_tools/retry.bat %PYTHON% updatezinfo.py"
   # This environment variable tells the test suite it's OK to mess with the time zone.
   - set DATEUTIL_MAY_CHANGE_TZ=1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ steps:
     versionSpec: $(python.version)
 
 - bash: |
-    python -m pip install -U six && python -m pip install -U 'tox < 3.8.0'
+    python -m pip install -U 'tox < 3.8.0'
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'virtualenv<16.0'; fi
     if [[ $PYTHON_VERSION == "3.3" ]]; then pip install 'setuptools<40.0'; fi
   displayName: Ensure prereqs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # dateutil documentation build configuration file, created by
 # sphinx-quickstart on Thu Nov 20 23:18:41 2014.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ known_first_party = ["dateutil"]
 known_third_party=[
     "pytest",
     "hypothesis",
-    "six",
     "freezegun",
     "mock",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-six
 pytest >= 3.0; python_version != '3.3'
 pytest-cov >= 2.0.0
 freezegun ; python_version != '3.3'

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ classifiers =
 [options]
 zip_safe = True
 setup_requires = setuptools_scm
-install_requires = six >= 1.5
 package_dir=
     =src
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ class Unsupported(TestCommand):
 # Load metadata
 
 def README():
-    with io.open('README.rst', encoding='utf-8') as f:
+    with open('README.rst', encoding='utf-8') as f:
         readme_lines = f.readlines()
 
     # The .. doctest directive is not supported by PyPA

--- a/src/dateutil/__init__.py
+++ b/src/dateutil/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 
 try:
@@ -15,7 +14,7 @@ def __getattr__(name):
     if name in __all__:
         return importlib.import_module("." + name, __name__)
     raise AttributeError(
-        "module {!r} has not attribute {!r}".format(__name__, name)
+        f"module {__name__!r} has not attribute {name!r}"
     )
 
 

--- a/src/dateutil/_common.py
+++ b/src/dateutil/_common.py
@@ -3,7 +3,7 @@ Common code used in multiple modules.
 """
 
 
-class weekday(object):
+class weekday:
     __slots__ = ["weekday", "n"]
 
     def __init__(self, weekday, n=None):

--- a/src/dateutil/easter.py
+++ b/src/dateutil/easter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers a generic Easter computing method for any given year, using
 Western, Orthodox or Julian algorithms.

--- a/src/dateutil/parser/__init__.py
+++ b/src/dateutil/parser/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from ._parser import parse, parser, parserinfo, ParserError
 from ._parser import DEFAULTPARSER, DEFAULTTZPARSER
 from ._parser import UnknownTimezoneWarning
@@ -45,7 +44,7 @@ def __deprecate_private_class(c):
 
         def __init__(self, *args, **kwargs):
             warnings.warn(msg, DeprecationWarning)
-            super(private_class, self).__init__(*args, **kwargs)
+            super().__init__(*args, **kwargs)
 
     private_class.__name__ = c.__name__
 

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers a generic date/time string parser which is able to parse
 most known formats to represent a date and/or time.
@@ -28,7 +27,6 @@ Additional resources about date/time string formats can be found below:
 - `Java SimpleDateFormat Class
   <https://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html>`_
 """
-from __future__ import unicode_literals
 
 import datetime
 import re
@@ -55,7 +53,7 @@ __all__ = ["parse", "parserinfo", "ParserError"]
 # TODO: pandas.core.tools.datetimes imports this explicitly.  Might be worth
 # making public and/or figuring out if there is something we can
 # take off their plate.
-class _timelex(object):
+class _timelex:
     # Fractional seconds are sometimes split by a comma
     _split_decimal = re.compile("([.,])")
 
@@ -63,7 +61,7 @@ class _timelex(object):
         if isinstance(instream, (bytes, bytearray)):
             instream = instream.decode()
 
-        if isinstance(instream, text_type):
+        if isinstance(instream, str):
             instream = StringIO(instream)
         elif getattr(instream, 'read', None) is None:
             raise TypeError('Parser must be a string or character stream, not '
@@ -216,7 +214,7 @@ class _timelex(object):
         return nextchar.isspace()
 
 
-class _resultbase(object):
+class _resultbase:
 
     def __init__(self):
         for attr in self.__slots__:
@@ -227,8 +225,8 @@ class _resultbase(object):
         for attr in self.__slots__:
             value = getattr(self, attr)
             if value is not None:
-                l.append("%s=%s" % (attr, repr(value)))
-        return "%s(%s)" % (classname, ", ".join(l))
+                l.append("{}={}".format(attr, repr(value)))
+        return "{}({})".format(classname, ", ".join(l))
 
     def __len__(self):
         return (sum(getattr(self, attr) is not None
@@ -238,7 +236,7 @@ class _resultbase(object):
         return self._repr(self.__class__.__name__)
 
 
-class parserinfo(object):
+class parserinfo:
     """
     Class which handles what inputs are accepted. Subclass this to customize
     the language and acceptable values for each parameter.
@@ -565,7 +563,7 @@ class _ymd(list):
         return year, month, day
 
 
-class parser(object):
+class parser:
     def __init__(self, info=None):
         self.info = info or parserinfo()
 
@@ -648,7 +646,7 @@ class parser(object):
         try:
             ret = self._build_naive(res, default)
         except ValueError as e:
-            six.raise_from(ParserError(str(e) + ": %s", timestr), e)
+            raise ParserError(str(e) + ": %s", timestr) from e
 
         if not ignoretz:
             ret = self._build_tzaware(ret, res, tzinfos)
@@ -878,7 +876,7 @@ class parser(object):
         try:
             value = self._to_decimal(value_repr)
         except Exception as e:
-            six.raise_from(ValueError('Unknown numeric token'), e)
+            raise ValueError('Unknown numeric token') from e
 
         len_li = len(value_repr)
 
@@ -1147,7 +1145,7 @@ class parser(object):
                 raise ValueError("Converted decimal value is infinite or NaN")
         except Exception as e:
             msg = "Could not convert %s to decimal" % val
-            six.raise_from(ValueError(msg), e)
+            raise ValueError(msg) from e
         else:
             return decimal_value
 
@@ -1165,9 +1163,9 @@ class parser(object):
         # eg tzinfos = {'BRST' : None}
         if isinstance(tzdata, datetime.tzinfo) or tzdata is None:
             tzinfo = tzdata
-        elif isinstance(tzdata, text_type):
+        elif isinstance(tzdata, str):
             tzinfo = tz.tzstr(tzdata)
-        elif isinstance(tzdata, integer_types):
+        elif isinstance(tzdata, int):
             tzinfo = tz.tzoffset(tzname, tzdata)
         else:
             raise TypeError("Offset must be tzinfo subclass, tz string, "
@@ -1368,7 +1366,7 @@ def parse(timestr, parserinfo=None, **kwargs):
         return DEFAULTPARSER.parse(timestr, **kwargs)
 
 
-class _tzparser(object):
+class _tzparser:
 
     class _result(_resultbase):
 
@@ -1598,11 +1596,11 @@ class ParserError(ValueError):
         try:
             return self.args[0] % self.args[1:]
         except (TypeError, IndexError):
-            return super(ParserError, self).__str__()
+            return super().__str__()
 
     def __repr__(self):
         args = ", ".join("'%s'" % arg for arg in self.args)
-        return "%s(%s)" % (self.__class__.__name__, args)
+        return "{}({})".format(self.__class__.__name__, args)
 
 
 class UnknownTimezoneWarning(RuntimeWarning):

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers a parser for ISO-8601 strings
 
@@ -26,20 +25,20 @@ def _takes_ascii(f):
         str_in = getattr(str_in, 'read', lambda: str_in)()
 
         # If it's unicode, turn it into bytes, since ISO-8601 only covers ASCII
-        if isinstance(str_in, six.text_type):
+        if isinstance(str_in, str):
             # ASCII is the same in UTF-8
             try:
                 str_in = str_in.encode('ascii')
             except UnicodeEncodeError as e:
                 msg = 'ISO-8601 strings should contain only ASCII characters'
-                six.raise_from(ValueError(msg), e)
+                raise ValueError(msg) from e
 
         return f(self, str_in, *args, **kwargs)
 
     return func
 
 
-class isoparser(object):
+class isoparser:
     def __init__(self, sep=None):
         """
         :param sep:
@@ -287,7 +286,7 @@ class isoparser(object):
 
             if ordinal_day < 1 or ordinal_day > (365 + calendar.isleap(year)):
                 raise ValueError('Invalid ordinal day' +
-                                 ' {} for year {}'.format(ordinal_day, year))
+                                 f' {ordinal_day} for year {year}')
 
             base_date = date(year, 1, 1) + timedelta(days=ordinal_day - 1)
 
@@ -314,10 +313,10 @@ class isoparser(object):
             Returns a :class:`datetime.date`
         """
         if not 0 < week < 54:
-            raise ValueError('Invalid week: {}'.format(week))
+            raise ValueError(f'Invalid week: {week}')
 
         if not 0 < day < 8:     # Range is 1-7
-            raise ValueError('Invalid weekday: {}'.format(day))
+            raise ValueError(f'Invalid weekday: {day}')
 
         # Get week 1 for the specific year:
         jan_4 = date(year, 1, 4)   # Week 1 always has January 4th in it

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import calendar
 
@@ -15,7 +14,7 @@ MO, TU, WE, TH, FR, SA, SU = weekdays = tuple(weekday(x) for x in range(7))
 __all__ = ["relativedelta", "MO", "TU", "WE", "TH", "FR", "SA", "SU"]
 
 
-class relativedelta(object):
+class relativedelta:
     """
     The relativedelta type is designed to be applied to an existing datetime and
     can replace specific components of that datetime, or represents an interval
@@ -200,7 +199,7 @@ class relativedelta(object):
                      "This is not a well-defined condition and will raise " +
                      "errors in future versions.", DeprecationWarning)
 
-            if isinstance(weekday, integer_types):
+            if isinstance(weekday, int):
                 self.weekday = weekdays[weekday]
             else:
                 self.weekday = weekday
@@ -583,12 +582,12 @@ class relativedelta(object):
                      "hours", "minutes", "seconds", "microseconds"]:
             value = getattr(self, attr)
             if value:
-                l.append("{attr}={value:+g}".format(attr=attr, value=value))
+                l.append(f"{attr}={value:+g}")
         for attr in ["year", "month", "day", "weekday",
                      "hour", "minute", "second", "microsecond"]:
             value = getattr(self, attr)
             if value is not None:
-                l.append("{attr}={value}".format(attr=attr, value=repr(value)))
+                l.append(f"{attr}={repr(value)}")
         return "{classname}({attrs})".format(classname=self.__class__.__name__,
                                              attrs=", ".join(l))
 

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 The rrule module offers a small, complete, and very fast, implementation of
 the recurrence rules documented in the
@@ -17,7 +16,7 @@ from warnings import warn
 
 from six import advance_iterator, integer_types
 
-from six.moves import _thread, range
+import _thread
 
 from ._common import weekday as weekdaybase
 
@@ -71,7 +70,7 @@ class weekday(weekdaybase):
         if n == 0:
             raise ValueError("Can't create weekday with n==0")
 
-        super(weekday, self).__init__(wkday, n)
+        super().__init__(wkday, n)
 
 
 MO, TU, WE, TH, FR, SA, SU = weekdays = tuple(weekday(x) for x in range(7))
@@ -91,7 +90,7 @@ def _invalidates_cache(f):
     return inner_func
 
 
-class rrulebase(object):
+class rrulebase:
     def __init__(self, cache=False):
         if cache:
             self._cache = []
@@ -134,7 +133,7 @@ class rrulebase(object):
                     break
                 try:
                     for j in range(10):
-                        cache.append(advance_iterator(gen))
+                        cache.append(next(gen))
                 except StopIteration:
                     self._cache_gen = gen = None
                     self._cache_complete = True
@@ -161,7 +160,7 @@ class rrulebase(object):
             gen = iter(self)
             try:
                 for i in range(item+1):
-                    res = advance_iterator(gen)
+                    res = next(gen)
             except StopIteration:
                 raise IndexError
             return res
@@ -431,7 +430,7 @@ class rrule(rrulebase):
                  byweekno=None, byweekday=None,
                  byhour=None, byminute=None, bysecond=None,
                  cache=False):
-        super(rrule, self).__init__(cache)
+        super().__init__(cache)
         global easter
         if not dtstart:
             if until and until.tzinfo:
@@ -479,14 +478,14 @@ class rrule(rrulebase):
 
         if wkst is None:
             self._wkst = calendar.firstweekday()
-        elif isinstance(wkst, integer_types):
+        elif isinstance(wkst, int):
             self._wkst = wkst
         else:
             self._wkst = wkst.weekday
 
         if bysetpos is None:
             self._bysetpos = None
-        elif isinstance(bysetpos, integer_types):
+        elif isinstance(bysetpos, int):
             if bysetpos == 0 or not (-366 <= bysetpos <= 366):
                 raise ValueError("bysetpos must be between 1 and 366, "
                                  "or between -366 and -1")
@@ -520,7 +519,7 @@ class rrule(rrulebase):
         if bymonth is None:
             self._bymonth = None
         else:
-            if isinstance(bymonth, integer_types):
+            if isinstance(bymonth, int):
                 bymonth = (bymonth,)
 
             self._bymonth = tuple(sorted(set(bymonth)))
@@ -532,7 +531,7 @@ class rrule(rrulebase):
         if byyearday is None:
             self._byyearday = None
         else:
-            if isinstance(byyearday, integer_types):
+            if isinstance(byyearday, int):
                 byyearday = (byyearday,)
 
             self._byyearday = tuple(sorted(set(byyearday)))
@@ -542,7 +541,7 @@ class rrule(rrulebase):
         if byeaster is not None:
             if not easter:
                 from dateutil import easter
-            if isinstance(byeaster, integer_types):
+            if isinstance(byeaster, int):
                 self._byeaster = (byeaster,)
             else:
                 self._byeaster = tuple(sorted(byeaster))
@@ -556,7 +555,7 @@ class rrule(rrulebase):
             self._bymonthday = ()
             self._bynmonthday = ()
         else:
-            if isinstance(bymonthday, integer_types):
+            if isinstance(bymonthday, int):
                 bymonthday = (bymonthday,)
 
             bymonthday = set(bymonthday)            # Ensure it's unique
@@ -573,7 +572,7 @@ class rrule(rrulebase):
         if byweekno is None:
             self._byweekno = None
         else:
-            if isinstance(byweekno, integer_types):
+            if isinstance(byweekno, int):
                 byweekno = (byweekno,)
 
             self._byweekno = tuple(sorted(set(byweekno)))
@@ -588,13 +587,13 @@ class rrule(rrulebase):
             # If it's one of the valid non-sequence types, convert to a
             # single-element sequence before the iterator that builds the
             # byweekday set.
-            if isinstance(byweekday, integer_types) or hasattr(byweekday, "n"):
+            if isinstance(byweekday, int) or hasattr(byweekday, "n"):
                 byweekday = (byweekday,)
 
             self._byweekday = set()
             self._bynweekday = set()
             for wday in byweekday:
-                if isinstance(wday, integer_types):
+                if isinstance(wday, int):
                     self._byweekday.add(wday)
                 elif not wday.n or freq > MONTHLY:
                     self._byweekday.add(wday.weekday)
@@ -629,7 +628,7 @@ class rrule(rrulebase):
             else:
                 self._byhour = None
         else:
-            if isinstance(byhour, integer_types):
+            if isinstance(byhour, int):
                 byhour = (byhour,)
 
             if freq == HOURLY:
@@ -649,7 +648,7 @@ class rrule(rrulebase):
             else:
                 self._byminute = None
         else:
-            if isinstance(byminute, integer_types):
+            if isinstance(byminute, int):
                 byminute = (byminute,)
 
             if freq == MINUTELY:
@@ -669,7 +668,7 @@ class rrule(rrulebase):
             else:
                 self._bysecond = None
         else:
-            if isinstance(bysecond, integer_types):
+            if isinstance(bysecond, int):
                 bysecond = (bysecond,)
 
             self._bysecond = set(bysecond)
@@ -1062,7 +1061,7 @@ class rrule(rrulebase):
         cset = set()
 
         # Support a single byxxx value.
-        if isinstance(byxxx, integer_types):
+        if isinstance(byxxx, int):
             byxxx = (byxxx, )
 
         for num in byxxx:
@@ -1109,7 +1108,7 @@ class rrule(rrulebase):
                 return (accumulator, value)
 
 
-class _iterinfo(object):
+class _iterinfo:
     __slots__ = ["rrule", "lastyear", "lastmonth",
                  "yearlen", "nextyearlen", "yearordinal", "yearweekday",
                  "mmask", "mrange", "mdaymask", "nmdaymask",
@@ -1312,10 +1311,10 @@ class rruleset(rrulebase):
     :param cache: If True, caching of results will be enabled, improving
                   performance of multiple queries considerably. """
 
-    class _genitem(object):
+    class _genitem:
         def __init__(self, genlist, gen):
             try:
-                self.dt = advance_iterator(gen)
+                self.dt = next(gen)
                 genlist.append(self)
             except StopIteration:
                 pass
@@ -1324,7 +1323,7 @@ class rruleset(rrulebase):
 
         def __next__(self):
             try:
-                self.dt = advance_iterator(self.gen)
+                self.dt = next(self.gen)
             except StopIteration:
                 if self.genlist[0] is self:
                     heapq.heappop(self.genlist)
@@ -1347,7 +1346,7 @@ class rruleset(rrulebase):
             return self.dt != other.dt
 
     def __init__(self, cache=False):
-        super(rruleset, self).__init__(cache)
+        super().__init__(cache)
         self._rrule = []
         self._rdate = []
         self._exrule = []
@@ -1400,14 +1399,14 @@ class rruleset(rrulebase):
             if not lastdt or lastdt != ritem.dt:
                 while exlist and exlist[0] < ritem:
                     exitem = exlist[0]
-                    advance_iterator(exitem)
+                    next(exitem)
                     if exlist and exlist[0] is exitem:
                         heapq.heapreplace(exlist, exitem)
                 if not exlist or ritem != exlist[0]:
                     total += 1
                     yield ritem.dt
                 lastdt = ritem.dt
-            advance_iterator(ritem)
+            next(ritem)
             if rlist and rlist[0] is ritem:
                 heapq.heapreplace(rlist, ritem)
         self._len = total
@@ -1415,7 +1414,7 @@ class rruleset(rrulebase):
 
 
 
-class _rrulestr(object):
+class _rrulestr:
     """ Parses a string representation of a recurrence rule or set of
     recurrence rules.
 
@@ -1557,7 +1556,7 @@ class _rrulestr(object):
             except AttributeError:
                 raise ValueError("unknown parameter '%s'" % name)
             except (KeyError, ValueError):
-                raise ValueError("invalid '%s': %s" % (name, value))
+                raise ValueError("invalid '{}': {}".format(name, value))
         return rrule(dtstart=dtstart, cache=cache, **rrkwargs)
 
     def _parse_date_value(self, date_value, parms, rule_tzids,

--- a/src/dateutil/tz/__init__.py
+++ b/src/dateutil/tz/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from .tz import *
 from .tz import __doc__
 

--- a/src/dateutil/tz/_common.py
+++ b/src/dateutil/tz/_common.py
@@ -16,18 +16,7 @@ def tzname_in_python2(namefunc):
     tzname() API changed in Python 3. It used to return bytes, but was changed
     to unicode strings
     """
-    if PY2:
-        @wraps(namefunc)
-        def adjust_encoding(*args, **kwargs):
-            name = namefunc(*args, **kwargs)
-            if name is not None:
-                name = name.encode()
-
-            return name
-
-        return adjust_encoding
-    else:
-        return namefunc
+    return namefunc
 
 
 # The following is adapted from Alexander Belopolsky's tz library
@@ -83,7 +72,7 @@ else:
 
             for arg, argname in zip(args, argnames):
                 if argname in kwargs:
-                    raise TypeError('Duplicate argument: {}'.format(argname))
+                    raise TypeError(f'Duplicate argument: {argname}')
 
                 kwargs[argname] = arg
 

--- a/src/dateutil/tz/_factories.py
+++ b/src/dateutil/tz/_factories.py
@@ -2,17 +2,17 @@ from datetime import timedelta
 import weakref
 from collections import OrderedDict
 
-from six.moves import _thread
+import _thread
 
 
 class _TzSingleton(type):
     def __init__(cls, *args, **kwargs):
         cls.__instance = None
-        super(_TzSingleton, cls).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __call__(cls):
         if cls.__instance is None:
-            cls.__instance = super(_TzSingleton, cls).__call__()
+            cls.__instance = super().__call__()
         return cls.__instance
 
 

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module offers timezone implementations subclassing the abstract
 :py:class:`datetime.tzinfo` type. There are classes to handle tzfile format
@@ -18,7 +17,7 @@ from collections import OrderedDict
 
 import six
 from six import string_types
-from six.moves import _thread
+import _thread
 from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs
@@ -38,8 +37,7 @@ EPOCH = datetime.datetime(1970, 1, 1, 0, 0)
 EPOCHORDINAL = EPOCH.toordinal()
 
 
-@six.add_metaclass(_TzSingleton)
-class tzutc(datetime.tzinfo):
+class tzutc(datetime.tzinfo, metaclass=_TzSingleton):
     """
     This is a tzinfo object that represents the UTC time zone.
 
@@ -129,8 +127,7 @@ class tzutc(datetime.tzinfo):
 UTC = tzutc()
 
 
-@six.add_metaclass(_TzOffsetFactory)
-class tzoffset(datetime.tzinfo):
+class tzoffset(datetime.tzinfo, metaclass=_TzOffsetFactory):
     """
     A simple class for representing a fixed offset from UTC.
 
@@ -191,7 +188,7 @@ class tzoffset(datetime.tzinfo):
         return not (self == other)
 
     def __repr__(self):
-        return "%s(%s, %s)" % (self.__class__.__name__,
+        return "{}({}, {})".format(self.__class__.__name__,
                                repr(self._name),
                                int(self._offset.total_seconds()))
 
@@ -203,7 +200,7 @@ class tzlocal(_tzinfo):
     A :class:`tzinfo` subclass built around the ``time`` timezone functions.
     """
     def __init__(self):
-        super(tzlocal, self).__init__()
+        super().__init__()
 
         self._std_offset = datetime.timedelta(seconds=-time.timezone)
         if time.daylight:
@@ -325,7 +322,7 @@ class tzlocal(_tzinfo):
     __reduce__ = object.__reduce__
 
 
-class _ttinfo(object):
+class _ttinfo:
     __slots__ = ["offset", "delta", "isdst", "abbr",
                  "isstd", "isgmt", "dstoffset"]
 
@@ -338,8 +335,8 @@ class _ttinfo(object):
         for attr in self.__slots__:
             value = getattr(self, attr)
             if value is not None:
-                l.append("%s=%s" % (attr, repr(value)))
-        return "%s(%s)" % (self.__class__.__name__, ", ".join(l))
+                l.append("{}={}".format(attr, repr(value)))
+        return "{}({})".format(self.__class__.__name__, ", ".join(l))
 
     def __eq__(self, other):
         if not isinstance(other, _ttinfo):
@@ -370,7 +367,7 @@ class _ttinfo(object):
                 setattr(self, name, state[name])
 
 
-class _tzfile(object):
+class _tzfile:
     """
     Lightweight class for holding the relevant transition and time zone
     information read from binary tzfiles.
@@ -456,10 +453,10 @@ class tzfile(_tzinfo):
     """
 
     def __init__(self, fileobj, filename=None):
-        super(tzfile, self).__init__()
+        super().__init__()
 
         file_opened_here = False
-        if isinstance(fileobj, string_types):
+        if isinstance(fileobj, str):
             self._filename = fileobj
             fileobj = open(fileobj, 'rb')
             file_opened_here = True
@@ -862,7 +859,7 @@ class tzfile(_tzinfo):
         return not (self == other)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._filename))
+        return "{}({})".format(self.__class__.__name__, repr(self._filename))
 
     def __reduce__(self):
         return self.__reduce_ex__(None)
@@ -1033,8 +1030,7 @@ class tzrange(tzrangebase):
         return self._dst_base_offset_
 
 
-@six.add_metaclass(_TzStrFactory)
-class tzstr(tzrange):
+class tzstr(tzrange, metaclass=_TzStrFactory):
     """
     ``tzstr`` objects are time zone objects specified by a time-zone string as
     it would be passed to a ``TZ`` variable on POSIX-style systems (see
@@ -1150,10 +1146,10 @@ class tzstr(tzrange):
         return relativedelta.relativedelta(**kwargs)
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._s))
+        return "{}({})".format(self.__class__.__name__, repr(self._s))
 
 
-class _tzicalvtzcomp(object):
+class _tzicalvtzcomp:
     def __init__(self, tzoffsetfrom, tzoffsetto, isdst,
                  tzname=None, rrule=None):
         self.tzoffsetfrom = datetime.timedelta(seconds=tzoffsetfrom)
@@ -1166,7 +1162,7 @@ class _tzicalvtzcomp(object):
 
 class _tzicalvtz(_tzinfo):
     def __init__(self, tzid, comps=[]):
-        super(_tzicalvtz, self).__init__()
+        super().__init__()
 
         self._tzid = tzid
         self._comps = comps
@@ -1250,7 +1246,7 @@ class _tzicalvtz(_tzinfo):
     __reduce__ = object.__reduce__
 
 
-class tzical(object):
+class tzical:
     """
     This object is designed to parse an iCalendar-style ``VTIMEZONE`` structure
     as set out in `RFC 5545`_ Section 4.6.5 into one or more `tzinfo` objects.
@@ -1265,10 +1261,10 @@ class tzical(object):
         global rrule
         from dateutil import rrule
 
-        if isinstance(fileobj, string_types):
+        if isinstance(fileobj, str):
             self._s = fileobj
             # ical should be encoded in UTF-8 with CRLF
-            fileobj = open(fileobj, 'r')
+            fileobj = open(fileobj)
         else:
             self._s = getattr(fileobj, 'name', repr(fileobj))
             fileobj = _nullcontext(fileobj)
@@ -1421,7 +1417,7 @@ class tzical(object):
                     elif name == "TZOFFSETFROM":
                         if parms:
                             raise ValueError(
-                                "unsupported %s parm: %s " % (name, parms[0]))
+                                "unsupported {} parm: {} ".format(name, parms[0]))
                         tzoffsetfrom = self._parse_offset(value)
                     elif name == "TZOFFSETTO":
                         if parms:
@@ -1453,7 +1449,7 @@ class tzical(object):
                 invtz = True
 
     def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, repr(self._s))
+        return "{}({})".format(self.__class__.__name__, repr(self._s))
 
 
 if sys.platform != "win32":
@@ -1472,7 +1468,7 @@ def __get_gettz():
     if tzwinlocal is not None:
         tzlocal_classes += (tzwinlocal,)
 
-    class GettzFunc(object):
+    class GettzFunc:
         """
         Retrieve a time zone object from a string representation
 
@@ -1610,7 +1606,7 @@ def __get_gettz():
                         try:
                             tz = tzfile(filepath)
                             break
-                        except (IOError, OSError, ValueError):
+                        except (OSError, ValueError):
                             pass
                 else:
                     tz = tzlocal()
@@ -1621,7 +1617,7 @@ def __get_gettz():
                 except TypeError as e:
                     if isinstance(name, bytes):
                         new_msg = "gettz argument should be str, not bytes"
-                        six.raise_from(TypeError(new_msg), e)
+                        raise TypeError(new_msg) from e
                     else:
                         raise
                 if os.path.isabs(name):
@@ -1639,14 +1635,14 @@ def __get_gettz():
                         try:
                             tz = tzfile(filepath)
                             break
-                        except (IOError, OSError, ValueError):
+                        except (OSError, ValueError):
                             pass
                     else:
                         tz = None
                         if tzwin is not None:
                             try:
                                 tz = tzwin(name)
-                            except (WindowsError, UnicodeEncodeError):
+                            except (OSError, UnicodeEncodeError):
                                 # UnicodeEncodeError is for Python 2.7 compat
                                 tz = None
 
@@ -1814,25 +1810,15 @@ def _datetime_to_timestamp(dt):
     return (dt.replace(tzinfo=None) - EPOCH).total_seconds()
 
 
-if sys.version_info >= (3, 6):
-    def _get_supported_offset(second_offset):
-        return second_offset
-else:
-    def _get_supported_offset(second_offset):
-        # For python pre-3.6, round to full-minutes if that's not the case.
-        # Python's datetime doesn't accept sub-minute timezones. Check
-        # http://python.org/sf/1447945 or https://bugs.python.org/issue5288
-        # for some information.
-        old_offset = second_offset
-        calculated_offset = 60 * ((second_offset + 30) // 60)
-        return calculated_offset
+def _get_supported_offset(second_offset):
+    return second_offset
 
 
 try:
     # Python 3.7 feature
     from contextlib import nullcontext as _nullcontext
 except ImportError:
-    class _nullcontext(object):
+    class _nullcontext:
         """
         Class for wrapping contexts so that they are passed through in a
         with statement.

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module provides an interface to the native time zone data on Windows,
 including :py:class:`datetime.tzinfo` implementations.
@@ -36,7 +35,7 @@ def _settzkeyname():
     try:
         winreg.OpenKey(handle, TZKEYNAMENT).Close()
         TZKEYNAME = TZKEYNAMENT
-    except WindowsError:
+    except OSError:
         TZKEYNAME = TZKEYNAME9X
     handle.Close()
     return TZKEYNAME
@@ -45,7 +44,7 @@ def _settzkeyname():
 TZKEYNAME = _settzkeyname()
 
 
-class tzres(object):
+class tzres:
     """
     Class for accessing ``tzres.dll``, which contains timezone name related
     resources.
@@ -216,7 +215,7 @@ class tzwin(tzwinbase):
         self._name = name
 
         with winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE) as handle:
-            tzkeyname = text_type("{kn}\\{name}").format(kn=TZKEYNAME, name=name)
+            tzkeyname = "{kn}\\{name}".format(kn=TZKEYNAME, name=name)
             with winreg.OpenKey(handle, tzkeyname) as tzkey:
                 keydict = valuestodict(tzkey)
 
@@ -282,7 +281,7 @@ class tzwinlocal(tzwinbase):
             self._dst_abbr = keydict["DaylightName"]
 
             try:
-                tzkeyname = text_type('{kn}\\{sn}').format(kn=TZKEYNAME,
+                tzkeyname = '{kn}\\{sn}'.format(kn=TZKEYNAME,
                                                           sn=self._std_abbr)
                 with winreg.OpenKey(handle, tzkeyname) as tzkey:
                     _keydict = valuestodict(tzkey)

--- a/src/dateutil/utils.py
+++ b/src/dateutil/utils.py
@@ -1,11 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 This module offers general convenience and utility functions for dealing with
 datetimes.
 
 .. versionadded:: 2.7.0
 """
-from __future__ import unicode_literals
 
 from datetime import datetime, time
 

--- a/src/dateutil/zoneinfo/__init__.py
+++ b/src/dateutil/zoneinfo/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import warnings
 import json
 
@@ -22,12 +21,12 @@ class tzfile(_tzfile):
 def getzoneinfofile_stream():
     try:
         return BytesIO(get_data(__name__, ZONEFILENAME))
-    except IOError as e:  # TODO  switch to FileNotFoundError?
-        warnings.warn("I/O error({0}): {1}".format(e.errno, e.strerror))
+    except OSError as e:  # TODO  switch to FileNotFoundError?
+        warnings.warn(f"I/O error({e.errno}): {e.strerror}")
         return None
 
 
-class ZoneInfoFile(object):
+class ZoneInfoFile:
     def __init__(self, zonefile_stream=None):
         if zonefile_stream is not None:
             with TarFile.open(fileobj=zonefile_stream) as tf:

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 import os
 import time
 import subprocess
@@ -9,7 +8,7 @@ import pickle
 import pytest
 
 
-class PicklableMixin(object):
+class PicklableMixin:
     def _get_nobj_bytes(self, obj, dump_kwargs, load_kwargs):
         """
         Pickle and unpickle an object using ``pickle.dumps`` / ``pickle.loads``
@@ -46,7 +45,7 @@ class PicklableMixin(object):
         self.assertEqual(obj, nobj)
 
 
-class TZContextBase(object):
+class TZContextBase:
     """
     Base class for a context manager which allows changing of time zones.
 
@@ -164,7 +163,7 @@ class TZWinContext(TZContextBase):
 
 ###
 # Utility classes
-class NotAValueClass(object):
+class NotAValueClass:
     """
     A class analogous to NaN that has operations defined for any type.
     """
@@ -191,7 +190,7 @@ class NotAValueClass(object):
 NotAValue = NotAValueClass()
 
 
-class ComparesEqualClass(object):
+class ComparesEqualClass:
     """
     A class that is always equal to whatever you compare it to.
     """
@@ -225,7 +224,7 @@ class ComparesEqualClass(object):
 ComparesEqual = ComparesEqualClass()
 
 
-class UnsetTzClass(object):
+class UnsetTzClass:
     """ Sentinel class for unset time zone variable """
     pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def set_tzpath():
 
     path_components = tzpath.split(':')
 
-    print("Setting TZPATH to {}".format(path_components))
+    print(f"Setting TZPATH to {path_components}")
 
     from dateutil import tz
     tz.TZPATHS.clear()

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -25,10 +25,7 @@ def test_gettz_returns_local(gettz_arg, dt):
         return
 
     dt_act = dt.astimezone(tz.gettz(gettz_arg))
-    if six.PY2:
-        dt_exp = dt.astimezone(tz.tzlocal())
-    else:
-        dt_exp = dt.astimezone()
+    dt_exp = dt.astimezone()
 
     assert dt_act == dt_exp
     assert dt_act.tzname() == dt_exp.tzname()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -10,12 +10,9 @@ MODULE_TYPE = type(sys)
 # But since we expect lazy imports tests to fail for Python < 3.7  we'll ignore those
 # warnings with this filter.
 
-if six.PY2:
-    filter_import_warning = pytest.mark.filterwarnings("ignore::RuntimeWarning")
-else:
 
-    def filter_import_warning(f):
-        return f
+def filter_import_warning(f):
+    return f
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for implementation details, not necessarily part of the user-facing
 API.

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime, timedelta, date, time
 import itertools as it
 
@@ -300,7 +297,7 @@ def test_isoparser_invalid_sep(sep):
 @pytest.mark.xfail(not six.PY2, reason="Fails on Python 3 only")
 def test_isoparser_byte_sep():
     dt = datetime(2017, 12, 6, 12, 30, 45)
-    dt_str = dt.isoformat(sep=str('T'))
+    dt_str = dt.isoformat(sep='T')
 
     dt_rt = isoparser(sep=b'T').isoparse(dt_str)
 
@@ -347,9 +344,8 @@ def __make_date_examples():
         date(2016, 2, 1)
     ]
 
-    if not six.PY2:
-        # strftime does not support dates before 1900 in Python 2
-        dates_no_day.append(date(1000, 11, 1))
+    # strftime does not support dates before 1900 in Python 2
+    dates_no_day.append(date(1000, 11, 1))
 
     # Only one supported format for dates with no day
     o = zip(dates_no_day, it.repeat('%Y-%m'))
@@ -371,7 +367,7 @@ def __make_date_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_parse_isodate(d, dt_fmt, as_bytes):
     d_str = d.strftime(dt_fmt)
-    if isinstance(d_str, six.text_type) and as_bytes:
+    if isinstance(d_str, str) and as_bytes:
         d_str = d_str.encode('ascii')
     elif isinstance(d_str, bytes) and not as_bytes:
         d_str = d_str.decode('ascii')
@@ -400,10 +396,7 @@ def test_parse_isodate_error_text():
         isoparser().parse_isodate('2014-0423')
 
     # ensure the error message does not contain b' prefixes
-    if six.PY2:
-        expected_error = "String contains unknown ISO components: u'2014-0423'"
-    else:
-        expected_error = "String contains unknown ISO components: '2014-0423'"
+    expected_error = "String contains unknown ISO components: '2014-0423'"
     assert expected_error == str(excinfo.value)
 
 
@@ -458,7 +451,7 @@ def __make_time_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_isotime(time_val, time_fmt, as_bytes):
     tstr = time_val.strftime(time_fmt)
-    if isinstance(tstr, six.text_type) and as_bytes:
+    if isinstance(tstr, str) and as_bytes:
         tstr = tstr.encode('ascii')
     elif isinstance(tstr, bytes) and not as_bytes:
         tstr = tstr.decode('ascii')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import itertools
 from datetime import datetime, timedelta
 import unittest
@@ -102,7 +99,7 @@ PARSER_TEST_CASES = [
     ("2016-12-21 04.2h", datetime(2016, 12, 21, 4, 12), "Fractional Hours"),
 ]
 # Check that we don't have any duplicates
-assert len(set([x[0] for x in PARSER_TEST_CASES])) == len(PARSER_TEST_CASES)
+assert len({x[0] for x in PARSER_TEST_CASES}) == len(PARSER_TEST_CASES)
 
 
 @pytest.mark.parametrize("parsable_text,expected_datetime,assertion_message", PARSER_TEST_CASES)
@@ -159,7 +156,7 @@ PARSER_DEFAULT_TEST_CASES = [
     ("2004 10 Apr 11h30m", datetime(2004, 4, 10, 11, 30), "random format")
 ]
 # Check that we don't have any duplicates
-assert len(set([x[0] for x in PARSER_DEFAULT_TEST_CASES])) == len(PARSER_DEFAULT_TEST_CASES)
+assert len({x[0] for x in PARSER_DEFAULT_TEST_CASES}) == len(PARSER_DEFAULT_TEST_CASES)
 
 
 @pytest.mark.parametrize("parsable_text,expected_datetime,assertion_message", PARSER_DEFAULT_TEST_CASES)
@@ -223,7 +220,7 @@ def test_parse_with_tzoffset(dstr, expected):
     assert result == expected
 
 
-class TestFormat(object):
+class TestFormat:
 
     def test_ybd(self):
         # If we have a 4-digit year, a non-numeric month (abbreviated or not),
@@ -291,7 +288,7 @@ class TestFormat(object):
         assert res == expected
 
 
-class TestInputTypes(object):
+class TestInputTypes:
     def test_empty_string_invalid(self):
         with pytest.raises(ParserError):
             parse('')
@@ -308,7 +305,7 @@ class TestInputTypes(object):
         # We want to support arbitrary classes that implement the stream
         # interface.
 
-        class StringPassThrough(object):
+        class StringPassThrough:
             def __init__(self, stream):
                 self.stream = stream
 
@@ -349,7 +346,7 @@ class TestInputTypes(object):
         assert res == expected
 
 
-class TestTzinfoInputTypes(object):
+class TestTzinfoInputTypes:
     def assert_equal_same_tz(self, dt1, dt2):
         assert dt1 == dt2
         assert dt1.tzinfo is dt2.tzinfo
@@ -382,7 +379,7 @@ class TestTzinfoInputTypes(object):
 
     def test_valid_tzinfo_unicode_input(self):
         dstr = "2014 January 19 09:00 UTC"
-        tzinfos = {u"UTC": u"UTC+0"}
+        tzinfos = {"UTC": "UTC+0"}
         expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzstr("UTC+0"))
         res = parse(dstr, tzinfos=tzinfos)
         self.assert_equal_same_tz(res, expected)
@@ -391,7 +388,7 @@ class TestTzinfoInputTypes(object):
         dstr = "2014 January 19 09:00 UTC"
 
         def tzinfos(*args, **kwargs):
-            return u"UTC+0"
+            return "UTC+0"
 
         expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzstr("UTC+0"))
         res = parse(dstr, tzinfos=tzinfos)
@@ -399,8 +396,8 @@ class TestTzinfoInputTypes(object):
 
     def test_valid_tzinfo_int_input(self):
         dstr = "2014 January 19 09:00 UTC"
-        tzinfos = {u"UTC": -28800}
-        expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzoffset(u"UTC", -28800))
+        tzinfos = {"UTC": -28800}
+        expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzoffset("UTC", -28800))
         res = parse(dstr, tzinfos=tzinfos)
         self.assert_equal_same_tz(res, expected)
 
@@ -570,11 +567,11 @@ class ParserTest(unittest.TestCase):
             parse('shouldfail')
 
     def testCorrectErrorOnFuzzyWithTokens(self):
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
                           parse, '04/04/32/423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
                           parse, '04/04/04 +32423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
                           parse, '04/04/0d4', fuzzy_with_tokens=True)
 
     def testIncreasingCTime(self):
@@ -734,7 +731,7 @@ class ParserTest(unittest.TestCase):
             pytest.fail("Failed to raise ParserError")
 
 
-class TestOutOfBounds(object):
+class TestOutOfBounds:
 
     def test_no_year_zero(self):
         with pytest.raises(ParserError):
@@ -769,7 +766,7 @@ class TestOutOfBounds(object):
             parse(dstr, fuzzy=fuzzy)
 
 
-class TestParseUnimplementedCases(object):
+class TestParseUnimplementedCases:
     @pytest.mark.xfail
     def test_somewhat_ambiguous_string(self):
         # Ref: github issue #487
@@ -887,7 +884,7 @@ class TestParseUnimplementedCases(object):
 
 
 @pytest.mark.skipif(IS_WIN, reason="Windows does not use TZ var")
-class TestTZVar(object):
+class TestTZVar:
     def test_parse_unambiguous_nonexistent_local(self):
         # When dates are specified "EST" even when they should be "EDT" in the
         # local time zone, we should still assign the local time zone

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from ._common import NotAValue
 
 import calendar

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from datetime import datetime, date
 import unittest
 from six import PY2
@@ -4876,13 +4873,13 @@ class WeekdayTest(unittest.TestCase):
     def testWeekdayEqualitySubclass(self):
         # Two weekday objects equal if their "weekday" and "n" attributes are
         # available and the same
-        class BasicWeekday(object):
+        class BasicWeekday:
             def __init__(self, weekday):
                 self.weekday = weekday
 
         class BasicNWeekday(BasicWeekday):
             def __init__(self, weekday, n=None):
-                super(BasicNWeekday, self).__init__(weekday)
+                super().__init__(weekday)
                 self.n = n
 
         MO_Basic = BasicWeekday(0)

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from ._common import PicklableMixin
 from ._common import TZEnvContext, TZWinContext
 from ._common import ComparesEqual
@@ -168,7 +166,7 @@ def get_timezone_tuple(dt):
 
 ###
 # Mix-ins
-class context_passthrough(object):
+class context_passthrough:
     def __init__(*args, **kwargs):
         pass
 
@@ -179,7 +177,7 @@ class context_passthrough(object):
         pass
 
 
-class TzFoldMixin(object):
+class TzFoldMixin:
     """ Mix-in class for testing ambiguous times """
     def gettz(self, tzname):
         raise NotImplementedError
@@ -434,11 +432,11 @@ class TzFoldMixin(object):
             self.assertEqual(t0_syd0, t0_syd1)
 
 
-class TzWinFoldMixin(object):
+class TzWinFoldMixin:
     def get_args(self, tzname):
         return (tzname, )
 
-    class context(object):
+    class context:
         def __init__(*args, **kwargs):
             pass
 
@@ -1428,9 +1426,9 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         # Test that tz.tzstr() won't throw an error if given a str instead
         # of a unicode literal.
         self.assertEqual(datetime(2003, 4, 6, 1, 59,
-                                  tzinfo=tz.tzstr(str("EST5EDT"))).tzname(), "EST")
+                                  tzinfo=tz.tzstr("EST5EDT")).tzname(), "EST")
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
-                                  tzinfo=tz.tzstr(str("EST5EDT"))).tzname(), "EDT")
+                                  tzinfo=tz.tzstr("EST5EDT")).tzname(), "EDT")
 
     def testStrInequality(self):
         TZS1 = tz.tzstr('EST5EDT4')
@@ -1535,7 +1533,7 @@ def test_tzstr_weakref():
     assert tz.tzstr('EST5EDT') is tz_t2_ref()
 
     for offset in range(5,15):
-        tz.tzstr('GMT+{}'.format(offset))
+        tz.tzstr(f'GMT+{offset}')
     gc.collect()
 
     assert tz_t2_ref() is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from datetime import timedelta, datetime
 
 from dateutil import tz

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -4,8 +4,8 @@ import hashlib
 import json
 import io
 
-from six.moves.urllib import request
-from six.moves.urllib import error as urllib_error
+from urllib import request
+from urllib import error as urllib_error
 
 try:
     import dateutil
@@ -22,7 +22,7 @@ METADATA_FILE = "zonefile_metadata.json"
 
 
 def main(metadata_file):
-    with io.open(metadata_file, 'r') as f:
+    with open(metadata_file) as f:
         metadata = json.load(f)
 
     releases_urls = metadata['releases_url']
@@ -33,7 +33,7 @@ def main(metadata_file):
     if not os.path.isfile(metadata['tzdata_file']):
 
         for ii, releases_url in enumerate(releases_urls):
-            print("Downloading tz file from mirror {ii}".format(ii=ii))
+            print(f"Downloading tz file from mirror {ii}")
             try:
                 request.urlretrieve(os.path.join(releases_url,
                                                  metadata['tzdata_file']),


### PR DESCRIPTION
Upgrade code to py38 syntax and remove `six` module dependencies.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
