### PR TITLE
docs: add solutions and fix typo for Next Monday and Parsing tzname exercises

### DIFF
--- a/changelog.d/1473.doc.rst
+++ b/changelog.d/1473.doc.rst
@@ -1,0 +1,2 @@
+Added solutions for the "Next Monday meeting" and "Parsing a local tzname" exercises;
+fixed "Ireland" → "Israel" typo in exercise #666.

--- a/docs/exercises/index.rst
+++ b/docs/exercises/index.rst
@@ -71,6 +71,8 @@ To solve this exercise, copy-paste this script into a document, change anything 
 A solution to this problem is provided :doc:`here <solutions/mlk-day-rrule>`.
 
 
+.. _next-monday-exercise:
+
 Next Monday meeting
 -------------------
 
@@ -121,6 +123,10 @@ To solve this exercise, copy-paste this script into a document, change anything 
 
     </details>
 
+A solution to this problem is provided :doc:`here <solutions/next-monday-meeting>`.
+
+
+.. _parsing-local-tzname-exercise:
 
 Parsing a local tzname
 ----------------------
@@ -194,7 +200,7 @@ To solve this exercise, copy-paste this script into a document, change anything 
 
 Problem 2
 *********
-    Given the context that you will *only* be passed dates from India or Ireland, write a function that correctly parses all *unambiguous* time zone strings to aware datetimes localized to the correct IANA zone, and for *ambiguous* time zone strings default to India.
+    Given the context that you will *only* be passed dates from India or Israel, write a function that correctly parses all *unambiguous* time zone strings to aware datetimes localized to the correct IANA zone, and for *ambiguous* time zone strings default to India.
 
 **Test Script**
 
@@ -211,7 +217,7 @@ To solve this exercise, copy-paste this script into a document, change anything 
     from dateutil.parser import parse
     from dateutil import tz
 
-    def parse_func_ind_ire():
+    def parse_func_ind_isr():
         <<YOUR CODE HERE>>
 
     # ---------------------------------- #
@@ -228,7 +234,7 @@ To solve this exercise, copy-paste this script into a document, change anything 
 
     def test_parse_ixt():
         for dtstr, dt_exp in PARSE_IXT_TEST_CASE:
-            dt_act = parse_func_ind_ire(dtstr)
+            dt_act = parse_func_ind_isr(dtstr)
             assert dt_act == dt_exp, (dt_act, dt_exp)
             assert dt_act.tzinfo is dt_exp.tzinfo, (dt_act, dt_exp)
 
@@ -239,4 +245,6 @@ To solve this exercise, copy-paste this script into a document, change anything 
 .. raw:: html
 
     </details>
+
+A solution to this problem is provided :doc:`here <solutions/parsing-local-tzname>`.
 

--- a/docs/exercises/solutions/next-monday-meeting.rst
+++ b/docs/exercises/solutions/next-monday-meeting.rst
@@ -1,0 +1,34 @@
+Next Monday Meeting — Solution
+==============================
+
+This is a solution to the :ref:`Next Monday meeting exercise <next-monday-exercise>`.
+
+The key insight is to use :class:`dateutil.relativedelta.relativedelta` with ``weekday=MO(+1)``
+to advance to the next Monday, and replace the time components at the same time. However, if
+the input is already exactly Monday at 10:00, it should return that same datetime (not the
+following week).
+
+.. code-block:: python3
+
+    from datetime import datetime
+    from dateutil.relativedelta import relativedelta, MO
+    from dateutil import tz
+
+    def next_monday(dt):
+        # Replace time to 10:00 and move to next Monday (or stay if already Monday at 10:00)
+        candidate = dt + relativedelta(weekday=MO, hour=10, minute=0, second=0, microsecond=0)
+        # If the candidate is in the past relative to dt (same Monday but already past 10:00),
+        # advance by one week
+        if candidate < dt:
+            candidate += relativedelta(weeks=1)
+        return candidate
+
+**Walkthrough**
+
+``relativedelta(weekday=MO, hour=10, minute=0, second=0, microsecond=0)`` does two things at once:
+
+1. Advances (or stays) to the nearest Monday using ``weekday=MO``.
+2. Sets the time to 10:00:00 by replacing ``hour``, ``minute``, ``second``, and ``microsecond``.
+
+If the result is still *before* ``dt`` — which happens when ``dt`` is a Monday after 10:00 AM —
+we add one more week to get the *next* Monday.

--- a/docs/exercises/solutions/next-monday-meeting.rst
+++ b/docs/exercises/solutions/next-monday-meeting.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Next Monday Meeting — Solution
 ==============================
 

--- a/docs/exercises/solutions/parsing-local-tzname.rst
+++ b/docs/exercises/solutions/parsing-local-tzname.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Parsing a local tzname — Solution
 ==================================
 

--- a/docs/exercises/solutions/parsing-local-tzname.rst
+++ b/docs/exercises/solutions/parsing-local-tzname.rst
@@ -1,0 +1,53 @@
+Parsing a local tzname — Solution
+==================================
+
+This is a solution to the :ref:`parsing-local-tzname-exercise`.
+
+Problem 1 — US, India and Japan
+---------------------------------
+
+The trick is to pass a ``tzinfos`` dictionary to :func:`dateutil.parser.parse` that maps
+each timezone abbreviation to the correct IANA timezone object:
+
+.. code-block:: python3
+
+    from dateutil.parser import parse
+    from dateutil import tz
+
+    US_JP_IND_TZINFOS = {
+        # US timezones (standard and daylight)
+        'EST': tz.gettz('America/New_York'),
+        'EDT': tz.gettz('America/New_York'),
+        'CST': tz.gettz('America/Chicago'),
+        'CDT': tz.gettz('America/Chicago'),
+        'MST': tz.gettz('America/Denver'),
+        'MDT': tz.gettz('America/Denver'),
+        'PST': tz.gettz('America/Los_Angeles'),
+        'PDT': tz.gettz('America/Los_Angeles'),
+        # India
+        'IST': tz.gettz('Asia/Kolkata'),
+        # Japan
+        'JST': tz.gettz('Asia/Tokyo'),
+    }
+
+    def parse_func_us_jp_ind(dtstr):
+        return parse(dtstr, tzinfos=US_JP_IND_TZINFOS)
+
+Problem 2 — India and Israel
+------------------------------
+
+``IST`` is ambiguous between India Standard Time and Israel Standard Time (``IDT`` is
+Israel Daylight Time). We default to India for ambiguous strings:
+
+.. code-block:: python3
+
+    from dateutil.parser import parse
+    from dateutil import tz
+
+    IND_ISR_TZINFOS = {
+        'IST': tz.gettz('Asia/Kolkata'),   # ambiguous → default to India
+        'IDT': tz.gettz('Asia/Jerusalem'),  # unambiguous Israel Daylight Time
+    }
+
+    def parse_func_ind_isr(dtstr):
+        return parse(dtstr, tzinfos=IND_ISR_TZINFOS)


### PR DESCRIPTION
Fixes #665, fixes #666

## Changes

### Solution files added
- `docs/exercises/solutions/next-monday-meeting.rst` — solution for the Next Monday meeting exercise using `relativedelta(weekday=MO, hour=10, ...)` with edge-case handling
- `docs/exercises/solutions/parsing-local-tzname.rst` — solutions for both Problem 1 (US/India/Japan) and Problem 2 (India/Israel) using `parser.parse()` with a `tzinfos` mapping

### Fixes in `index.rst`
- Added RST anchors (`.. _next-monday-exercise:`, `.. _parsing-local-tzname-exercise:`) so solutions can link back
- Added solution links at the end of each exercise (matching the pattern used by the MLK Day exercise)
- **Typo fix**: Problem 2 said "India or Ireland" but the test code used `ISRAEL = tz.gettz('Asia/Jerusalem')` — corrected to "India or Israel" (noted by @ffe4 in #666)
- **Function name fix**: `parse_func_ind_ire` → `parse_func_ind_isr` in test code to match the corrected problem

## Changelog

I'll add the `changelog.d/` fragment once the PR number is known (per CONTRIBUTING.md).