### PR TITLE
Remove dependencies to six in updatezinfo.py.

### DIFF
--- a/updatezinfo.py
+++ b/updatezinfo.py
@@ -4,8 +4,8 @@ import hashlib
 import json
 import io
 
-from six.moves.urllib import request
-from six.moves.urllib import error as urllib_error
+import urllib.error
+import urllib.request
 
 try:
     import dateutil
@@ -35,10 +35,10 @@ def main(metadata_file):
         for ii, releases_url in enumerate(releases_urls):
             print("Downloading tz file from mirror {ii}".format(ii=ii))
             try:
-                request.urlretrieve(os.path.join(releases_url,
-                                                 metadata['tzdata_file']),
-                                    metadata['tzdata_file'])
-            except urllib_error.URLError as e:
+                urllib.request.urlretrieve(os.path.join(releases_url,
+                                                        metadata['tzdata_file']),
+                                           metadata['tzdata_file'])
+            except urllib.error.URLError as e:
                 print("Download failed, trying next mirror.")
                 last_error = e
                 continue


### PR DESCRIPTION
## Summary of changes

This change removes dependencies on six from updatezinfo.py. That file has no test. This change was tested manually by running updatezinfo.py.

This contributes to resolving https://github.com/dateutil/dateutil/issues/653

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details