### PR TITLE
Increase deadline for isoparse test

### DIFF
--- a/changelog.d/1462.misc.rst
+++ b/changelog.d/1462.misc.rst
@@ -1,0 +1,1 @@
+Deflaked two tests: gave ``test_isoparse_prop.py::test_timespec_auto`` a longer timeout and skipped ``test_tz_prop.py::tz_gettz_returns_local`` on Python 2. (gh pr #1462)

--- a/tests/property/test_isoparse_prop.py
+++ b/tests/property/test_isoparse_prop.py
@@ -1,10 +1,11 @@
-from hypothesis import given, assume
+from datetime import timedelta
+
+import pytest
+from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 from dateutil import tz
 from dateutil.parser import isoparse
-
-import pytest
 
 # Strategies
 TIME_ZONE_STRATEGY = st.sampled_from([None, tz.UTC] +
@@ -14,6 +15,7 @@ ASCII_STRATEGY = st.characters(max_codepoint=127)
 
 
 @pytest.mark.isoparser
+@settings(deadline=3000)
 @given(dt=st.datetimes(timezones=TIME_ZONE_STRATEGY), sep=ASCII_STRATEGY)
 def test_timespec_auto(dt, sep):
     if dt.tzinfo is not None:

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -12,6 +12,7 @@ NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
 
 
 @pytest.mark.gettz
+@pytest.mark.skipif(six.PY2, reason="Not supported on Python 2")
 @pytest.mark.parametrize("gettz_arg", [None, ""])
 # TODO: Remove bounds when GH #590 is resolved
 @given(
@@ -25,10 +26,7 @@ def test_gettz_returns_local(gettz_arg, dt):
         return
 
     dt_act = dt.astimezone(tz.gettz(gettz_arg))
-    if six.PY2:
-        dt_exp = dt.astimezone(tz.tzlocal())
-    else:
-        dt_exp = dt.astimezone()
+    dt_exp = dt.astimezone()
 
     assert dt_act == dt_exp
     assert dt_act.tzname() == dt_exp.tzname()


### PR DESCRIPTION
This test has been somewhat flaky in the past on some platforms, so we will explicitly give it more time.