### PR TITLE
Add support for Python 3.12+ where six.moves is not available.

### DIFF
--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -17,7 +17,11 @@ from warnings import warn
 
 from six import advance_iterator, integer_types
 
-from six.moves import _thread, range
+try:
+    from six.moves import _thread, range
+except ModuleNotFoundError:
+    # Support for Python 3.12+ where six.moves is not available. 
+    import _thread
 
 from ._common import weekday as weekdaybase
 

--- a/src/dateutil/tz/_factories.py
+++ b/src/dateutil/tz/_factories.py
@@ -2,7 +2,11 @@ from datetime import timedelta
 import weakref
 from collections import OrderedDict
 
-from six.moves import _thread
+try:
+    from six.moves import _thread
+except ModuleNotFoundError:
+    # Support for Python 3.12+ where six.moves is not available. 
+    import _thread
 
 
 class _TzSingleton(type):

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -18,7 +18,13 @@ from collections import OrderedDict
 
 import six
 from six import string_types
-from six.moves import _thread
+
+try:
+    from six.moves import _thread
+except ModuleNotFoundError:
+    # Support for Python 3.12+ where six.moves is not available. 
+    import _thread
+
 from ._common import tzname_in_python2, _tzinfo
 from ._common import tzrangebase, enfold
 from ._common import _validate_fromutc_inputs

--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -10,7 +10,12 @@ Attempting to import this module on a non-Windows platform will raise an
 import datetime
 import struct
 
-from six.moves import winreg
+try:
+    from six.moves import winreg
+except ModuleNotFoundError:
+    # Support for Python 3.12+ where six.moves is not available. 
+    import winreg
+
 from six import text_type
 
 try:

--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -4,8 +4,13 @@ import hashlib
 import json
 import io
 
-from six.moves.urllib import request
-from six.moves.urllib import error as urllib_error
+try:
+    from six.moves.urllib import request
+    from six.moves.urllib import error as urllib_error
+except ModuleNotFoundError:
+    # Support for Python 3.12+ where six.moves is not available. 
+    from urllib import request
+    from urllib import error as urllib_error
 
 try:
     import dateutil


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
