### PR TITLE
Build a pinned copy of tzdata for use with CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,8 +10,39 @@ on:
 
 env:
   pypi-hosts: "pypi.python.org pypi.org files.pythonhosted.org"
+  TZDATA_VERSION: "2024a"
 
 jobs:
+  build-tzdata:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cache tzdata
+        id: cache-tzdata
+        uses: actions/cache@v4
+        with:
+          path: tzdata_built
+          key: tzdata-${{ env.TZDATA_VERSION }}
+
+      - name: Build tzdata
+        if: steps.cache-tzdata.outputs.cache-hit != 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lzip curl
+          mkdir -p tzdata_built
+          TMP_DIR=$(mktemp -d)
+          cd $TMP_DIR
+          curl --fail --location "https://data.iana.org/time-zones/releases/tzdb-${{ env.TZDATA_VERSION }}.tar.lz" -o tzdb.tar.lz
+          tar --lzip -xf tzdb.tar.lz
+          cd tzdb-${{ env.TZDATA_VERSION }}
+          make install DESTDIR=$GITHUB_WORKSPACE/tzdata_built \
+                        DATAFORM=main
+
+      - name: Upload tzdata artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tzdata
+          path: tzdata_built/usr/share/zoneinfo
+
   test:
     strategy:
       matrix:
@@ -54,11 +85,13 @@ jobs:
             python-version: "3.7"
             use-container: true
     runs-on: ${{ matrix.os }}
+    needs: build-tzdata
     container:
       image: ${{ matrix.use-container && format('python:{0}', matrix.python-version) || '' }}
     env:
       TOXENV: py
       PIP_TRUSTED_HOST: pypi.python.org
+      SUDO: ${{ !matrix.use-container && 'sudo' || '' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -70,6 +103,19 @@ jobs:
           allow-prereleases: true
         env:
           PIP_TRUSTED_HOST: ${{ contains(fromJson('["2.7", "3.5", "3.6", "3.7"]'), matrix.python-version) && env.pypi-hosts || '' }}
+      - name: Download tzdata artifact
+        uses: actions/download-artifact@v4
+        if: startsWith(matrix.os, 'ubuntu')
+        with:
+          name: tzdata
+          path: tzdata_download
+      - name: Install specific tzdata version
+        run: |
+          $SUDO rm -rf /usr/share/zoneinfo
+          $SUDO mv tzdata_download /usr/share/zoneinfo
+
+          cat /usr/share/zoneinfo/tzdata.zi | head -n 1
+        if: startsWith(matrix.os, 'ubuntu')
       - name: Install dependencies
         run: python -m pip install -U tox six
       - name: Install zic (Windows)
@@ -101,6 +147,7 @@ jobs:
 
   other:
     runs-on: "ubuntu-latest"
+    needs: build-tzdata
     strategy:
       matrix:
         toxenv: ["docs", "tz", "precommit"]
@@ -115,6 +162,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: Download tzdata artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: tzdata
+          path: tzdata_download
+      - name: Install specific tzdata version
+        run: |
+          sudo rm -rf /usr/share/zoneinfo
+          sudo mv tzdata_download /usr/share/zoneinfo
+
+          cat /usr/share/zoneinfo/tzdata.zi | head -n 1
       - name: Install tox
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tzdata_built
-          key: tzdata-${{ env.TZDATA_VERSION }}
+          key: tzdata-${{ env.TZDATA_VERSION }}-fat
 
       - name: Build tzdata
         if: steps.cache-tzdata.outputs.cache-hit != 'true'
@@ -34,8 +34,10 @@ jobs:
           curl --fail --location "https://data.iana.org/time-zones/releases/tzdb-${{ env.TZDATA_VERSION }}.tar.lz" -o tzdb.tar.lz
           tar --lzip -xf tzdb.tar.lz
           cd tzdb-${{ env.TZDATA_VERSION }}
+          # TODO: Don't use fat when slim builds are available
           make install DESTDIR=$GITHUB_WORKSPACE/tzdata_built \
-                        DATAFORM=main
+                        DATAFORM=main \
+                        ZFLAGS="-b fat"
 
       - name: Upload tzdata artifact
         uses: actions/upload-artifact@v4
@@ -114,7 +116,7 @@ jobs:
           $SUDO rm -rf /usr/share/zoneinfo
           $SUDO mv tzdata_download /usr/share/zoneinfo
 
-          cat /usr/share/zoneinfo/tzdata.zi | head -n 1
+          head -n 1 /usr/share/zoneinfo/tzdata.zi
         if: startsWith(matrix.os, 'ubuntu')
       - name: Install dependencies
         run: python -m pip install -U tox six

--- a/changelog.d/1470.misc.rst
+++ b/changelog.d/1470.misc.rst
@@ -1,0 +1,1 @@
+A specific version of tzdata is now used, rather than relying on the system version. (gh pr #1470)

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,11 @@ commands =
 description = Run the tests against the master of the tz database
 basepython = python3.13
 deps = -r {toxinidir}/requirements-dev.txt
-setenv = DATEUTIL_TZPATH = {envtmpdir}/tzdir/usr/share/zoneinfo
+# TODO: Remove the TZ = UTC requirement
+setenv =
+    DATEUTIL_TZPATH = {envtmpdir}/tzdir/usr/share/zoneinfo
+    TZDIR = {envtmpdir}/tzdir/usr/share/zoneinfo
+    TZ = UTC
 changedir = {toxworkdir}
 allowlist_externals =
     {toxinidir}/ci_tools/run_tz_master_env.sh


### PR DESCRIPTION
## Summary of changes

This allows us to pin to a specific version rather than relying on whatever is on the system version.

This is implemented as a single (cached) job to build the TZif files which are then used by anything that needs them.

### Pull Request Checklist
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [X] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
