### PR TITLE
Optimize get_token by with inline methods

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -95,6 +95,12 @@ class _timelex(object):
         token = None
         state = None
 
+        # Note:
+        # Inline optimizations
+        # nextchar.isalpha() := self.isword(nextchar)
+        # nextchar.isdigit() := self.isnum(nextchar)
+        # nextchar.isspace() := self.isspace(nextchar)
+
         while not self.eof:
             # We only realize that we've reached the end of a token when we
             # find a character that's not part of the current token - since
@@ -114,11 +120,11 @@ class _timelex(object):
                 # First character of the token - determines if we're starting
                 # to parse a word, a number or something else.
                 token = nextchar
-                if self.isword(nextchar):
+                if nextchar.isalpha():
                     state = 'a'
-                elif self.isnum(nextchar):
+                elif nextchar.isdigit():
                     state = '0'
-                elif self.isspace(nextchar):
+                elif nextchar.isspace():
                     token = ' '
                     break  # emit token
                 else:
@@ -127,7 +133,7 @@ class _timelex(object):
                 # If we've already started reading a word, we keep reading
                 # letters until we find something that's not part of a word.
                 seenletters = True
-                if self.isword(nextchar):
+                if nextchar.isalpha():
                     token += nextchar
                 elif nextchar == '.':
                     token += nextchar
@@ -138,7 +144,7 @@ class _timelex(object):
             elif state == '0':
                 # If we've already started reading a number, we keep reading
                 # numbers until we find something that doesn't fit.
-                if self.isnum(nextchar):
+                if nextchar.isdigit():
                     token += nextchar
                 elif nextchar == '.' or (nextchar == ',' and len(token) >= 2):
                     token += nextchar
@@ -150,9 +156,9 @@ class _timelex(object):
                 # If we've seen some letters and a dot separator, continue
                 # parsing, and the tokens will be broken up later.
                 seenletters = True
-                if nextchar == '.' or self.isword(nextchar):
+                if nextchar == '.' or nextchar.isalpha():
                     token += nextchar
-                elif self.isnum(nextchar) and token[-1] == '.':
+                elif nextchar.isdigit() and token[-1] == '.':
                     token += nextchar
                     state = '0.'
                 else:
@@ -161,9 +167,9 @@ class _timelex(object):
             elif state == '0.':
                 # If we've seen at least one dot separator, keep going, we'll
                 # break up the tokens later.
-                if nextchar == '.' or self.isnum(nextchar):
+                if nextchar == '.' or nextchar.isdigit():
                     token += nextchar
-                elif self.isword(nextchar) and token[-1] == '.':
+                elif nextchar.isalpha() and token[-1] == '.':
                     token += nextchar
                     state = 'a.'
                 else:


### PR DESCRIPTION
I'm noticing that the `dateutil.parser.parse` is a bottleneck in some of my
scripts, and I sought to investigate if there are any speedups that might be
possible. I've inserted profile decorators using the line-profiler package to 
investigate where the slow parts of the code are, and I've found that 
`dateutil.parser._timelex.split` has a large footprint, with
`dateutil.parser._timelex.get_token` looking like it has the most potential for
optimization.


One immediate thing I noticed is that there are a lot of method calls to
one-line functions, that area really just aliases for string methods, although
they do enhance readability. But I wondered if there was a significant speedup
possible by sacrificing some readability., So I inserted two calls in a hot
section of the code to the `self.getword(nextchar)` method as well as its
inline form `nextchar.isalpha`, and measured a significant speedup by removing
the extra call overhead.


```
   124    450000   83274344.0    185.1      3.8                  nextchar.isalpha()
   125    450000  150698960.0    334.9      6.9                  self.isword(nextchar)
```

However, this code is running under line-profiler, so we need to see if there
is a speedup achieved outside of the profiling context. 

Using 100 loops with a best of 10, over 100 parsings of random 

With line profiler on, and using my benchmark the best loop iteration took
22.121 ms, and with the inline optimizations the best time was 20.690ms per
loop. This is a 6.469% speedup.

With line profile off the results are better. I increased the number of loops to 1000. 
The original code runs at 2.485 ms per loop and the inline code hits 2.221 ms
per loop which is 10.59% faster.
Details from the script output for a second run are:

```
Timed original for: 1000 loops, best of 10
    body took: 2.562 s
    time per loop: best=2.431 ms, mean=2.480 ± 0.0 ms

Timed alternative for: 1000 loops, best of 10
    body took: 2.271 s
    time per loop: best=2.185 ms, mean=2.206 ± 0.0 ms

min(percent_faster)=10.088560162984272%
mean(percent_faster)=11.049236678221678%
```

The above code is on a separate branch that I created to explore the speedups: https://github.com/Erotemic/dateutil/blob/benchmark_gettoken/benchmark_iso_parse.py


For a perfectly fair comparison, I added just the optimizations to a branch (which is the one in this PR),
and ran a simpler script on the master branch and on the branch with the
optimization. This means both methods will see the exact same random sequence
of dates and be a more apples-to-apples comparison.


The script is:

```python

def random_time(rng):
    import datetime as datetime_mod
    from datetime import datetime as datetime_cls
    min_ts = datetime_cls(1, 1, 2, 0, 0).timestamp()
    max_ts = datetime_cls.max.timestamp()
    ts = rng.randint(int(min_ts), int(max_ts))
    tz = datetime_mod.timezone.utc
    time = datetime_cls.fromtimestamp(ts, tz=tz)
    return time


def random_time_strings(num_timestamps, rng):
    for _ in range(num_timestamps):
        time = random_time(rng)
        yield time.isoformat()


def main():
    from dateutil import parser as date_parser
    import timerit
    import random

    rng = random.Random(0)

    num_per_iter = 100
    ti = timerit.Timerit(10000, bestof=100, verbose=3)

    # Benchmark the original get_token code
    import ubelt as ub
    branchname = ub.cmd('git rev-parse --abbrev-ref HEAD').stdout
    for timer in ti.reset(f'branch: {branchname}'):
        timestrs = list(random_time_strings(num_per_iter, rng))
        with timer:
            for timestr in timestrs:
                date_parser.parse(timestr)

if __name__ == '__main__':
    """
    CommandLine:
        python benchmark2.py
    """
    main()
```

Results from the `master` branch:
```
Timing branch: master
 for: 10000 loops, best of 100
Timed branch: master
 for: 10000 loops, best of 100
    body took: 25.661 s
    time per loop: best=2.397 ms, mean=2.438 ± 0.0 ms

```


Results from the `inline_timelex_optimization` branch:
```
Timing branch: inline_timelex_optimization
 for: 10000 loops, best of 100
Timed branch: inline_timelex_optimization
 for: 10000 loops, best of 100
    body took: 23.392 s
    time per loop: best=2.181 ms, mean=2.203 ± 0.0 ms
```

This is a 9.0% speed increase. 

The main question is: is this 9% speed increase worth it? I would think yes because the readability isn't that much worse (in fact, the string names:

```
        # nextchar.isalpha() := self.isword(nextchar)
        # nextchar.isdigit() := self.isnum(nextchar)
        # nextchar.isspace() := self.isspace(nextchar)
```

Are so semantically similar, I don't think readability is hurt at all. But that is my opinion, so I'm opening this PR up for discussion and review.

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
