### PR TITLE
Do not require wheel for building

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools; python_version != '3.3'",
     "setuptools<40.0; python_version == '3.3'",
-    "wheel",
     "setuptools_scm<8.0"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary of changes

 - current version of setuptools (70.1+) does not need wheel at all
 - older versions of setuptools would fetch wheel when building wheels (but not sdists)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
