### PR TITLE
Pin setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools; python_version != '3.3'",
+    "setuptools<72.0; python_version != '3.3'",
     "setuptools<40.0; python_version == '3.3'",
     "wheel",
     "setuptools_scm<8.0"


### PR DESCRIPTION
Alternatively to https://github.com/dateutil/dateutil/pull/1376, this PR just pins the setuptools version to keep things working the way they did before.