### PR TITLE
parser: add CHARSETS_OF_SEP_YMD and accept '_' for JUMP

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -255,9 +255,10 @@ class parserinfo(object):
         to be the year, otherwise the last number is taken to be the year.
         Default is ``False``.
     """
-
+    CHARSETS_OF_SEP_YMD = ('-', '/', "_")
+    
     # m from a.m/p.m, t from ISO T separator
-    JUMP = [" ", ".", ",", ";", "-", "/", "'",
+    JUMP = [" ", ".", ",", ";", "-", "/", "'", "_",
             "at", "on", "and", "ad", "m", "t", "of",
             "st", "nd", "rd", "th"]
 
@@ -310,8 +311,8 @@ class parserinfo(object):
         dct = {}
         for i, v in enumerate(lst):
             if isinstance(v, tuple):
-                for v in v:
-                    dct[v.lower()] = i
+                for c in v:
+                    dct[c.lower()] = i
             else:
                 dct[v.lower()] = i
         return dct
@@ -750,7 +751,7 @@ class parser(object):
                     ymd.append(value, 'M')
 
                     if i + 1 < len_l:
-                        if l[i + 1] in ('-', '/'):
+                        if l[i + 1] in self.info.CHARSETS_OF_SEP_YMD:
                             # Jan-01[-99]
                             sep = l[i + 1]
                             ymd.append(l[i + 2])


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes
to support  formats like 
- "2024_10_30_15_11_12"
- "20241030_151112"
as python file not support "-",  common  files with datestring replace  "-" with "_".

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
