### PR TITLE
Fix validation workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,10 +16,6 @@ jobs:
     strategy:
       matrix:
         python-version: [
-          "2.7",
-          "3.5",
-          "3.6",
-          "3.7",
           "3.8",
           "3.9",
           "3.10",
@@ -30,49 +26,43 @@ jobs:
           "pypy-3.8",
         ]
         os: [ubuntu-latest, windows-latest, macos-latest]
-        exclude:
-          - python-version: "2.7"
-            os: "ubuntu-latest"
-          - python-version: "2.7"
-            os: "windows-latest"
-          - python-version: "2.7"
-            os: "macos-latest"
-          - python-version: "3.5"
-            os: "macos-latest"
-          - python-version: "3.6"
-            os: "macos-latest"
-          - python-version: "3.7"
-            os: "macos-latest"
-          - python-version: "3.5"
-            os: "ubuntu-latest"
-          - python-version: "3.6"
-            os: "ubuntu-latest"
         include:
-          - python-version: "3.5"
-            os: "macos-12"
-          - python-version: "3.6"
-            os: "macos-12"
-          - python-version: "3.7"
-            os: "macos-12"
-          - python-version: "2.7"
-            os: "ubuntu-20.04"
-          - python-version: "3.5"
-            os: "ubuntu-20.04"
-          - python-version: "3.6"
-            os: "ubuntu-20.04"
+          # Older versions (<=3.7) are included separately since they need
+          # special handling (using an older os or a container)
+          - os: "macos-13"
+            python-version: "3.5"
+          - os: "macos-13"
+            python-version: "3.6"
+          - os: "macos-13"
+            python-version: "3.7"
+          - os: "windows-latest"
+            python-version: "3.5"
+          - os: "windows-latest"
+            python-version: "3.6"
+          - os: "windows-latest"
+            python-version: "3.7"
+          - os: "ubuntu-latest"
+            python-version: "2.7"
+            use-container: true
+          - os: "ubuntu-latest"
+            python-version: "3.5"
+            use-container: true
+          - os: "ubuntu-latest"
+            python-version: "3.6"
+            use-container: true
+          - os: "ubuntu-latest"
+            python-version: "3.7"
+            use-container: true
     runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.use-container && format('python:{0}', matrix.python-version) || '' }}
     env:
       TOXENV: py
     steps:
-      - uses: actions/checkout@v3
-      - if: ${{ matrix.python-version == '2.7' }}
-        run: |
-          sudo apt-get install python-is-python2
-          curl -sSL https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
-          python get-pip.py
-        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
-      - if: ${{ matrix.python-version != '2.7' }}
-        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - if: ${{ !matrix.use-container }}
+        name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }} (non-containers)
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -104,6 +94,9 @@ jobs:
           file: ./.tox/coverage.xml
           name: ${{ matrix.os }}:${{ matrix.python-version }}
           fail_ci_if_error: false
+          # codecov/codecov-action@v3 needs v0.7.3 to work on (intel) macos-13
+          # See https://github.com/codecov/codecov-action/issues/1549
+          version: ${{ matrix.os == 'macos-13' && 'v0.7.3' || 'latest' }}
 
   other:
     runs-on: "ubuntu-latest"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -100,6 +100,7 @@ switch, and thus all their contributions are dual-licensed.
 - Raymond Cha (gh: @weatherpattern) **D**
 - Ridhi Mahajan <ridhikmahajan@MASKED> **D**
 - Robin Henriksson Törnström <gh: @MrRawbin> **D**
+- Rowan Walsh (gh: @rowan-walsh) **D**
 - Roy Williams <rwilliams@MASKED>
 - Rustem Saiargaliev (gh: @amureki) **D**
 - Satyabrat Bhol <satyabrat35@MASKED> (gh: @Satyabrat35) **D**

--- a/changelog.d/1417.misc.rst
+++ b/changelog.d/1417.misc.rst
@@ -1,0 +1,1 @@
+Fixed validation CI workflow. Fixed by @rowan-walsh (gh pr #1417).


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

- Rearrange test matrix: removed exclude section and moved special cases (older versions) as include entries.
- Switch to macos-13 runners for 3.5-3.7 since macos-12 is no longer available.
- Fix issue with latest codecov action not working on intel macos runners.
- Remove ubuntu-20.04 runners since these are being deprecated soon: https://github.com/actions/runner-images/issues/11101. Instead, test older python versions in python:x.y containers.

### Pull Request Checklist
- [x] Changes have tests (N/A: CI changes)
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
