### PR TITLE
Fix bitrot in Github Actions on older Python versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - master
 
+env:
+  pypi-hosts: "pypi.python.org pypi.org files.pythonhosted.org"
+
 jobs:
   test:
     strategy:
@@ -35,10 +38,22 @@ jobs:
           - python-version: "2.7"
             os: "macos-latest"
           - python-version: "3.5"
+            os: "macos-latest"
+          - python-version: "3.6"
+            os: "macos-latest"
+          - python-version: "3.7"
+            os: "macos-latest"
+          - python-version: "3.5"
             os: "ubuntu-latest"
           - python-version: "3.6"
             os: "ubuntu-latest"
         include:
+          - python-version: "3.5"
+            os: "macos-12"
+          - python-version: "3.6"
+            os: "macos-12"
+          - python-version: "3.7"
+            os: "macos-12"
           - python-version: "2.7"
             os: "ubuntu-20.04"
           - python-version: "3.5"
@@ -62,6 +77,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+        env:
+          PIP_TRUSTED_HOST: ${{ contains(fromJson('["3.5"]'), matrix.python-version) && env.pypi-hosts || '' }}
       - name: Install dependencies
         run: python -m pip install -U tox six
       - name: Install zic (Windows)
@@ -86,7 +103,7 @@ jobs:
         with:
           file: ./.tox/coverage.xml
           name: ${{ matrix.os }}:${{ matrix.python-version }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   other:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
Unsurprisingly, the CI has started to bitrot again.

Looks like the current issues are https://github.com/actions/setup-python/issues/866 and `macos-latest` being an arm runner that does not have support for some older versions of Python.

Codecov was also giving some errors due to rate limiting, so I've made it a soft check, since I am hoping to switch to a [native GHA solution](https://hynek.me/articles/ditch-codecov-python/) anyway.