### PR TITLE
fix: remove dependency on the module six for Python 3

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,7 +80,7 @@ jobs:
         env:
           PIP_TRUSTED_HOST: ${{ contains(fromJson('["3.5"]'), matrix.python-version) && env.pypi-hosts || '' }}
       - name: Install dependencies
-        run: python -m pip install -U tox six
+        run: python -m pip install -U tox
       - name: Install zic (Windows)
         run: |
           curl https://get.enterprisedb.com/postgresql/postgresql-9.5.21-2-windows-x64-binaries.zip --output $env:GITHUB_WORKSPACE\postgresql9.5.21.zip

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -77,6 +77,7 @@ switch, and thus all their contributions are dual-licensed.
 - Mario Corchero <mcorcherojim@MASKED> (gh: @mariocj89) **R**
 - Mark Bailey <msb@MASKED> **D**
 - Mateusz Dziedzic (gh: @m-dz) **D**
+- Matěj Cepl <mcepl@cepl.eu> (gh: @mcepl) **D**
 - Matt Cooper <vtbassmatt@MASKED> (gh: @vtbassmatt) **D**
 - Matthew Schinckel <matt@MASKED>
 - Max Shenfield <shenfieldmax@MASKED>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ install:
 
   # This frequently fails with network errors, so we'll retry it up to 5 times
   # with a 1 minute rate limit.
-  - "%PYTHON% -m pip install six"
   - "ci_tools/retry.bat %PYTHON% updatezinfo.py"
   # This environment variable tells the test suite it's OK to mess with the time zone.
   - set DATEUTIL_MAY_CHANGE_TZ=1

--- a/changelog.d/1403.deprecation.rst
+++ b/changelog.d/1403.deprecation.rst
@@ -1,0 +1,1 @@
+Removed dependency on the `six` module. Fixed by @mcepl (gh pr #1403)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -188,7 +188,7 @@ htmlhelp_basename = 'dateutildoc'
 
 # -- Options for autodoc -------------------------------------------------
 
-autodoc_mock_imports = ['ctypes.wintypes', 'six.moves.winreg']
+autodoc_mock_imports = ['ctypes.wintypes', 'winreg']
 
 # Need to mock this out specifically to avoid errors
 import ctypes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,7 @@ known_first_party = ["dateutil"]
 known_third_party=[
     "pytest",
     "hypothesis",
-    "six",
     "freezegun",
-    "mock",
 ]
 multi_line_output=3
 use_parentheses=true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,7 @@
-six
 pytest >= 3.0; python_version != '3.3'
 pytest-cov >= 2.0.0
 freezegun ; python_version != '3.3'
 hypothesis >= 3.30
 coverage
-mock ; python_version < '3.0'
 build >= 0.3.0 ; python_version >= '3.6'
 attrs!=21.1.0

--- a/requirements/3.3/constraints.txt
+++ b/requirements/3.3/constraints.txt
@@ -10,6 +10,5 @@ py==1.4.34
 pytest==3.2.5
 pytest-cov==2.5.1
 setuptools==39.2.0
-six==1.12.0
 tox==2.9.1
 virtualenv==15.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ classifiers =
 [options]
 zip_safe = True
 setup_requires = setuptools_scm
-install_requires = six >= 1.5
 package_dir=
     =src
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -39,9 +39,6 @@ import warnings
 from calendar import monthrange
 from io import StringIO
 
-import six
-from six import integer_types, text_type
-
 from decimal import Decimal
 
 from warnings import warn
@@ -63,7 +60,7 @@ class _timelex(object):
         if isinstance(instream, (bytes, bytearray)):
             instream = instream.decode()
 
-        if isinstance(instream, text_type):
+        if isinstance(instream, str):
             instream = StringIO(instream)
         elif getattr(instream, 'read', None) is None:
             raise TypeError('Parser must be a string or character stream, not '
@@ -648,7 +645,7 @@ class parser(object):
         try:
             ret = self._build_naive(res, default)
         except ValueError as e:
-            six.raise_from(ParserError(str(e) + ": %s", timestr), e)
+            raise ParserError(str(e) + ": %s", timestr) from e
 
         if not ignoretz:
             ret = self._build_tzaware(ret, res, tzinfos)
@@ -878,7 +875,7 @@ class parser(object):
         try:
             value = self._to_decimal(value_repr)
         except Exception as e:
-            six.raise_from(ValueError('Unknown numeric token'), e)
+            raise ValueError('Unknown numeric token') from e
 
         len_li = len(value_repr)
 
@@ -1147,7 +1144,7 @@ class parser(object):
                 raise ValueError("Converted decimal value is infinite or NaN")
         except Exception as e:
             msg = "Could not convert %s to decimal" % val
-            six.raise_from(ValueError(msg), e)
+            raise ValueError(msg) from e
         else:
             return decimal_value
 
@@ -1165,9 +1162,9 @@ class parser(object):
         # eg tzinfos = {'BRST' : None}
         if isinstance(tzdata, datetime.tzinfo) or tzdata is None:
             tzinfo = tzdata
-        elif isinstance(tzdata, text_type):
+        elif isinstance(tzdata, str):
             tzinfo = tz.tzstr(tzdata)
-        elif isinstance(tzdata, integer_types):
+        elif isinstance(tzdata, int):
             tzinfo = tz.tzoffset(tzname, tzdata)
         else:
             raise TypeError("Offset must be tzinfo subclass, tz string, "

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -14,7 +14,6 @@ from dateutil import tz
 from functools import wraps
 
 import re
-import six
 
 __all__ = ["isoparse", "isoparser"]
 
@@ -26,13 +25,13 @@ def _takes_ascii(f):
         str_in = getattr(str_in, 'read', lambda: str_in)()
 
         # If it's unicode, turn it into bytes, since ISO-8601 only covers ASCII
-        if isinstance(str_in, six.text_type):
+        if isinstance(str_in, str):
             # ASCII is the same in UTF-8
             try:
                 str_in = str_in.encode('ascii')
             except UnicodeEncodeError as e:
                 msg = 'ISO-8601 strings should contain only ASCII characters'
-                six.raise_from(ValueError(msg), e)
+                raise ValueError(msg) from e
 
         return f(self, str_in, *args, **kwargs)
 

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -5,7 +5,6 @@ import calendar
 import operator
 from math import copysign
 
-from six import integer_types
 from warnings import warn
 
 from ._common import weekday
@@ -200,7 +199,7 @@ class relativedelta(object):
                      "This is not a well-defined condition and will raise " +
                      "errors in future versions.", DeprecationWarning)
 
-            if isinstance(weekday, integer_types):
+            if isinstance(weekday, int):
                 self.weekday = weekdays[weekday]
             else:
                 self.weekday = weekday

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -11,13 +11,10 @@ import heapq
 import itertools
 import re
 import sys
+import _thread
 from functools import wraps
 # For warning about deprecation of until and count
 from warnings import warn
-
-from six import advance_iterator, integer_types
-
-from six.moves import _thread, range
 
 from ._common import weekday as weekdaybase
 
@@ -134,7 +131,7 @@ class rrulebase(object):
                     break
                 try:
                     for j in range(10):
-                        cache.append(advance_iterator(gen))
+                        cache.append(next(gen))
                 except StopIteration:
                     self._cache_gen = gen = None
                     self._cache_complete = True
@@ -161,7 +158,7 @@ class rrulebase(object):
             gen = iter(self)
             try:
                 for i in range(item+1):
-                    res = advance_iterator(gen)
+                    res = next(gen)
             except StopIteration:
                 raise IndexError
             return res
@@ -479,14 +476,14 @@ class rrule(rrulebase):
 
         if wkst is None:
             self._wkst = calendar.firstweekday()
-        elif isinstance(wkst, integer_types):
+        elif isinstance(wkst, int):
             self._wkst = wkst
         else:
             self._wkst = wkst.weekday
 
         if bysetpos is None:
             self._bysetpos = None
-        elif isinstance(bysetpos, integer_types):
+        elif isinstance(bysetpos, int):
             if bysetpos == 0 or not (-366 <= bysetpos <= 366):
                 raise ValueError("bysetpos must be between 1 and 366, "
                                  "or between -366 and -1")
@@ -520,7 +517,7 @@ class rrule(rrulebase):
         if bymonth is None:
             self._bymonth = None
         else:
-            if isinstance(bymonth, integer_types):
+            if isinstance(bymonth, int):
                 bymonth = (bymonth,)
 
             self._bymonth = tuple(sorted(set(bymonth)))
@@ -532,7 +529,7 @@ class rrule(rrulebase):
         if byyearday is None:
             self._byyearday = None
         else:
-            if isinstance(byyearday, integer_types):
+            if isinstance(byyearday, int):
                 byyearday = (byyearday,)
 
             self._byyearday = tuple(sorted(set(byyearday)))
@@ -542,7 +539,7 @@ class rrule(rrulebase):
         if byeaster is not None:
             if not easter:
                 from dateutil import easter
-            if isinstance(byeaster, integer_types):
+            if isinstance(byeaster, int):
                 self._byeaster = (byeaster,)
             else:
                 self._byeaster = tuple(sorted(byeaster))
@@ -556,7 +553,7 @@ class rrule(rrulebase):
             self._bymonthday = ()
             self._bynmonthday = ()
         else:
-            if isinstance(bymonthday, integer_types):
+            if isinstance(bymonthday, int):
                 bymonthday = (bymonthday,)
 
             bymonthday = set(bymonthday)            # Ensure it's unique
@@ -573,7 +570,7 @@ class rrule(rrulebase):
         if byweekno is None:
             self._byweekno = None
         else:
-            if isinstance(byweekno, integer_types):
+            if isinstance(byweekno, int):
                 byweekno = (byweekno,)
 
             self._byweekno = tuple(sorted(set(byweekno)))
@@ -588,13 +585,13 @@ class rrule(rrulebase):
             # If it's one of the valid non-sequence types, convert to a
             # single-element sequence before the iterator that builds the
             # byweekday set.
-            if isinstance(byweekday, integer_types) or hasattr(byweekday, "n"):
+            if isinstance(byweekday, int) or hasattr(byweekday, "n"):
                 byweekday = (byweekday,)
 
             self._byweekday = set()
             self._bynweekday = set()
             for wday in byweekday:
-                if isinstance(wday, integer_types):
+                if isinstance(wday, int):
                     self._byweekday.add(wday)
                 elif not wday.n or freq > MONTHLY:
                     self._byweekday.add(wday.weekday)
@@ -629,7 +626,7 @@ class rrule(rrulebase):
             else:
                 self._byhour = None
         else:
-            if isinstance(byhour, integer_types):
+            if isinstance(byhour, int):
                 byhour = (byhour,)
 
             if freq == HOURLY:
@@ -649,7 +646,7 @@ class rrule(rrulebase):
             else:
                 self._byminute = None
         else:
-            if isinstance(byminute, integer_types):
+            if isinstance(byminute, int):
                 byminute = (byminute,)
 
             if freq == MINUTELY:
@@ -669,7 +666,7 @@ class rrule(rrulebase):
             else:
                 self._bysecond = None
         else:
-            if isinstance(bysecond, integer_types):
+            if isinstance(bysecond, int):
                 bysecond = (bysecond,)
 
             self._bysecond = set(bysecond)
@@ -1062,7 +1059,7 @@ class rrule(rrulebase):
         cset = set()
 
         # Support a single byxxx value.
-        if isinstance(byxxx, integer_types):
+        if isinstance(byxxx, int):
             byxxx = (byxxx, )
 
         for num in byxxx:
@@ -1315,7 +1312,7 @@ class rruleset(rrulebase):
     class _genitem(object):
         def __init__(self, genlist, gen):
             try:
-                self.dt = advance_iterator(gen)
+                self.dt = next(gen)
                 genlist.append(self)
             except StopIteration:
                 pass
@@ -1324,7 +1321,7 @@ class rruleset(rrulebase):
 
         def __next__(self):
             try:
-                self.dt = advance_iterator(self.gen)
+                self.dt = next(self.gen)
             except StopIteration:
                 if self.genlist[0] is self:
                     heapq.heappop(self.genlist)
@@ -1400,14 +1397,14 @@ class rruleset(rrulebase):
             if not lastdt or lastdt != ritem.dt:
                 while exlist and exlist[0] < ritem:
                     exitem = exlist[0]
-                    advance_iterator(exitem)
+                    next(exitem)
                     if exlist and exlist[0] is exitem:
                         heapq.heapreplace(exlist, exitem)
                 if not exlist or ritem != exlist[0]:
                     total += 1
                     yield ritem.dt
                 lastdt = ritem.dt
-            advance_iterator(ritem)
+            next(ritem)
             if rlist and rlist[0] is ritem:
                 heapq.heapreplace(rlist, ritem)
         self._len = total

--- a/src/dateutil/tz/_common.py
+++ b/src/dateutil/tz/_common.py
@@ -1,5 +1,3 @@
-from six import PY2
-
 from functools import wraps
 
 from datetime import datetime, timedelta, tzinfo
@@ -16,18 +14,7 @@ def tzname_in_python2(namefunc):
     tzname() API changed in Python 3. It used to return bytes, but was changed
     to unicode strings
     """
-    if PY2:
-        @wraps(namefunc)
-        def adjust_encoding(*args, **kwargs):
-            name = namefunc(*args, **kwargs)
-            if name is not None:
-                name = name.encode()
-
-            return name
-
-        return adjust_encoding
-    else:
-        return namefunc
+    return namefunc
 
 
 # The following is adapted from Alexander Belopolsky's tz library

--- a/src/dateutil/tz/_factories.py
+++ b/src/dateutil/tz/_factories.py
@@ -1,9 +1,7 @@
 from datetime import timedelta
+import _thread
 import weakref
 from collections import OrderedDict
-
-from six.moves import _thread
-
 
 class _TzSingleton(type):
     def __init__(cls, *args, **kwargs):

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -13,12 +13,10 @@ import time
 import sys
 import os
 import bisect
+import _thread
 import weakref
 from collections import OrderedDict
 
-import six
-from six import string_types
-from six.moves import _thread
 from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs
@@ -38,8 +36,7 @@ EPOCH = datetime.datetime(1970, 1, 1, 0, 0)
 EPOCHORDINAL = EPOCH.toordinal()
 
 
-@six.add_metaclass(_TzSingleton)
-class tzutc(datetime.tzinfo):
+class tzutc(datetime.tzinfo, metaclass=_TzSingleton):
     """
     This is a tzinfo object that represents the UTC time zone.
 
@@ -129,8 +126,7 @@ class tzutc(datetime.tzinfo):
 UTC = tzutc()
 
 
-@six.add_metaclass(_TzOffsetFactory)
-class tzoffset(datetime.tzinfo):
+class tzoffset(datetime.tzinfo, metaclass=_TzOffsetFactory):
     """
     A simple class for representing a fixed offset from UTC.
 
@@ -459,7 +455,7 @@ class tzfile(_tzinfo):
         super(tzfile, self).__init__()
 
         file_opened_here = False
-        if isinstance(fileobj, string_types):
+        if isinstance(fileobj, str):
             self._filename = fileobj
             fileobj = open(fileobj, 'rb')
             file_opened_here = True
@@ -1033,8 +1029,7 @@ class tzrange(tzrangebase):
         return self._dst_base_offset_
 
 
-@six.add_metaclass(_TzStrFactory)
-class tzstr(tzrange):
+class tzstr(tzrange, metaclass=_TzStrFactory):
     """
     ``tzstr`` objects are time zone objects specified by a time-zone string as
     it would be passed to a ``TZ`` variable on POSIX-style systems (see
@@ -1265,7 +1260,7 @@ class tzical(object):
         global rrule
         from dateutil import rrule
 
-        if isinstance(fileobj, string_types):
+        if isinstance(fileobj, str):
             self._s = fileobj
             # ical should be encoded in UTF-8 with CRLF
             fileobj = open(fileobj, 'r')
@@ -1621,7 +1616,7 @@ def __get_gettz():
                 except TypeError as e:
                     if isinstance(name, bytes):
                         new_msg = "gettz argument should be str, not bytes"
-                        six.raise_from(TypeError(new_msg), e)
+                        raise TypeError(new_msg) from e
                     else:
                         raise
                 if os.path.isabs(name):

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -9,9 +9,7 @@ Attempting to import this module on a non-Windows platform will raise an
 # This code was originally contributed by Jeffrey Harris.
 import datetime
 import struct
-
-from six.moves import winreg
-from six import text_type
+import winreg
 
 try:
     import ctypes
@@ -216,7 +214,7 @@ class tzwin(tzwinbase):
         self._name = name
 
         with winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE) as handle:
-            tzkeyname = text_type("{kn}\\{name}").format(kn=TZKEYNAME, name=name)
+            tzkeyname = str("{kn}\\{name}").format(kn=TZKEYNAME, name=name)
             with winreg.OpenKey(handle, tzkeyname) as tzkey:
                 keydict = valuestodict(tzkey)
 
@@ -282,7 +280,7 @@ class tzwinlocal(tzwinbase):
             self._dst_abbr = keydict["DaylightName"]
 
             try:
-                tzkeyname = text_type('{kn}\\{sn}').format(kn=TZKEYNAME,
+                tzkeyname = str('{kn}\\{sn}').format(kn=TZKEYNAME,
                                                           sn=self._std_abbr)
                 with winreg.OpenKey(handle, tzkeyname) as tzkey:
                     _keydict = valuestodict(tzkey)

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 
 import pytest
-import six
 from hypothesis import assume, given
 from hypothesis import strategies as st
 
@@ -25,10 +24,7 @@ def test_gettz_returns_local(gettz_arg, dt):
         return
 
     dt_act = dt.astimezone(tz.gettz(gettz_arg))
-    if six.PY2:
-        dt_exp = dt.astimezone(tz.tzlocal())
-    else:
-        dt_exp = dt.astimezone()
+    dt_exp = dt.astimezone()
 
     assert dt_act == dt_exp
     assert dt_act.tzname() == dt_exp.tzname()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,7 +1,6 @@
 import sys
 import unittest
 import pytest
-import six
 
 MODULE_TYPE = type(sys)
 
@@ -10,12 +9,8 @@ MODULE_TYPE = type(sys)
 # But since we expect lazy imports tests to fail for Python < 3.7  we'll ignore those
 # warnings with this filter.
 
-if six.PY2:
-    filter_import_warning = pytest.mark.filterwarnings("ignore::RuntimeWarning")
-else:
-
-    def filter_import_warning(f):
-        return f
+def filter_import_warning(f):
+    return f
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -9,7 +9,6 @@ from dateutil.tz import UTC
 from dateutil.parser import isoparser, isoparse
 
 import pytest
-import six
 
 
 def _generate_tzoffsets(limited):
@@ -296,8 +295,7 @@ def test_isoparser_invalid_sep(sep):
         isoparser(sep=sep)
 
 
-# This only fails on Python 3
-@pytest.mark.xfail(not six.PY2, reason="Fails on Python 3 only")
+@pytest.mark.xfail(reason="Fails on Python 3 only")
 def test_isoparser_byte_sep():
     dt = datetime(2017, 12, 6, 12, 30, 45)
     dt_str = dt.isoformat(sep=str('T'))
@@ -347,10 +345,6 @@ def __make_date_examples():
         date(2016, 2, 1)
     ]
 
-    if not six.PY2:
-        # strftime does not support dates before 1900 in Python 2
-        dates_no_day.append(date(1000, 11, 1))
-
     # Only one supported format for dates with no day
     o = zip(dates_no_day, it.repeat('%Y-%m'))
 
@@ -371,7 +365,7 @@ def __make_date_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_parse_isodate(d, dt_fmt, as_bytes):
     d_str = d.strftime(dt_fmt)
-    if isinstance(d_str, six.text_type) and as_bytes:
+    if isinstance(d_str, str) and as_bytes:
         d_str = d_str.encode('ascii')
     elif isinstance(d_str, bytes) and not as_bytes:
         d_str = d_str.decode('ascii')
@@ -400,10 +394,7 @@ def test_parse_isodate_error_text():
         isoparser().parse_isodate('2014-0423')
 
     # ensure the error message does not contain b' prefixes
-    if six.PY2:
-        expected_error = "String contains unknown ISO components: u'2014-0423'"
-    else:
-        expected_error = "String contains unknown ISO components: '2014-0423'"
+    expected_error = "String contains unknown ISO components: '2014-0423'"
     assert expected_error == str(excinfo.value)
 
 
@@ -458,7 +449,7 @@ def __make_time_examples():
 @pytest.mark.parametrize('as_bytes', [True, False])
 def test_isotime(time_val, time_fmt, as_bytes):
     tstr = time_val.strftime(time_fmt)
-    if isinstance(tstr, six.text_type) and as_bytes:
+    if isinstance(tstr, str) and as_bytes:
         tstr = tstr.encode('ascii')
     elif isinstance(tstr, bytes) and not as_bytes:
         tstr = tstr.decode('ascii')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -14,7 +14,6 @@ from dateutil.parser import UnknownTimezoneWarning
 
 from ._common import TZEnvContext
 
-from six import assertRaisesRegex, PY2
 from io import StringIO
 
 import pytest
@@ -462,13 +461,6 @@ class ParserTest(unittest.TestCase):
                          datetime(2003, 9, 25, 10, 36, 28,
                                   tzinfo=self.brsttz))
 
-    def testDateCommandFormatWithLong(self):
-        if PY2:
-            self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
-                                   tzinfos={"BRST": long(-10800)}),
-                             datetime(2003, 9, 25, 10, 36, 28,
-                                      tzinfo=self.brsttz))
-
     def testISOFormatStrip2(self):
         self.assertEqual(parse("2003-09-25T10:49:41+03:00"),
                          datetime(2003, 9, 25, 10, 49, 41,
@@ -570,11 +562,11 @@ class ParserTest(unittest.TestCase):
             parse('shouldfail')
 
     def testCorrectErrorOnFuzzyWithTokens(self):
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
                           parse, '04/04/32/423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
                           parse, '04/04/04 +32423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
+        self.assertRaisesRegex(ParserError, 'Unknown string format',
                           parse, '04/04/0d4', fuzzy_with_tokens=True)
 
     def testIncreasingCTime(self):

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 
 from datetime import datetime, date
 import unittest
-from six import PY2
 
 from dateutil import tz
 from dateutil.rrule import (
@@ -2282,27 +2281,6 @@ class RRuleTest(unittest.TestCase):
                           datetime(2010, 3, 22, 13, 1),
                           datetime(2010, 3, 22, 14, 1)])
 
-    def testLongIntegers(self):
-        if PY2:  # There are no longs in python3
-            self.assertEqual(list(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 2, 5, 6, 6, 6),
-                              datetime(1998, 2, 12, 6, 6, 6)])
-            self.assertEqual(list(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0))),
-                             [datetime(1998, 1, 5, 9, 0),
-                              datetime(2004, 1, 5, 9, 0)])
-
     def testHourlyBadRRule(self):
         """
         When `byhour` is specified with `freq=HOURLY`, there are certain
@@ -4576,24 +4554,6 @@ class RRuleTest(unittest.TestCase):
                               count=3,
                               wkst=SU,
                               dtstart=datetime(1997, 9, 2, 9, 0)))
-
-    def testToStrLongIntegers(self):
-        if PY2:  # There are no longs in python3
-            self._rrulestr_reverse_test(rrule(MINUTELY,
-                                  count=long(2),
-                                  interval=long(2),
-                                  bymonth=long(2),
-                                  byweekday=long(3),
-                                  byhour=long(6),
-                                  byminute=long(6),
-                                  bysecond=long(6),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
-
-            self._rrulestr_reverse_test(rrule(YEARLY,
-                                  count=long(2),
-                                  bymonthday=long(5),
-                                  byweekno=long(2),
-                                  dtstart=datetime(1997, 9, 2, 9, 0)))
 
     def testReplaceIfSet(self):
         rr = rrule(YEARLY,

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -7,7 +7,6 @@ from ._common import ComparesEqual
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from datetime import tzinfo
-from six import PY2
 from io import BytesIO, StringIO
 import unittest
 
@@ -1114,11 +1113,6 @@ def test_gettz_badzone_unicode():
             b"America/New_York",
             ".*should be str, not bytes.*",
             id="bytes on Python 3",
-            marks=[
-                pytest.mark.skipif(
-                    PY2, reason="bytes arguments accepted in Python 2"
-                )
-            ],
         ),
         pytest.param(
             object(),

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -4,8 +4,8 @@ import hashlib
 import json
 import io
 
-from six.moves.urllib import request
-from six.moves.urllib import error as urllib_error
+from urllib import request
+from urllib import error as urllib_error
 
 try:
     import dateutil


### PR DESCRIPTION
I understand that this may not be accepted immediately (#653), but at least it will be present here for anybody who cares (e.g., most Linux distributions).

### Pull Request Checklist
- [x] Changes have tests (no API should change for Python 3, no change of tests needed)
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
