### PR TITLE
replace star imports in quick example of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,11 +97,10 @@ date out of the "date" unix system command. Here is the code:
 
 .. doctest:: readmeexample
 
-    >>> from dateutil.relativedelta import *
-    >>> from dateutil.easter import *
-    >>> from dateutil.rrule import *
-    >>> from dateutil.parser import *
-    >>> from datetime import *
+    >>> from dateutil.relativedelta import relativedelta
+    >>> from dateutil.easter import easter
+    >>> from dateutil.rrule import rrule, YEARLY, FR
+    >>> from dateutil.parser import parse
     >>> now = parse("Sat Oct 11 17:13:46 UTC 2003")
     >>> today = now.date()
     >>> year = rrule(YEARLY,dtstart=now,bymonth=8,bymonthday=13,byweekday=FR)[0].year


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Replaces the star imports in the "Quick Example" section of the README to improve import clarity, as per discussion on https://github.com/dateutil/dateutil/issues/1365

Closes 1365

### Pull Request Checklist
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
