### PR TITLE
Fix importing six.moves._thread.

### DIFF
--- a/src/dateutil/tz/_factories.py
+++ b/src/dateutil/tz/_factories.py
@@ -2,7 +2,11 @@ from datetime import timedelta
 import weakref
 from collections import OrderedDict
 
-from six.moves import _thread
+try:
+    from six.moves import _thread
+except ModuleNotFoundError:
+    import six
+    _thread = six.moves._thread
 
 
 class _TzSingleton(type):

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -18,7 +18,10 @@ from collections import OrderedDict
 
 import six
 from six import string_types
-from six.moves import _thread
+try:
+    from six.moves import _thread
+except ModuleNotFoundError:
+    _thread = six.moves._thread
 from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs


### PR DESCRIPTION
I am opening this PR to pro-actively discuss #1415. Welcome for comments and, once LGTMerge, I'll go through the other stuff in the Checklist.

## Summary of changes

Add alternate method to get `_thread` from `six.moves`.

At least this is a problem in Ubuntu 20.04 with Python 3.12.

Closes #1415

### Pull Request Checklist
- [ NA?] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
