### PR TITLE
Infer BYMONTH from DTSTART for yearly BYMONTHDAY rules

### DIFF
--- a/changelog.d/1471.bugfix.rst
+++ b/changelog.d/1471.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed yearly ``rrule`` generation so ``BYMONTHDAY`` rules without an explicit
+``BYMONTH`` now use the month from ``DTSTART`` instead of expanding across
+every month in the year. Reported by @laydros (gh issue #1452). Fixed by
+@oaksprout (gh pr #1471)

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -501,6 +501,12 @@ class rrule(rrulebase):
         if self._bysetpos:
             self._original_rule['bysetpos'] = self._bysetpos
 
+        if (freq == YEARLY and bymonth is None and bymonthday is not None and
+                byweekday is None and bysetpos is None and
+                byyearday is None and byweekno is None and byeaster is None):
+            bymonth = dtstart.month
+            self._original_rule['bymonth'] = None
+
         if (byweekno is None and byyearday is None and bymonthday is None and
                 byweekday is None and byeaster is None):
             if freq == YEARLY:

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -501,11 +501,18 @@ class rrule(rrulebase):
         if self._bysetpos:
             self._original_rule['bysetpos'] = self._bysetpos
 
-        if (freq == YEARLY and bymonth is None and bymonthday is not None and
-                byweekday is None and bysetpos is None and
-                byyearday is None and byweekno is None and byeaster is None):
+        if (
+            freq == YEARLY
+            and bymonth is None
+            and bymonthday is not None
+            and byweekday is None
+            and bysetpos is None
+            and byyearday is None
+            and byweekno is None
+            and byeaster is None
+        ):
             bymonth = dtstart.month
-            self._original_rule['bymonth'] = None
+            self._original_rule["bymonth"] = None
 
         if (byweekno is None and byyearday is None and bymonthday is None and
                 byweekday is None and byeaster is None):

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -81,13 +81,21 @@ class RRuleTest(unittest.TestCase):
                           datetime(1999, 1, 2, 9, 0)])
 
     def testYearlyByMonthDay(self):
-        self.assertEqual(list(rrule(YEARLY,
-                              count=3,
-                              bymonthday=(1, 3),
-                              dtstart=datetime(1997, 9, 2, 9, 0))),
-                         [datetime(1997, 9, 3, 9, 0),
-                          datetime(1998, 9, 1, 9, 0),
-                          datetime(1998, 9, 3, 9, 0)])
+        self.assertEqual(
+            list(
+                rrule(
+                    YEARLY,
+                    count=3,
+                    bymonthday=(1, 3),
+                    dtstart=datetime(1997, 9, 2, 9, 0),
+                )
+            ),
+            [
+                datetime(1997, 9, 3, 9, 0),
+                datetime(1998, 9, 1, 9, 0),
+                datetime(1998, 9, 3, 9, 0),
+            ],
+        )
 
     def testYearlyByMonthAndMonthDay(self):
         self.assertEqual(list(rrule(YEARLY,
@@ -169,22 +177,30 @@ class RRuleTest(unittest.TestCase):
                           datetime(1998, 3, 3, 9, 0)])
 
     def testYearlyByMonthDayUsesDtstartMonth(self):
-        self.assertEqual(list(rrule(YEARLY,
-                              count=12,
-                              bymonthday=30,
-                              dtstart=datetime(2010, 3, 30))),
-                         [datetime(2010, 3, 30),
-                          datetime(2011, 3, 30),
-                          datetime(2012, 3, 30),
-                          datetime(2013, 3, 30),
-                          datetime(2014, 3, 30),
-                          datetime(2015, 3, 30),
-                          datetime(2016, 3, 30),
-                          datetime(2017, 3, 30),
-                          datetime(2018, 3, 30),
-                          datetime(2019, 3, 30),
-                          datetime(2020, 3, 30),
-                          datetime(2021, 3, 30)])
+        self.assertEqual(
+            list(
+                rrule(
+                    YEARLY,
+                    count=12,
+                    bymonthday=30,
+                    dtstart=datetime(2010, 3, 30),
+                )
+            ),
+            [
+                datetime(2010, 3, 30),
+                datetime(2011, 3, 30),
+                datetime(2012, 3, 30),
+                datetime(2013, 3, 30),
+                datetime(2014, 3, 30),
+                datetime(2015, 3, 30),
+                datetime(2016, 3, 30),
+                datetime(2017, 3, 30),
+                datetime(2018, 3, 30),
+                datetime(2019, 3, 30),
+                datetime(2020, 3, 30),
+                datetime(2021, 3, 30),
+            ],
+        )
 
     def testYearlyByMonthAndMonthDayAndWeekDay(self):
         self.assertEqual(list(rrule(YEARLY,

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -86,8 +86,8 @@ class RRuleTest(unittest.TestCase):
                               bymonthday=(1, 3),
                               dtstart=datetime(1997, 9, 2, 9, 0))),
                          [datetime(1997, 9, 3, 9, 0),
-                          datetime(1997, 10, 1, 9, 0),
-                          datetime(1997, 10, 3, 9, 0)])
+                          datetime(1998, 9, 1, 9, 0),
+                          datetime(1998, 9, 3, 9, 0)])
 
     def testYearlyByMonthAndMonthDay(self):
         self.assertEqual(list(rrule(YEARLY,
@@ -167,6 +167,24 @@ class RRuleTest(unittest.TestCase):
                          [datetime(1998, 1, 1, 9, 0),
                           datetime(1998, 2, 3, 9, 0),
                           datetime(1998, 3, 3, 9, 0)])
+
+    def testYearlyByMonthDayUsesDtstartMonth(self):
+        self.assertEqual(list(rrule(YEARLY,
+                              count=12,
+                              bymonthday=30,
+                              dtstart=datetime(2010, 3, 30))),
+                         [datetime(2010, 3, 30),
+                          datetime(2011, 3, 30),
+                          datetime(2012, 3, 30),
+                          datetime(2013, 3, 30),
+                          datetime(2014, 3, 30),
+                          datetime(2015, 3, 30),
+                          datetime(2016, 3, 30),
+                          datetime(2017, 3, 30),
+                          datetime(2018, 3, 30),
+                          datetime(2019, 3, 30),
+                          datetime(2020, 3, 30),
+                          datetime(2021, 3, 30)])
 
     def testYearlyByMonthAndMonthDayAndWeekDay(self):
         self.assertEqual(list(rrule(YEARLY,


### PR DESCRIPTION
## Summary
- infer `BYMONTH` from `DTSTART` for `YEARLY` rules that only specify `BYMONTHDAY`
- keep the broader year-wide behavior for combinations that also use selectors like `BYWEEKDAY` or `BYSETPOS`
- add regression coverage for the March 30 yearly recurrence from #1452

## Testing
- `.venv/bin/pytest tests/test_rrule.py`
- `.venv/bin/pytest tests/test_rrule.py -k "YearlyByMonthDay or YearlyBySetPos"`

Fixes #1452.