### PR TITLE
workflows/publish: switch to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,21 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
+    - name: Determine destination index
+      id: determine-index
+      run: |
+        if [[ "${GITHUB_EVENT_NAME}" == "push" || \
+              "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          echo "TWINE_REPOSITORY_URL=https://test.pypi.org/legacy/" >> "${GITHUB_OUTPUT}"
+        elif [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+          echo "TWINE_REPOSITORY_URL=https://upload.pypi.org/legacy/" >> "${GITHUB_OUTPUT}"
+        else
+          echo "Unknown event name: ${GITHUB_EVENT_NAME}"
+          exit 1
+        fi
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -46,18 +60,7 @@ jobs:
       run: |
         tox -e build
     - name: Publish package
-      env:
-        TWINE_USERNAME: "__token__"
-      run: |
-        if [[ "$GITHUB_EVENT_NAME" == "push" || \
-              "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
-          export TWINE_REPOSITORY_URL="https://test.pypi.org/legacy/"
-          export TWINE_PASSWORD="${{ secrets.TEST_PYPI_UPLOAD_TOKEN }}"
-        elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-          export TWINE_REPOSITORY="pypi"
-          export TWINE_PASSWORD="${{ secrets.PYPI_UPLOAD_TOKEN }}"
-        else
-          echo "Unknown event name: ${GITHUB_EVENT_NAME}"
-          exit 1
-        fi
-        tox -e release
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: ${{ steps.determine-index.outputs.TWINE_REPOSITORY_URL }}
+

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -116,6 +116,7 @@ switch, and thus all their contributions are dual-licensed.
 - Tomasz Kluczkowski (gh: @Tomasz-Kluczkowski) **D**
 - Tomi Pieviläinen <tomi.pievilainen@iki.fi>
 - Unrud <Unrud@MASKED> (gh: @unrud)
+- William Woodruff <william@yossarian.net> (gh: @woodruffw) **D**
 - Xavier Lapointe <lapointe.xavier@MASKED> (gh: @lapointexavier) **D**
 - X O <xo@MASKED>
 - Yaron de Leeuw <me@jarondl.net> (gh: @jarondl)


### PR DESCRIPTION
Turns out "tomorrow" was really 4 months, but here's the PR I promised :sweat_smile: 

As part of switching over to trusted publishing, a project maintainer will need to do two things before merging here:

1. Remove the current secrets (`TEST_PYPI_UPLOAD_TOKEN` and `PYPI_UPLOAD_TOKEN`)
2. Configure the trusted publisher on both PyPI and TestPyPI ([docs](https://docs.pypi.org/trusted-publishers/adding-a-publisher/))

Once both of those are complete, doing a trial publish to TestPyPI should confirm that everything is in good shape here.

## Summary of changes

* Switches the `publish.yml` workflow from manually configured API tokens to trusted publishing, which is encapsulated via `pypa/gh-action-pypi-publish`.

Closes #1298.

### Pull Request Checklist

I've left the changes/news fragment unmarked below, since this should be a non-functional change w/r/t the library itself.

- [ ] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details

