### PR TITLE
remove setuptools test command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import os
 
 import setuptools
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 
 from distutils.version import LooseVersion
 import warnings
@@ -18,13 +17,6 @@ if isfile("MANIFEST"):
 if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
     warnings.warn("python_requires requires setuptools version > 24.3",
                   UserWarning)
-
-
-class Unsupported(TestCommand):
-    def run(self):
-        sys.stderr.write("Running 'test' with setup.py is not supported. "
-                         "Use 'pytest' or 'tox' to run the tests.\n")
-        sys.exit(1)
 
 
 ###
@@ -52,7 +44,4 @@ setup(
       },
       ## Needed since doctest not supported by PyPA.
       long_description = README,
-      cmdclass={
-          "test": Unsupported
-      }
       )


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->

## Summary of changes

`setuptools==72.0.0` just [removed their test command](https://github.com/pypa/setuptools/blob/main/NEWS.rst#deprecations-and-removals) so this import now fails

### Pull Request Checklist

- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
