### PR TITLE
fix(parser): preserve sign for UTC/GMT/Z offset notation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -286,6 +286,8 @@ linkcheck_ignore = [
     r'https://pgp.mit.edu',
     # MetaCPAN frequently returns 402 for automated link checkers
     r"https://metacpan.org/.*",
+    # Oracle Java docs often fail TLS from CI runners
+    r"https://docs\.oracle\.com/.*",
 ]
 
 # Reduce problems with ephemeral failures

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -35,19 +35,15 @@ import re
 import string
 import time
 import warnings
-
 from calendar import monthrange
+from decimal import Decimal
 from io import StringIO
+from warnings import warn
 
 import six
 from six import integer_types, text_type
 
-from decimal import Decimal
-
-from warnings import warn
-
-from .. import relativedelta
-from .. import tz
+from .. import relativedelta, tz
 
 __all__ = ["parse", "parserinfo", "ParserError"]
 
@@ -65,9 +61,11 @@ class _timelex(object):
 
         if isinstance(instream, text_type):
             instream = StringIO(instream)
-        elif getattr(instream, 'read', None) is None:
-            raise TypeError('Parser must be a string or character stream, not '
-                            '{itype}'.format(itype=instream.__class__.__name__))
+        elif getattr(instream, "read", None) is None:
+            raise TypeError(
+                "Parser must be a string or character stream, not "
+                "{itype}".format(itype=instream.__class__.__name__)
+            )
 
         self.instream = instream
         self.charstack = []
@@ -104,7 +102,7 @@ class _timelex(object):
                 nextchar = self.charstack.pop(0)
             else:
                 nextchar = self.instream.read(1)
-                while nextchar == '\x00':
+                while nextchar == "\x00":
                     nextchar = self.instream.read(1)
 
             if not nextchar:
@@ -115,71 +113,72 @@ class _timelex(object):
                 # to parse a word, a number or something else.
                 token = nextchar
                 if self.isword(nextchar):
-                    state = 'a'
+                    state = "a"
                 elif self.isnum(nextchar):
-                    state = '0'
+                    state = "0"
                 elif self.isspace(nextchar):
-                    token = ' '
+                    token = " "
                     break  # emit token
                 else:
                     break  # emit token
-            elif state == 'a':
+            elif state == "a":
                 # If we've already started reading a word, we keep reading
                 # letters until we find something that's not part of a word.
                 seenletters = True
                 if self.isword(nextchar):
                     token += nextchar
-                elif nextchar == '.':
+                elif nextchar == ".":
                     token += nextchar
-                    state = 'a.'
+                    state = "a."
                 else:
                     self.charstack.append(nextchar)
                     break  # emit token
-            elif state == '0':
+            elif state == "0":
                 # If we've already started reading a number, we keep reading
                 # numbers until we find something that doesn't fit.
                 if self.isnum(nextchar):
                     token += nextchar
-                elif nextchar == '.' or (nextchar == ',' and len(token) >= 2):
+                elif nextchar == "." or (nextchar == "," and len(token) >= 2):
                     token += nextchar
-                    state = '0.'
+                    state = "0."
                 else:
                     self.charstack.append(nextchar)
                     break  # emit token
-            elif state == 'a.':
+            elif state == "a.":
                 # If we've seen some letters and a dot separator, continue
                 # parsing, and the tokens will be broken up later.
                 seenletters = True
-                if nextchar == '.' or self.isword(nextchar):
+                if nextchar == "." or self.isword(nextchar):
                     token += nextchar
-                elif self.isnum(nextchar) and token[-1] == '.':
+                elif self.isnum(nextchar) and token[-1] == ".":
                     token += nextchar
-                    state = '0.'
+                    state = "0."
                 else:
                     self.charstack.append(nextchar)
                     break  # emit token
-            elif state == '0.':
+            elif state == "0.":
                 # If we've seen at least one dot separator, keep going, we'll
                 # break up the tokens later.
-                if nextchar == '.' or self.isnum(nextchar):
+                if nextchar == "." or self.isnum(nextchar):
                     token += nextchar
-                elif self.isword(nextchar) and token[-1] == '.':
+                elif self.isword(nextchar) and token[-1] == ".":
                     token += nextchar
-                    state = 'a.'
+                    state = "a."
                 else:
                     self.charstack.append(nextchar)
                     break  # emit token
 
-        if (state in ('a.', '0.') and (seenletters or token.count('.') > 1 or
-                                       token[-1] in '.,')):
+        if state in ("a.", "0.") and (
+            seenletters or token.count(".") > 1 or token[-1] in ".,"
+        ):
             l = self._split_decimal.split(token)
             token = l[0]
             for tok in l[1:]:
                 if tok:
                     self.tokenstack.append(tok)
 
-        if state == '0.' and token.count('.') == 0:
-            token = token.replace(',', '.')
+        if state == "0." and token.count(".") == 0:
+            token = token.replace(",", ".")
 
         return token
 
@@ -202,22 +201,21 @@ class _timelex(object):
 
     @classmethod
     def isword(cls, nextchar):
-        """ Whether or not the next character is part of a word """
+        """Whether or not the next character is part of a word"""
         return nextchar.isalpha()
 
     @classmethod
     def isnum(cls, nextchar):
-        """ Whether the next character is part of a number """
+        """Whether the next character is part of a number"""
         return nextchar.isdigit()
 
     @classmethod
     def isspace(cls, nextchar):
-        """ Whether the next character is whitespace """
+        """Whether the next character is whitespace"""
         return nextchar.isspace()
 
 
 class _resultbase(object):
-
     def __init__(self):
         for attr in self.__slots__:
             setattr(self, attr, None)
@@ -231,8 +229,7 @@ class _resultbase(object):
         return "%s(%s)" % (classname, ", ".join(l))
 
     def __len__(self):
-        return (sum(getattr(self, attr) is not None
-                    for attr in self.__slots__))
+        return sum(getattr(self, attr) is not None for attr in self.__slots__)
 
     def __repr__(self):
         return self._repr(self.__class__.__name__)
@@ -257,34 +254,56 @@ class parserinfo(object):
     """
 
     # m from a.m/p.m, t from ISO T separator
-    JUMP = [" ", ".", ",", ";", "-", "/", "'",
-            "at", "on", "and", "ad", "m", "t", "of",
-            "st", "nd", "rd", "th"]
+    JUMP = [
+        " ",
+        ".",
+        ",",
+        ";",
+        "-",
+        "/",
+        "'",
+        "at",
+        "on",
+        "and",
+        "ad",
+        "m",
+        "t",
+        "of",
+        "st",
+        "nd",
+        "rd",
+        "th",
+    ]
 
-    WEEKDAYS = [("Mon", "Monday"),
-                ("Tue", "Tuesday"),     # TODO: "Tues"
-                ("Wed", "Wednesday"),
-                ("Thu", "Thursday"),    # TODO: "Thurs"
-                ("Fri", "Friday"),
-                ("Sat", "Saturday"),
-                ("Sun", "Sunday")]
-    MONTHS = [("Jan", "January"),
-              ("Feb", "February"),      # TODO: "Febr"
-              ("Mar", "March"),
-              ("Apr", "April"),
-              ("May", "May"),
-              ("Jun", "June"),
-              ("Jul", "July"),
-              ("Aug", "August"),
-              ("Sep", "Sept", "September"),
-              ("Oct", "October"),
-              ("Nov", "November"),
-              ("Dec", "December")]
-    HMS = [("h", "hour", "hours"),
-           ("m", "minute", "minutes"),
-           ("s", "second", "seconds")]
-    AMPM = [("am", "a"),
-            ("pm", "p")]
+    WEEKDAYS = [
+        ("Mon", "Monday"),
+        ("Tue", "Tuesday"),  # TODO: "Tues"
+        ("Wed", "Wednesday"),
+        ("Thu", "Thursday"),  # TODO: "Thurs"
+        ("Fri", "Friday"),
+        ("Sat", "Saturday"),
+        ("Sun", "Sunday"),
+    ]
+    MONTHS = [
+        ("Jan", "January"),
+        ("Feb", "February"),  # TODO: "Febr"
+        ("Mar", "March"),
+        ("Apr", "April"),
+        ("May", "May"),
+        ("Jun", "June"),
+        ("Jul", "July"),
+        ("Aug", "August"),
+        ("Sep", "Sept", "September"),
+        ("Oct", "October"),
+        ("Nov", "November"),
+        ("Dec", "December"),
+    ]
+    HMS = [
+        ("h", "hour", "hours"),
+        ("m", "minute", "minutes"),
+        ("s", "second", "seconds"),
+    ]
+    AMPM = [("am", "a"), ("pm", "p")]
     UTCZONE = ["UTC", "GMT", "Z", "z"]
     PERTAIN = ["of"]
     TZOFFSET = {}
@@ -382,8 +401,9 @@ class parserinfo(object):
         if res.year is not None:
             res.year = self.convertyear(res.year, res.century_specified)
 
-        if ((res.tzoffset == 0 and not res.tzname) or
-             (res.tzname == 'Z' or res.tzname == 'z')):
+        if (res.tzoffset == 0 and not res.tzname) or (
+            res.tzname == "Z" or res.tzname == "z"
+        ):
             res.tzname = "UTC"
             res.tzoffset = 0
         elif res.tzoffset != 0 and res.tzname and self.utczone(res.tzname):
@@ -426,31 +446,31 @@ class _ymd(list):
             return 1 <= value <= monthrange(year, month)[1]
 
     def append(self, val, label=None):
-        if hasattr(val, '__len__'):
+        if hasattr(val, "__len__"):
             if val.isdigit() and len(val) > 2:
                 self.century_specified = True
-                if label not in [None, 'Y']:  # pragma: no cover
+                if label not in [None, "Y"]:  # pragma: no cover
                     raise ValueError(label)
-                label = 'Y'
+                label = "Y"
         elif val > 100:
             self.century_specified = True
-            if label not in [None, 'Y']:  # pragma: no cover
+            if label not in [None, "Y"]:  # pragma: no cover
                 raise ValueError(label)
-            label = 'Y'
+            label = "Y"
 
         super(self.__class__, self).append(int(val))
 
-        if label == 'M':
+        if label == "M":
             if self.has_month:
-                raise ValueError('Month is already set')
+                raise ValueError("Month is already set")
             self.mstridx = len(self) - 1
-        elif label == 'D':
+        elif label == "D":
             if self.has_day:
-                raise ValueError('Day is already set')
+                raise ValueError("Day is already set")
             self.dstridx = len(self) - 1
-        elif label == 'Y':
+        elif label == "Y":
             if self.has_year:
-                raise ValueError('Year is already set')
+                raise ValueError("Year is already set")
             self.ystridx = len(self) - 1
 
     def _resolve_from_stridxs(self, strids):
@@ -461,7 +481,7 @@ class _ymd(list):
         if len(self) == 3 and len(strids) == 2:
             # we can back out the remaining stridx value
             missing = [x for x in range(3) if x not in strids.values()]
-            key = [x for x in ['y', 'm', 'd'] if x not in strids]
+            key = [x for x in ["y", "m", "d"] if x not in strids]
             assert len(missing) == len(key) == 1
             key = key[0]
             val = missing[0]
@@ -469,19 +489,18 @@ class _ymd(list):
 
         assert len(self) == len(strids)  # otherwise this should not be called
         out = {key: self[strids[key]] for key in strids}
-        return (out.get('y'), out.get('m'), out.get('d'))
+        return (out.get("y"), out.get("m"), out.get("d"))
 
     def resolve_ymd(self, yearfirst, dayfirst):
         len_ymd = len(self)
         year, month, day = (None, None, None)
 
-        strids = (('y', self.ystridx),
-                  ('m', self.mstridx),
-                  ('d', self.dstridx))
+        strids = (("y", self.ystridx), ("m", self.mstridx), ("d", self.dstridx))
 
         strids = {key: val for key, val in strids if val is not None}
-        if (len(self) == len(strids) > 0 or
-                (len(self) == 3 and len(strids) == 2)):
+        if len(self) == len(strids) > 0 or (
+            len(self) == 3 and len(strids) == 2
+        ):
             return self._resolve_from_stridxs(strids)
 
         mstridx = self.mstridx
@@ -547,9 +566,11 @@ class _ymd(list):
                     year, day, month = self
 
             else:
-                if (self[0] > 31 or
-                    self.ystridx == 0 or
-                        (yearfirst and self[1] <= 12 and self[2] <= 31)):
+                if (
+                    self[0] > 31
+                    or self.ystridx == 0
+                    or (yearfirst and self[1] <= 12 and self[2] <= 31)
+                ):
                     # 99-01-01
                     if dayfirst and self[2] <= 12:
                         year, day, month = self
@@ -569,8 +590,9 @@ class parser(object):
     def __init__(self, info=None):
         self.info = info or parserinfo()
 
-    def parse(self, timestr, default=None,
-              ignoretz=False, tzinfos=None, **kwargs):
+    def parse(
+        self, timestr, default=None, ignoretz=False, tzinfos=None, **kwargs
+    ):
         """
         Parse the date/time string into a :class:`datetime.datetime` object.
 
@@ -634,8 +656,9 @@ class parser(object):
         """
 
         if default is None:
-            default = datetime.datetime.now().replace(hour=0, minute=0,
-                                                      second=0, microsecond=0)
+            default = datetime.datetime.now().replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
 
         res, skipped_tokens = self._parse(timestr, **kwargs)
 
@@ -653,18 +676,35 @@ class parser(object):
         if not ignoretz:
             ret = self._build_tzaware(ret, res, tzinfos)
 
-        if kwargs.get('fuzzy_with_tokens', False):
+        if kwargs.get("fuzzy_with_tokens", False):
             return ret, skipped_tokens
         else:
             return ret
 
     class _result(_resultbase):
-        __slots__ = ["year", "month", "day", "weekday",
-                     "hour", "minute", "second", "microsecond",
-                     "tzname", "tzoffset", "ampm","any_unused_tokens"]
+        __slots__ = [
+            "year",
+            "month",
+            "day",
+            "weekday",
+            "hour",
+            "minute",
+            "second",
+            "microsecond",
+            "tzname",
+            "tzoffset",
+            "ampm",
+            "any_unused_tokens",
+        ]
 
-    def _parse(self, timestr, dayfirst=None, yearfirst=None, fuzzy=False,
-               fuzzy_with_tokens=False):
+    def _parse(
+        self,
+        timestr,
+        dayfirst=None,
+        yearfirst=None,
+        fuzzy=False,
+        fuzzy_with_tokens=False,
+    ):
         """
         Private method which performs the heavy lifting of parsing, called from
         ``parse()``, which passes on its ``kwargs`` to this function.
@@ -716,7 +756,7 @@ class parser(object):
             yearfirst = info.yearfirst
 
         res = self._result()
-        l = _timelex.split(timestr)         # Splits the timestr into tokens
+        l = _timelex.split(timestr)  # Splits the timestr into tokens
 
         skipped_idxs = []
 
@@ -727,7 +767,6 @@ class parser(object):
         i = 0
         try:
             while i < len_l:
-
                 # Check if it's a number
                 value_repr = l[i]
                 try:
@@ -747,10 +786,10 @@ class parser(object):
                 # Check month name
                 elif info.month(l[i]) is not None:
                     value = info.month(l[i])
-                    ymd.append(value, 'M')
+                    ymd.append(value, "M")
 
                     if i + 1 < len_l:
-                        if l[i + 1] in ('-', '/'):
+                        if l[i + 1] in ("-", "/"):
                             # Jan-01[-99]
                             sep = l[i + 1]
                             ymd.append(l[i + 2])
@@ -762,15 +801,18 @@ class parser(object):
 
                             i += 2
 
-                        elif (i + 4 < len_l and l[i + 1] == l[i + 3] == ' ' and
-                              info.pertain(l[i + 2])):
+                        elif (
+                            i + 4 < len_l
+                            and l[i + 1] == l[i + 3] == " "
+                            and info.pertain(l[i + 2])
+                        ):
                             # Jan of 01
                             # In this case, 01 is clearly year
                             if l[i + 4].isdigit():
                                 # Convert it here to become unambiguous
                                 value = int(l[i + 4])
                                 year = str(info.convertyear(value))
-                                ymd.append(year, 'Y')
+                                ymd.append(year, "Y")
                             else:
                                 # Wrong guess
                                 pass
@@ -790,7 +832,9 @@ class parser(object):
                         skipped_idxs.append(i)
 
                 # Check for a timezone name
-                elif self._could_be_tzname(res.hour, res.tzname, res.tzoffset, l[i]):
+                elif self._could_be_tzname(
+                    res.hour, res.tzname, res.tzoffset, l[i]
+                ):
                     res.tzname = l[i]
                     res.tzoffset = info.tzoffset(res.tzname)
 
@@ -804,7 +848,7 @@ class parser(object):
                     # following offset should NOT be reversed - it
                     # represents a direct UTC offset like "UTC-4"
                     # meaning UTC minus 4 hours, not POSIX convention.
-                    if i + 1 < len_l and l[i + 1] in ('+', '-'):
+                    if i + 1 < len_l and l[i + 1] in ("+", "-"):
                         if info.utczone(res.tzname):
                             # For UTC/GMT/Z, the offset is literal:
                             # "UTC-4" means UTC-4, not UTC+4
@@ -814,12 +858,12 @@ class parser(object):
                             # For non-UTC timezone abbreviations,
                             # apply POSIX convention: BRST+3 means
                             # "my time +3 is BRST", i.e. UTC-3
-                            l[i + 1] = ('+', '-')[l[i + 1] == '+']
+                            l[i + 1] = ("+", "-")[l[i + 1] == "+"]
                             res.tzoffset = None
 
                 # Check for a numbered timezone
-                elif res.hour is not None and l[i] in ('+', '-'):
-                    signal = (-1, 1)[l[i] == '+']
+                elif res.hour is not None and l[i] in ("+", "-"):
+                    signal = (-1, 1)[l[i] == "+"]
                     len_li = len(l[i + 1])
 
                     # TODO: check that l[i + 1] is integer?
@@ -827,10 +871,12 @@ class parser(object):
                         # -0300
                         hour_offset = int(l[i + 1][:2])
                         min_offset = int(l[i + 1][2:])
-                    elif i + 2 < len_l and l[i + 2] == ':':
+                    elif i + 2 < len_l and l[i + 2] == ":":
                         # -03:00
                         hour_offset = int(l[i + 1])
-                        min_offset = int(l[i + 3])  # TODO: Check that l[i+3] is minute-like?
+                        min_offset = int(
+                            l[i + 3]
+                        )  # TODO: Check that l[i+3] is minute-like?
                         i += 2
                     elif len_li <= 2:
                         # -[0]3
@@ -839,15 +885,21 @@ class parser(object):
                     else:
                         raise ValueError(timestr)
 
-                    res.tzoffset = signal * (hour_offset * 3600 + min_offset * 60)
+                    res.tzoffset = signal * (
+                        hour_offset * 3600 + min_offset * 60
+                    )
 
                     # Look for a timezone name between parenthesis
-                    if (i + 5 < len_l and
-                            info.jump(l[i + 2]) and l[i + 3] == '(' and
-                            l[i + 5] == ')' and
-                            3 <= len(l[i + 4]) and
-                            self._could_be_tzname(res.hour, res.tzname,
-                                                  None, l[i + 4])):
+                    if (
+                        i + 5 < len_l
+                        and info.jump(l[i + 2])
+                        and l[i + 3] == "("
+                        and l[i + 5] == ")"
+                        and 3 <= len(l[i + 4])
+                        and self._could_be_tzname(
+                            res.hour, res.tzname, None, l[i + 4]
+                        )
+                    ):
                         # -0300 (BRST)
                         res.tzname = l[i + 4]
                         i += 4
@@ -888,17 +940,23 @@ class parser(object):
         try:
             value = self._to_decimal(value_repr)
         except Exception as e:
-            six.raise_from(ValueError('Unknown numeric token'), e)
+            six.raise_from(ValueError("Unknown numeric token"), e)
 
         len_li = len(value_repr)
 
         len_l = len(tokens)
 
-        if (len(ymd) == 3 and len_li in (2, 4) and
-            res.hour is None and
-            (idx + 1 >= len_l or
-             (tokens[idx + 1] != ':' and
-              info.hms(tokens[idx + 1]) is None))):
+        if (
+            len(ymd) == 3
+            and len_li in (2, 4)
+            and res.hour is None
+            and (
+                idx + 1 >= len_l
+                or (
+                    tokens[idx + 1] != ":" and info.hms(tokens[idx + 1]) is None
+                )
+            )
+        ):
             # 19990101T23[59]
             s = tokens[idx]
             res.hour = int(s[:2])
@@ -906,11 +964,11 @@ class parser(object):
             if len_li == 4:
                 res.minute = int(s[2:])
 
-        elif len_li == 6 or (len_li > 6 and tokens[idx].find('.') == 6):
+        elif len_li == 6 or (len_li > 6 and tokens[idx].find(".") == 6):
             # YYMMDD or HHMMSS[.ss]
             s = tokens[idx]
 
-            if not ymd and '.' not in tokens[idx]:
+            if not ymd and "." not in tokens[idx]:
                 ymd.append(s[:2])
                 ymd.append(s[2:4])
                 ymd.append(s[4:])
@@ -925,7 +983,7 @@ class parser(object):
         elif len_li in (8, 12, 14):
             # YYYYMMDD
             s = tokens[idx]
-            ymd.append(s[:4], 'Y')
+            ymd.append(s[:4], "Y")
             ymd.append(s[4:6])
             ymd.append(s[6:8])
 
@@ -945,20 +1003,22 @@ class parser(object):
                 # already set?
                 self._assign_hms(res, value_repr, hms)
 
-        elif idx + 2 < len_l and tokens[idx + 1] == ':':
+        elif idx + 2 < len_l and tokens[idx + 1] == ":":
             # HH:MM[:SS[.ss]]
             res.hour = int(value)
-            value = self._to_decimal(tokens[idx + 2])  # TODO: try/except for this?
+            value = self._to_decimal(
+                tokens[idx + 2]
+            )  # TODO: try/except for this?
             (res.minute, res.second) = self._parse_min_sec(value)
 
-            if idx + 4 < len_l and tokens[idx + 3] == ':':
+            if idx + 4 < len_l and tokens[idx + 3] == ":":
                 res.second, res.microsecond = self._parsems(tokens[idx + 4])
 
                 idx += 2
 
             idx += 2
 
-        elif idx + 1 < len_l and tokens[idx + 1] in ('-', '/', '.'):
+        elif idx + 1 < len_l and tokens[idx + 1] in ("-", "/", "."):
             sep = tokens[idx + 1]
             ymd.append(value_repr)
 
@@ -971,7 +1031,7 @@ class parser(object):
                     value = info.month(tokens[idx + 2])
 
                     if value is not None:
-                        ymd.append(value, 'M')
+                        ymd.append(value, "M")
                     else:
                         raise ValueError()
 
@@ -980,7 +1040,7 @@ class parser(object):
                     value = info.month(tokens[idx + 4])
 
                     if value is not None:
-                        ymd.append(value, 'M')
+                        ymd.append(value, "M")
                     else:
                         ymd.append(tokens[idx + 4])
                     idx += 2
@@ -1016,27 +1076,34 @@ class parser(object):
     def _find_hms_idx(self, idx, tokens, info, allow_jump):
         len_l = len(tokens)
 
-        if idx+1 < len_l and info.hms(tokens[idx+1]) is not None:
+        if idx + 1 < len_l and info.hms(tokens[idx + 1]) is not None:
             # There is an "h", "m", or "s" label following this token.  We take
             # assign the upcoming label to the current token.
             # e.g. the "12" in 12h"
             hms_idx = idx + 1
 
-        elif (allow_jump and idx+2 < len_l and tokens[idx+1] == ' ' and
-              info.hms(tokens[idx+2]) is not None):
+        elif (
+            allow_jump
+            and idx + 2 < len_l
+            and tokens[idx + 1] == " "
+            and info.hms(tokens[idx + 2]) is not None
+        ):
             # There is a space and then an "h", "m", or "s" label.
             # e.g. the "12" in "12 h"
             hms_idx = idx + 2
 
-        elif idx > 0 and info.hms(tokens[idx-1]) is not None:
+        elif idx > 0 and info.hms(tokens[idx - 1]) is not None:
             # There is a "h", "m", or "s" preceding this token.  Since neither
             # of the previous cases was hit, there is no label following this
             # token, so we use the previous label.
             # e.g. the "04" in "12h04"
-            hms_idx = idx-1
+            hms_idx = idx - 1
 
-        elif (1 < idx == len_l-1 and tokens[idx-1] == ' ' and
-              info.hms(tokens[idx-2]) is not None):
+        elif (
+            1 < idx == len_l - 1
+            and tokens[idx - 1] == " "
+            and info.hms(tokens[idx - 2]) is not None
+        ):
             # If we are looking at the final token, we allow for a
             # backward-looking check to skip over a space.
             # TODO: Are we sure this is the right condition here?
@@ -1055,7 +1122,7 @@ class parser(object):
             # Hour
             res.hour = int(value)
             if value % 1:
-                res.minute = int(60*(value % 1))
+                res.minute = int(60 * (value % 1))
 
         elif hms == 1:
             (res.minute, res.second) = self._parse_min_sec(value)
@@ -1064,12 +1131,16 @@ class parser(object):
             (res.second, res.microsecond) = self._parsems(value_repr)
 
     def _could_be_tzname(self, hour, tzname, tzoffset, token):
-        return (hour is not None and
-                tzname is None and
-                tzoffset is None and
-                len(token) <= 5 and
-                (all(x in string.ascii_uppercase for x in token)
-                 or token in self.info.UTCZONE))
+        return (
+            hour is not None
+            and tzname is None
+            and tzoffset is None
+            and len(token) <= 5
+            and (
+                all(x in string.ascii_uppercase for x in token)
+                or token in self.info.UTCZONE
+            )
+        )
 
     def _ampm_valid(self, hour, ampm, fuzzy):
         """
@@ -1088,14 +1159,14 @@ class parser(object):
             if fuzzy:
                 val_is_ampm = False
             else:
-                raise ValueError('No hour specified with AM or PM flag.')
+                raise ValueError("No hour specified with AM or PM flag.")
         elif not 0 <= hour <= 12:
             # If AM/PM is found, it's a 12 hour clock, so raise
             # an error for invalid range
             if fuzzy:
                 val_is_ampm = False
             else:
-                raise ValueError('Invalid hour specified for 12-hour clock.')
+                raise ValueError("Invalid hour specified for 12-hour clock.")
 
         return val_is_ampm
 
@@ -1180,12 +1251,13 @@ class parser(object):
         elif isinstance(tzdata, integer_types):
             tzinfo = tz.tzoffset(tzname, tzdata)
         else:
-            raise TypeError("Offset must be tzinfo subclass, tz string, "
-                            "or int offset.")
+            raise TypeError(
+                "Offset must be tzinfo subclass, tz string, " "or int offset."
+            )
         return tzinfo
 
     def _build_tzaware(self, naive, res, tzinfos):
-        if (callable(tzinfos) or (tzinfos and res.tzname in tzinfos)):
+        if callable(tzinfos) or (tzinfos and res.tzname in tzinfos):
             tzinfo = self._build_tzinfo(tzinfos, res.tzname, res.tzoffset)
             aware = naive.replace(tzinfo=tzinfo)
             aware = self._assign_tzname(aware, res.tzname)
@@ -1197,8 +1269,7 @@ class parser(object):
             aware = self._assign_tzname(aware, res.tzname)
 
             # This is mostly relevant for winter GMT zones parsed in the UK
-            if (aware.tzname() != res.tzname and
-                    res.tzname in self.info.UTCZONE):
+            if aware.tzname() != res.tzname and res.tzname in self.info.UTCZONE:
                 aware = aware.replace(tzinfo=tz.UTC)
 
         elif res.tzoffset == 0:
@@ -1214,25 +1285,34 @@ class parser(object):
         elif res.tzname:
             # tz-like string was parsed but we don't know what to do
             # with it
-            warnings.warn("tzname {tzname} identified but not understood.  "
-                          "Pass `tzinfos` argument in order to correctly "
-                          "return a timezone-aware datetime.  In a future "
-                          "version, this will raise an "
-                          "exception.".format(tzname=res.tzname),
-                          category=UnknownTimezoneWarning)
+            warnings.warn(
+                "tzname {tzname} identified but not understood.  "
+                "Pass `tzinfos` argument in order to correctly "
+                "return a timezone-aware datetime.  In a future "
+                "version, this will raise an "
+                "exception.".format(tzname=res.tzname),
+                category=UnknownTimezoneWarning,
+            )
             aware = naive
 
         return aware
 
     def _build_naive(self, res, default):
         repl = {}
-        for attr in ("year", "month", "day", "hour",
-                     "minute", "second", "microsecond"):
+        for attr in (
+            "year",
+            "month",
+            "day",
+            "hour",
+            "minute",
+            "second",
+            "microsecond",
+        ):
             value = getattr(res, attr)
             if value is not None:
                 repl[attr] = value
 
-        if 'day' not in repl:
+        if "day" not in repl:
             # If the default day exceeds the last day of the month, fall back
             # to the end of the month.
             cyear = default.year if res.year is None else res.year
@@ -1240,7 +1320,7 @@ class parser(object):
             cday = default.day if res.day is None else res.day
 
             if cday > monthrange(cyear, cmonth)[1]:
-                repl['day'] = monthrange(cyear, cmonth)[1]
+                repl["day"] = monthrange(cyear, cmonth)[1]
 
         naive = default.replace(**repl)
 
@@ -1379,15 +1459,26 @@ def parse(timestr, parserinfo=None, **kwargs):
 
 
 class _tzparser(object):
-
     class _result(_resultbase):
-
-        __slots__ = ["stdabbr", "stdoffset", "dstabbr", "dstoffset",
-                     "start", "end"]
+        __slots__ = [
+            "stdabbr",
+            "stdoffset",
+            "dstabbr",
+            "dstoffset",
+            "start",
+            "end",
+        ]
 
         class _attr(_resultbase):
-            __slots__ = ["month", "week", "weekday",
-                         "yday", "jyday", "day", "time"]
+            __slots__ = [
+                "month",
+                "week",
+                "weekday",
+                "yday",
+                "jyday",
+                "day",
+                "time",
+            ]
 
         def __repr__(self):
             return self._repr("")
@@ -1399,18 +1490,18 @@ class _tzparser(object):
 
     def parse(self, tzstr):
         res = self._result()
-        l = [x for x in re.split(r'([,:.]|[a-zA-Z]+|[0-9]+)',tzstr) if x]
+        l = [x for x in re.split(r"([,:.]|[a-zA-Z]+|[0-9]+)", tzstr) if x]
         used_idxs = list()
         try:
-
             len_l = len(l)
 
             i = 0
             while i < len_l:
                 # BRST+3[BRDT[+2]]
                 j = i
-                while j < len_l and not [x for x in l[j]
-                                         if x in "0123456789:,-+"]:
+                while j < len_l and not [
+                    x for x in l[j] if x in "0123456789:,-+"
+                ]:
                     j += 1
                 if j != i:
                     if not res.stdabbr:
@@ -1423,12 +1514,13 @@ class _tzparser(object):
                     for ii in range(j):
                         used_idxs.append(ii)
                     i = j
-                    if (i < len_l and (l[i] in ('+', '-') or l[i][0] in
-                                       "0123456789")):
-                        if l[i] in ('+', '-'):
+                    if i < len_l and (
+                        l[i] in ("+", "-") or l[i][0] in "0123456789"
+                    ):
+                        if l[i] in ("+", "-"):
                             # Yes, that's right.  See the TZ variable
                             # documentation.
-                            signal = (1, -1)[l[i] == '+']
+                            signal = (1, -1)[l[i] == "+"]
                             used_idxs.append(i)
                             i += 1
                         else:
@@ -1436,19 +1528,25 @@ class _tzparser(object):
                         len_li = len(l[i])
                         if len_li == 4:
                             # -0300
-                            setattr(res, offattr, (int(l[i][:2]) * 3600 +
-                                                   int(l[i][2:]) * 60) * signal)
-                        elif i + 1 < len_l and l[i + 1] == ':':
+                            setattr(
+                                res,
+                                offattr,
+                                (int(l[i][:2]) * 3600 + int(l[i][2:]) * 60)
+                                * signal,
+                            )
+                        elif i + 1 < len_l and l[i + 1] == ":":
                             # -03:00
-                            setattr(res, offattr,
-                                    (int(l[i]) * 3600 +
-                                     int(l[i + 2]) * 60) * signal)
+                            setattr(
+                                res,
+                                offattr,
+                                (int(l[i]) * 3600 + int(l[i + 2]) * 60)
+                                * signal,
+                            )
                             used_idxs.append(i)
                             i += 2
                         elif len_li <= 2:
                             # -[0]3
-                            setattr(res, offattr,
-                                    int(l[i][:2]) * 3600 * signal)
+                            setattr(res, offattr, int(l[i][:2]) * 3600 * signal)
                         else:
                             return None
                         used_idxs.append(i)
@@ -1458,27 +1556,30 @@ class _tzparser(object):
                 else:
                     break
 
-
             if i < len_l:
                 for j in range(i, len_l):
-                    if l[j] == ';':
-                        l[j] = ','
+                    if l[j] == ";":
+                        l[j] = ","
 
-                assert l[i] == ','
+                assert l[i] == ","
 
                 i += 1
 
             if i >= len_l:
                 pass
-            elif (8 <= l.count(',') <= 9 and
-                  not [y for x in l[i:] if x != ','
-                       for y in x if y not in "0123456789+-"]):
+            elif 8 <= l.count(",") <= 9 and not [
+                y
+                for x in l[i:]
+                if x != ","
+                for y in x
+                if y not in "0123456789+-"
+            ]:
                 # GMT0BST,3,0,30,3600,10,0,26,7200[,3600]
                 for x in (res.start, res.end):
                     x.month = int(l[i])
                     used_idxs.append(i)
                     i += 2
-                    if l[i] == '-':
+                    if l[i] == "-":
                         value = int(l[i + 1]) * -1
                         used_idxs.append(i)
                         i += 1
@@ -1497,40 +1598,50 @@ class _tzparser(object):
                     used_idxs.append(i)
                     i += 2
                 if i < len_l:
-                    if l[i] in ('-', '+'):
+                    if l[i] in ("-", "+"):
                         signal = (-1, 1)[l[i] == "+"]
                         used_idxs.append(i)
                         i += 1
                     else:
                         signal = 1
                     used_idxs.append(i)
-                    res.dstoffset = (res.stdoffset + int(l[i]) * signal)
+                    res.dstoffset = res.stdoffset + int(l[i]) * signal
 
                 # This was a made-up format that is not in normal use
-                warn(('Parsed time zone "%s"' % tzstr) +
-                     'is in a non-standard dateutil-specific format, which ' +
-                     'is now deprecated; support for parsing this format ' +
-                     'will be removed in future versions. It is recommended ' +
-                     'that you switch to a standard format like the GNU ' +
-                     'TZ variable format.', tz.DeprecatedTzFormatWarning)
-            elif (l.count(',') == 2 and l[i:].count('/') <= 2 and
-                  not [y for x in l[i:] if x not in (',', '/', 'J', 'M',
-                                                     '.', '-', ':')
-                       for y in x if y not in "0123456789"]):
+                warn(
+                    ('Parsed time zone "%s"' % tzstr)
+                    + "is in a non-standard dateutil-specific format, which "
+                    + "is now deprecated; support for parsing this format "
+                    + "will be removed in future versions. It is recommended "
+                    + "that you switch to a standard format like the GNU "
+                    + "TZ variable format.",
+                    tz.DeprecatedTzFormatWarning,
+                )
+            elif (
+                l.count(",") == 2
+                and l[i:].count("/") <= 2
+                and not [
+                    y
+                    for x in l[i:]
+                    if x not in (",", "/", "J", "M", ".", "-", ":")
+                    for y in x
+                    if y not in "0123456789"
+                ]
+            ):
                 for x in (res.start, res.end):
-                    if l[i] == 'J':
+                    if l[i] == "J":
                         # non-leap year day (1 based)
                         used_idxs.append(i)
                         i += 1
                         x.jyday = int(l[i])
-                    elif l[i] == 'M':
+                    elif l[i] == "M":
                         # month[-.]week[-.]weekday
                         used_idxs.append(i)
                         i += 1
                         x.month = int(l[i])
                         used_idxs.append(i)
                         i += 1
-                        assert l[i] in ('-', '.')
+                        assert l[i] in ("-", ".")
                         used_idxs.append(i)
                         i += 1
                         x.week = int(l[i])
@@ -1538,7 +1649,7 @@ class _tzparser(object):
                             x.week = -1
                         used_idxs.append(i)
                         i += 1
-                        assert l[i] in ('-', '.')
+                        assert l[i] in ("-", ".")
                         used_idxs.append(i)
                         i += 1
                         x.weekday = (int(l[i]) - 1) % 7
@@ -1549,33 +1660,32 @@ class _tzparser(object):
                     used_idxs.append(i)
                     i += 1
 
-                    if i < len_l and l[i] == '/':
+                    if i < len_l and l[i] == "/":
                         used_idxs.append(i)
                         i += 1
                         # start time
                         len_li = len(l[i])
                         if len_li == 4:
                             # -0300
-                            x.time = (int(l[i][:2]) * 3600 +
-                                      int(l[i][2:]) * 60)
-                        elif i + 1 < len_l and l[i + 1] == ':':
+                            x.time = int(l[i][:2]) * 3600 + int(l[i][2:]) * 60
+                        elif i + 1 < len_l and l[i + 1] == ":":
                             # -03:00
                             x.time = int(l[i]) * 3600 + int(l[i + 2]) * 60
                             used_idxs.append(i)
                             i += 2
-                            if i + 1 < len_l and l[i + 1] == ':':
+                            if i + 1 < len_l and l[i + 1] == ":":
                                 used_idxs.append(i)
                                 i += 2
                                 x.time += int(l[i])
                         elif len_li <= 2:
                             # -[0]3
-                            x.time = (int(l[i][:2]) * 3600)
+                            x.time = int(l[i][:2]) * 3600
                         else:
                             return None
                         used_idxs.append(i)
                         i += 1
 
-                    assert i == len_l or l[i] == ','
+                    assert i == len_l or l[i] == ","
 
                     i += 1
 
@@ -1585,7 +1695,9 @@ class _tzparser(object):
             return None
 
         unused_idxs = set(range(len_l)).difference(used_idxs)
-        res.any_unused_tokens = not {l[n] for n in unused_idxs}.issubset({",",":"})
+        res.any_unused_tokens = not {l[n] for n in unused_idxs}.issubset(
+            {",", ":"}
+        )
         return res
 
 
@@ -1604,6 +1716,7 @@ class ParserError(ValueError):
 
     .. versionadded:: 2.8.1
     """
+
     def __str__(self):
         try:
             return self.args[0] % self.args[1:]
@@ -1620,4 +1733,6 @@ class UnknownTimezoneWarning(RuntimeWarning):
 
     .. versionadded:: 2.7.0
     """
+
+
 # vim:ts=4:sw=4:et

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -799,13 +799,23 @@ class parser(object):
                     # "my time +3 is GMT". If found, we reverse the
                     # logic so that timezone parsing code will get it
                     # right.
+                    #
+                    # However, for UTC zone names (UTC, GMT, Z), the
+                    # following offset should NOT be reversed - it
+                    # represents a direct UTC offset like "UTC-4"
+                    # meaning UTC minus 4 hours, not POSIX convention.
                     if i + 1 < len_l and l[i + 1] in ('+', '-'):
-                        l[i + 1] = ('+', '-')[l[i + 1] == '+']
-                        res.tzoffset = None
                         if info.utczone(res.tzname):
-                            # With something like GMT+3, the timezone
-                            # is *not* GMT.
+                            # For UTC/GMT/Z, the offset is literal:
+                            # "UTC-4" means UTC-4, not UTC+4
+                            res.tzoffset = None
                             res.tzname = None
+                        else:
+                            # For non-UTC timezone abbreviations,
+                            # apply POSIX convention: BRST+3 means
+                            # "my time +3 is BRST", i.e. UTC-3
+                            l[i + 1] = ('+', '-')[l[i + 1] == '+']
+                            res.tzoffset = None
 
                 # Check for a numbered timezone
                 elif res.hour is not None and l[i] in ('+', '-'):

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -7,8 +7,11 @@ from hypothesis import strategies as st
 
 from dateutil import tz
 
-EPOCHALYPSE = datetime.fromtimestamp(2147483647)
-NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
+# 32-bit Unix timestamp range as naive UTC. fromtimestamp() follows TZ, and
+# CI sets TZ=America/New_York, which would shift these bounds and let
+# hypothesis emit values before the first tzfile transition (LMT vs EST).
+EPOCHALYPSE = datetime(1970, 1, 1) + timedelta(seconds=2147483647)
+NEGATIVE_EPOCHALYPSE = datetime(1970, 1, 1) - timedelta(seconds=2147483648)
 
 
 @pytest.mark.gettz

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -118,12 +118,15 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset)
 
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
-@pytest.mark.parametrize('dt', tuple(DATETIMES))
-@pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', tuple(x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
-@pytest.mark.parametrize('tzoffset', TZOFFSETS)
-@pytest.mark.parametrize('precision', list(range(3, 7)))
+
+
+@pytest.mark.parametrize("dt", tuple(DATETIMES))
+@pytest.mark.parametrize("date_fmt", YMD_FMTS)
+@pytest.mark.parametrize(
+    "time_fmt", tuple(x + sep + "%f" for x in HMS_FMTS for sep in ".,")
+)
+@pytest.mark.parametrize("tzoffset", TZOFFSETS)
+@pytest.mark.parametrize("precision", list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
     # Truncate the microseconds to the desired precision for the representation
     dt = dt.replace(microsecond=int(round(dt.microsecond, precision-6)))

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -120,7 +120,7 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
 @pytest.mark.parametrize('dt', tuple(DATETIMES))
 @pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
+@pytest.mark.parametrize('time_fmt', tuple(x + sep + '%f' for x in HMS_FMTS
                                       for sep in '.,'))
 @pytest.mark.parametrize('tzoffset', TZOFFSETS)
 @pytest.mark.parametrize('precision', list(range(3, 7)))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,22 +2,24 @@
 from __future__ import unicode_literals
 
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
-from six import assertRaisesRegex, PY2
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+from six import PY2, assertRaisesRegex
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith("win")
@@ -774,7 +776,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -788,7 +790,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -20,11 +20,11 @@ from io import StringIO
 import pytest
 
 # Platform info
-IS_WIN = sys.platform.startswith('win')
+IS_WIN = sys.platform.startswith("win")
 
 PLATFORM_HAS_DASH_D = False
 try:
-    if datetime.now().strftime('%-d'):
+    if datetime.now().strftime("%-d"):
         PLATFORM_HAS_DASH_D = True
 except ValueError:
     pass
@@ -38,17 +38,37 @@ def fuzzy(request):
 
 # Parser test cases using no keyword arguments. Format: (parsable_text, expected_datetime, assertion_message)
 PARSER_TEST_CASES = [
-    ("Thu Sep 25 10:36:28 2003", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),
+    (
+        "Thu Sep 25 10:36:28 2003",
+        datetime(2003, 9, 25, 10, 36, 28),
+        "date command format strip",
+    ),
     ("Thu Sep 25 2003", datetime(2003, 9, 25), "date command format strip"),
-    ("2003-09-25T10:49:41", datetime(2003, 9, 25, 10, 49, 41), "iso format strip"),
+    (
+        "2003-09-25T10:49:41",
+        datetime(2003, 9, 25, 10, 49, 41),
+        "iso format strip",
+    ),
     ("2003-09-25T10:49", datetime(2003, 9, 25, 10, 49), "iso format strip"),
     ("2003-09-25T10", datetime(2003, 9, 25, 10), "iso format strip"),
     ("2003-09-25", datetime(2003, 9, 25), "iso format strip"),
-    ("20030925T104941", datetime(2003, 9, 25, 10, 49, 41), "iso stripped format strip"),
-    ("20030925T1049", datetime(2003, 9, 25, 10, 49, 0), "iso stripped format strip"),
+    (
+        "20030925T104941",
+        datetime(2003, 9, 25, 10, 49, 41),
+        "iso stripped format strip",
+    ),
+    (
+        "20030925T1049",
+        datetime(2003, 9, 25, 10, 49, 0),
+        "iso stripped format strip",
+    ),
     ("20030925T10", datetime(2003, 9, 25, 10), "iso stripped format strip"),
     ("20030925", datetime(2003, 9, 25), "iso stripped format strip"),
-    ("2003-09-25 10:49:41,502", datetime(2003, 9, 25, 10, 49, 41, 502000), "python logger format"),
+    (
+        "2003-09-25 10:49:41,502",
+        datetime(2003, 9, 25, 10, 49, 41, 502000),
+        "python logger format",
+    ),
     ("199709020908", datetime(1997, 9, 2, 9, 8), "no separator"),
     ("19970902090807", datetime(1997, 9, 2, 9, 8, 7), "no separator"),
     ("09-25-2003", datetime(2003, 9, 25), "date with dash"),
@@ -73,7 +93,11 @@ PARSER_TEST_CASES = [
     ("25 09 03", datetime(2003, 9, 25), "date with space"),
     ("03 25 Sep", datetime(2003, 9, 25), "strangely ordered date"),
     ("25 03 Sep", datetime(2025, 9, 3), "strangely ordered date"),
-    ("  July   4 ,  1976   12:01:02   am  ", datetime(1976, 7, 4, 0, 1, 2), "extra space"),
+    (
+        "  July   4 ,  1976   12:01:02   am  ",
+        datetime(1976, 7, 4, 0, 1, 2),
+        "extra space",
+    ),
     ("Wed, July 10, '96", datetime(1996, 7, 10, 0, 0), "random format"),
     ("1996.July.10 AD 12:08 PM", datetime(1996, 7, 10, 12, 8), "random format"),
     ("July 4, 1976", datetime(1976, 7, 4), "random format"),
@@ -83,21 +107,40 @@ PARSER_TEST_CASES = [
     ("7-4-76", datetime(1976, 7, 4), "random format"),
     ("19760704", datetime(1976, 7, 4), "random format"),
     ("0:01:02 on July 4, 1976", datetime(1976, 7, 4, 0, 1, 2), "random format"),
-    ("July 4, 1976 12:01:02 am", datetime(1976, 7, 4, 0, 1, 2), "random format"),
-    ("Mon Jan  2 04:24:27 1995", datetime(1995, 1, 2, 4, 24, 27), "random format"),
+    (
+        "July 4, 1976 12:01:02 am",
+        datetime(1976, 7, 4, 0, 1, 2),
+        "random format",
+    ),
+    (
+        "Mon Jan  2 04:24:27 1995",
+        datetime(1995, 1, 2, 4, 24, 27),
+        "random format",
+    ),
     ("04.04.95 00:22", datetime(1995, 4, 4, 0, 22), "random format"),
-    ("Jan 1 1999 11:23:34.578", datetime(1999, 1, 1, 11, 23, 34, 578000), "random format"),
+    (
+        "Jan 1 1999 11:23:34.578",
+        datetime(1999, 1, 1, 11, 23, 34, 578000),
+        "random format",
+    ),
     ("950404 122212", datetime(1995, 4, 4, 12, 22, 12), "random format"),
     ("3rd of May 2001", datetime(2001, 5, 3), "random format"),
     ("5th of March 2001", datetime(2001, 3, 5), "random format"),
     ("1st of May 2003", datetime(2003, 5, 1), "random format"),
-    ('0099-01-01T00:00:00', datetime(99, 1, 1, 0, 0), "99 ad"),
-    ('0031-01-01T00:00:00', datetime(31, 1, 1, 0, 0), "31 ad"),
-    ("20080227T21:26:01.123456789", datetime(2008, 2, 27, 21, 26, 1, 123456), "high precision seconds"),
-    ('13NOV2017', datetime(2017, 11, 13), "dBY (See GH360)"),
-    ('0003-03-04', datetime(3, 3, 4), "pre 12 year same month (See GH PR #293)"),
-    ('December.0031.30', datetime(31, 12, 30), "BYd corner case (GH#687)"),
-
+    ("0099-01-01T00:00:00", datetime(99, 1, 1, 0, 0), "99 ad"),
+    ("0031-01-01T00:00:00", datetime(31, 1, 1, 0, 0), "31 ad"),
+    (
+        "20080227T21:26:01.123456789",
+        datetime(2008, 2, 27, 21, 26, 1, 123456),
+        "high precision seconds",
+    ),
+    ("13NOV2017", datetime(2017, 11, 13), "dBY (See GH360)"),
+    (
+        "0003-03-04",
+        datetime(3, 3, 4),
+        "pre 12 year same month (See GH PR #293)",
+    ),
+    ("December.0031.30", datetime(31, 12, 30), "BYd corner case (GH#687)"),
     # Cases with legacy h/m/s format, candidates for deprecation (GH#886)
     ("2016-12-21 04.2h", datetime(2016, 12, 21, 4, 12), "Fractional Hours"),
 ]
@@ -105,7 +148,9 @@ PARSER_TEST_CASES = [
 assert len(set([x[0] for x in PARSER_TEST_CASES])) == len(PARSER_TEST_CASES)
 
 
-@pytest.mark.parametrize("parsable_text,expected_datetime,assertion_message", PARSER_TEST_CASES)
+@pytest.mark.parametrize(
+    "parsable_text,expected_datetime,assertion_message", PARSER_TEST_CASES
+)
 def test_parser(parsable_text, expected_datetime, assertion_message):
     assert parse(parsable_text) == expected_datetime, assertion_message
 
@@ -113,16 +158,40 @@ def test_parser(parsable_text, expected_datetime, assertion_message):
 # Parser test cases using datetime(2003, 9, 25) as a default.
 # Format: (parsable_text, expected_datetime, assertion_message)
 PARSER_DEFAULT_TEST_CASES = [
-    ("Thu Sep 25 10:36:28", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),
-    ("Thu Sep 10:36:28", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),
-    ("Thu 10:36:28", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),
-    ("Sep 10:36:28", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),
-    ("10:36:28", datetime(2003, 9, 25, 10, 36, 28), "date command format strip"),
+    (
+        "Thu Sep 25 10:36:28",
+        datetime(2003, 9, 25, 10, 36, 28),
+        "date command format strip",
+    ),
+    (
+        "Thu Sep 10:36:28",
+        datetime(2003, 9, 25, 10, 36, 28),
+        "date command format strip",
+    ),
+    (
+        "Thu 10:36:28",
+        datetime(2003, 9, 25, 10, 36, 28),
+        "date command format strip",
+    ),
+    (
+        "Sep 10:36:28",
+        datetime(2003, 9, 25, 10, 36, 28),
+        "date command format strip",
+    ),
+    (
+        "10:36:28",
+        datetime(2003, 9, 25, 10, 36, 28),
+        "date command format strip",
+    ),
     ("10:36", datetime(2003, 9, 25, 10, 36), "date command format strip"),
     ("Sep 2003", datetime(2003, 9, 25), "date command format strip"),
     ("Sep", datetime(2003, 9, 25), "date command format strip"),
     ("2003", datetime(2003, 9, 25), "date command format strip"),
-    ("10h36m28.5s", datetime(2003, 9, 25, 10, 36, 28, 500000), "hour with letters"),
+    (
+        "10h36m28.5s",
+        datetime(2003, 9, 25, 10, 36, 28, 500000),
+        "hour with letters",
+    ),
     ("10h36m28s", datetime(2003, 9, 25, 10, 36, 28), "hour with letters strip"),
     ("10h36m", datetime(2003, 9, 25, 10, 36), "hour with letters strip"),
     ("10h", datetime(2003, 9, 25, 10), "hour with letters strip"),
@@ -131,7 +200,11 @@ PARSER_DEFAULT_TEST_CASES = [
     ("36 m 5", datetime(2003, 9, 25, 0, 36, 5), "hour with letters spaces"),
     ("36 m 5 s", datetime(2003, 9, 25, 0, 36, 5), "minute with letters spaces"),
     ("36 m 05", datetime(2003, 9, 25, 0, 36, 5), "minute with letters spaces"),
-    ("36 m 05 s", datetime(2003, 9, 25, 0, 36, 5), "minutes with letters spaces"),
+    (
+        "36 m 05 s",
+        datetime(2003, 9, 25, 0, 36, 5),
+        "minutes with letters spaces",
+    ),
     ("10h am", datetime(2003, 9, 25, 10), "hour am pm"),
     ("10h pm", datetime(2003, 9, 25, 22), "hour am pm"),
     ("10am", datetime(2003, 9, 25, 10), "hour am pm"),
@@ -156,47 +229,59 @@ PARSER_DEFAULT_TEST_CASES = [
     ("01h02s", datetime(2003, 9, 25, 1, 0, 2), "random format"),
     ("01m02", datetime(2003, 9, 25, 0, 1, 2), "random format"),
     ("01m02h", datetime(2003, 9, 25, 2, 1), "random format"),
-    ("2004 10 Apr 11h30m", datetime(2004, 4, 10, 11, 30), "random format")
+    ("2004 10 Apr 11h30m", datetime(2004, 4, 10, 11, 30), "random format"),
 ]
 # Check that we don't have any duplicates
-assert len(set([x[0] for x in PARSER_DEFAULT_TEST_CASES])) == len(PARSER_DEFAULT_TEST_CASES)
+assert len(set([x[0] for x in PARSER_DEFAULT_TEST_CASES])) == len(
+    PARSER_DEFAULT_TEST_CASES
+)
 
 
-@pytest.mark.parametrize("parsable_text,expected_datetime,assertion_message", PARSER_DEFAULT_TEST_CASES)
+@pytest.mark.parametrize(
+    "parsable_text,expected_datetime,assertion_message",
+    PARSER_DEFAULT_TEST_CASES,
+)
 def test_parser_default(parsable_text, expected_datetime, assertion_message):
-    assert parse(parsable_text, default=datetime(2003, 9, 25)) == expected_datetime, assertion_message
+    assert (
+        parse(parsable_text, default=datetime(2003, 9, 25)) == expected_datetime
+    ), assertion_message
 
 
-@pytest.mark.parametrize('sep', ['-', '.', '/', ' '])
+@pytest.mark.parametrize("sep", ["-", ".", "/", " "])
 def test_parse_dayfirst(sep):
     expected = datetime(2003, 9, 10)
-    fmt = sep.join(['%d', '%m', '%Y'])
+    fmt = sep.join(["%d", "%m", "%Y"])
     dstr = expected.strftime(fmt)
     result = parse(dstr, dayfirst=True)
     assert result == expected
 
 
-@pytest.mark.parametrize('sep', ['-', '.', '/', ' '])
+@pytest.mark.parametrize("sep", ["-", ".", "/", " "])
 def test_parse_yearfirst(sep):
     expected = datetime(2010, 9, 3)
-    fmt = sep.join(['%Y', '%m', '%d'])
+    fmt = sep.join(["%Y", "%m", "%d"])
     dstr = expected.strftime(fmt)
     result = parse(dstr, yearfirst=True)
     assert result == expected
 
 
-@pytest.mark.parametrize('dstr,expected', [
-    ("Thu Sep 25 10:36:28 BRST 2003", datetime(2003, 9, 25, 10, 36, 28)),
-    ("1996.07.10 AD at 15:08:56 PDT", datetime(1996, 7, 10, 15, 8, 56)),
-    ("Tuesday, April 12, 1952 AD 3:30:42pm PST",
-     datetime(1952, 4, 12, 15, 30, 42)),
-    ("November 5, 1994, 8:15:30 am EST", datetime(1994, 11, 5, 8, 15, 30)),
-    ("1994-11-05T08:15:30-05:00", datetime(1994, 11, 5, 8, 15, 30)),
-    ("1994-11-05T08:15:30Z", datetime(1994, 11, 5, 8, 15, 30)),
-    ("1976-07-04T00:01:02Z", datetime(1976, 7, 4, 0, 1, 2)),
-    ("1986-07-05T08:15:30z", datetime(1986, 7, 5, 8, 15, 30)),
-    ("Tue Apr 4 00:22:12 PDT 1995", datetime(1995, 4, 4, 0, 22, 12)),
-])
+@pytest.mark.parametrize(
+    "dstr,expected",
+    [
+        ("Thu Sep 25 10:36:28 BRST 2003", datetime(2003, 9, 25, 10, 36, 28)),
+        ("1996.07.10 AD at 15:08:56 PDT", datetime(1996, 7, 10, 15, 8, 56)),
+        (
+            "Tuesday, April 12, 1952 AD 3:30:42pm PST",
+            datetime(1952, 4, 12, 15, 30, 42),
+        ),
+        ("November 5, 1994, 8:15:30 am EST", datetime(1994, 11, 5, 8, 15, 30)),
+        ("1994-11-05T08:15:30-05:00", datetime(1994, 11, 5, 8, 15, 30)),
+        ("1994-11-05T08:15:30Z", datetime(1994, 11, 5, 8, 15, 30)),
+        ("1976-07-04T00:01:02Z", datetime(1976, 7, 4, 0, 1, 2)),
+        ("1986-07-05T08:15:30z", datetime(1986, 7, 5, 8, 15, 30)),
+        ("Tue Apr 4 00:22:12 PDT 1995", datetime(1995, 4, 4, 0, 22, 12)),
+    ],
+)
 def test_parse_ignoretz(dstr, expected):
     result = parse(dstr, ignoretz=True)
     assert result == expected
@@ -205,18 +290,31 @@ def test_parse_ignoretz(dstr, expected):
 _brsttz = tzoffset("BRST", -10800)
 
 
-@pytest.mark.parametrize('dstr,expected', [
-    ("20030925T104941-0300",
-     datetime(2003, 9, 25, 10, 49, 41, tzinfo=_brsttz)),
-    ("Thu, 25 Sep 2003 10:49:41 -0300",
-     datetime(2003, 9, 25, 10, 49, 41, tzinfo=_brsttz)),
-    ("2003-09-25T10:49:41.5-03:00",
-     datetime(2003, 9, 25, 10, 49, 41, 500000, tzinfo=_brsttz)),
-    ("2003-09-25T10:49:41-03:00",
-     datetime(2003, 9, 25, 10, 49, 41, tzinfo=_brsttz)),
-    ("20030925T104941.5-0300",
-     datetime(2003, 9, 25, 10, 49, 41, 500000, tzinfo=_brsttz)),
-])
+@pytest.mark.parametrize(
+    "dstr,expected",
+    [
+        (
+            "20030925T104941-0300",
+            datetime(2003, 9, 25, 10, 49, 41, tzinfo=_brsttz),
+        ),
+        (
+            "Thu, 25 Sep 2003 10:49:41 -0300",
+            datetime(2003, 9, 25, 10, 49, 41, tzinfo=_brsttz),
+        ),
+        (
+            "2003-09-25T10:49:41.5-03:00",
+            datetime(2003, 9, 25, 10, 49, 41, 500000, tzinfo=_brsttz),
+        ),
+        (
+            "2003-09-25T10:49:41-03:00",
+            datetime(2003, 9, 25, 10, 49, 41, tzinfo=_brsttz),
+        ),
+        (
+            "20030925T104941.5-0300",
+            datetime(2003, 9, 25, 10, 49, 41, 500000, tzinfo=_brsttz),
+        ),
+    ],
+)
 def test_parse_with_tzoffset(dstr, expected):
     # In these cases, we are _not_ passing a tzinfos arg
     result = parse(dstr)
@@ -224,20 +322,19 @@ def test_parse_with_tzoffset(dstr, expected):
 
 
 class TestFormat(object):
-
     def test_ybd(self):
         # If we have a 4-digit year, a non-numeric month (abbreviated or not),
         # and a day (1 or 2 digits), then there is no ambiguity as to which
         # token is a year/month/day.  This holds regardless of what order the
         # terms are in and for each of the separators below.
 
-        seps = ['-', ' ', '/', '.']
+        seps = ["-", " ", "/", "."]
 
-        year_tokens = ['%Y']
-        month_tokens = ['%b', '%B']
-        day_tokens = ['%d']
+        year_tokens = ["%Y"]
+        month_tokens = ["%b", "%B"]
+        day_tokens = ["%d"]
         if PLATFORM_HAS_DASH_D:
-            day_tokens.append('%-d')
+            day_tokens.append("%-d")
 
         prods = itertools.product(year_tokens, month_tokens, day_tokens)
         perms = [y for x in prods for y in itertools.permutations(x)]
@@ -251,35 +348,41 @@ class TestFormat(object):
             assert res == actual
 
     # TODO: some redundancy with PARSER_TEST_CASES cases
-    @pytest.mark.parametrize("fmt,dstr", [
-        ("%a %b %d %Y", "Thu Sep 25 2003"),
-        ("%b %d %Y", "Sep 25 2003"),
-        ("%Y-%m-%d", "2003-09-25"),
-        ("%Y%m%d", "20030925"),
-        ("%Y-%b-%d", "2003-Sep-25"),
-        ("%d-%b-%Y", "25-Sep-2003"),
-        ("%b-%d-%Y", "Sep-25-2003"),
-        ("%m-%d-%Y", "09-25-2003"),
-        ("%d-%m-%Y", "25-09-2003"),
-        ("%Y.%m.%d", "2003.09.25"),
-        ("%Y.%b.%d", "2003.Sep.25"),
-        ("%d.%b.%Y", "25.Sep.2003"),
-        ("%b.%d.%Y", "Sep.25.2003"),
-        ("%m.%d.%Y", "09.25.2003"),
-        ("%d.%m.%Y", "25.09.2003"),
-        ("%Y/%m/%d", "2003/09/25"),
-        ("%Y/%b/%d", "2003/Sep/25"),
-        ("%d/%b/%Y", "25/Sep/2003"),
-        ("%b/%d/%Y", "Sep/25/2003"),
-        ("%m/%d/%Y", "09/25/2003"),
-        ("%d/%m/%Y", "25/09/2003"),
-        ("%Y %m %d", "2003 09 25"),
-        ("%Y %b %d", "2003 Sep 25"),
-        ("%d %b %Y", "25 Sep 2003"),
-        ("%m %d %Y", "09 25 2003"),
-        ("%d %m %Y", "25 09 2003"),
-        ("%y %d %b", "03 25 Sep",),
-    ])
+    @pytest.mark.parametrize(
+        "fmt,dstr",
+        [
+            ("%a %b %d %Y", "Thu Sep 25 2003"),
+            ("%b %d %Y", "Sep 25 2003"),
+            ("%Y-%m-%d", "2003-09-25"),
+            ("%Y%m%d", "20030925"),
+            ("%Y-%b-%d", "2003-Sep-25"),
+            ("%d-%b-%Y", "25-Sep-2003"),
+            ("%b-%d-%Y", "Sep-25-2003"),
+            ("%m-%d-%Y", "09-25-2003"),
+            ("%d-%m-%Y", "25-09-2003"),
+            ("%Y.%m.%d", "2003.09.25"),
+            ("%Y.%b.%d", "2003.Sep.25"),
+            ("%d.%b.%Y", "25.Sep.2003"),
+            ("%b.%d.%Y", "Sep.25.2003"),
+            ("%m.%d.%Y", "09.25.2003"),
+            ("%d.%m.%Y", "25.09.2003"),
+            ("%Y/%m/%d", "2003/09/25"),
+            ("%Y/%b/%d", "2003/Sep/25"),
+            ("%d/%b/%Y", "25/Sep/2003"),
+            ("%b/%d/%Y", "Sep/25/2003"),
+            ("%m/%d/%Y", "09/25/2003"),
+            ("%d/%m/%Y", "25/09/2003"),
+            ("%Y %m %d", "2003 09 25"),
+            ("%Y %b %d", "2003 Sep 25"),
+            ("%d %b %Y", "25 Sep 2003"),
+            ("%m %d %Y", "09 25 2003"),
+            ("%d %m %Y", "25 09 2003"),
+            (
+                "%y %d %b",
+                "03 25 Sep",
+            ),
+        ],
+    )
     def test_strftime_formats_2003Sep25(self, fmt, dstr):
         expected = datetime(2003, 9, 25)
 
@@ -294,7 +397,7 @@ class TestFormat(object):
 class TestInputTypes(object):
     def test_empty_string_invalid(self):
         with pytest.raises(ParserError):
-            parse('')
+            parse("")
 
     def test_none_invalid(self):
         with pytest.raises(TypeError):
@@ -315,14 +418,14 @@ class TestInputTypes(object):
             def read(self, *args, **kwargs):
                 return self.stream.read(*args, **kwargs)
 
-        dstr = StringPassThrough(StringIO('2014 January 19'))
+        dstr = StringPassThrough(StringIO("2014 January 19"))
 
         res = parse(dstr)
         expected = datetime(2014, 1, 19)
         assert res == expected
 
     def test_parse_stream(self):
-        dstr = StringIO('2014 January 19')
+        dstr = StringIO("2014 January 19")
 
         res = parse(dstr)
         expected = datetime(2014, 1, 19)
@@ -330,7 +433,7 @@ class TestInputTypes(object):
 
     def test_parse_str(self):
         # Parser should be able to handle bytestring and unicode
-        uni_str = '2014-05-01 08:00:00'
+        uni_str = "2014-05-01 08:00:00"
         bytes_str = uni_str.encode()
 
         res = parse(bytes_str)
@@ -338,13 +441,13 @@ class TestInputTypes(object):
         assert res == expected
 
     def test_parse_bytes(self):
-        res = parse(b'2014 January 19')
+        res = parse(b"2014 January 19")
         expected = datetime(2014, 1, 19)
         assert res == expected
 
     def test_parse_bytearray(self):
         # GH#417
-        res = parse(bytearray(b'2014 January 19'))
+        res = parse(bytearray(b"2014 January 19"))
         expected = datetime(2014, 1, 19)
         assert res == expected
 
@@ -382,7 +485,7 @@ class TestTzinfoInputTypes(object):
 
     def test_valid_tzinfo_unicode_input(self):
         dstr = "2014 January 19 09:00 UTC"
-        tzinfos = {u"UTC": u"UTC+0"}
+        tzinfos = {"UTC": "UTC+0"}
         expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzstr("UTC+0"))
         res = parse(dstr, tzinfos=tzinfos)
         self.assert_equal_same_tz(res, expected)
@@ -391,7 +494,7 @@ class TestTzinfoInputTypes(object):
         dstr = "2014 January 19 09:00 UTC"
 
         def tzinfos(*args, **kwargs):
-            return u"UTC+0"
+            return "UTC+0"
 
         expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzstr("UTC+0"))
         res = parse(dstr, tzinfos=tzinfos)
@@ -399,14 +502,13 @@ class TestTzinfoInputTypes(object):
 
     def test_valid_tzinfo_int_input(self):
         dstr = "2014 January 19 09:00 UTC"
-        tzinfos = {u"UTC": -28800}
-        expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzoffset(u"UTC", -28800))
+        tzinfos = {"UTC": -28800}
+        expected = datetime(2014, 1, 19, 9, tzinfo=tz.tzoffset("UTC", -28800))
         res = parse(dstr, tzinfos=tzinfos)
         self.assert_equal_same_tz(res, expected)
 
 
 class ParserTest(unittest.TestCase):
-
     @classmethod
     def setup_class(cls):
         cls.tzinfos = {"BRST": -10800}
@@ -414,7 +516,7 @@ class ParserTest(unittest.TestCase):
         cls.default = datetime(2003, 9, 25)
 
         # Parser should be able to handle bytestring and unicode
-        cls.uni_str = '2014-05-01 08:00:00'
+        cls.uni_str = "2014-05-01 08:00:00"
         cls.str_str = cls.uni_str.encode()
 
     def testParserParseStr(self):
@@ -423,61 +525,67 @@ class ParserTest(unittest.TestCase):
         assert parser().parse(self.str_str) == parser().parse(self.uni_str)
 
     def testParseUnicodeWords(self):
-
         class rus_parserinfo(parserinfo):
-            MONTHS = [("янв", "Январь"),
-                      ("фев", "Февраль"),
-                      ("мар", "Март"),
-                      ("апр", "Апрель"),
-                      ("май", "Май"),
-                      ("июн", "Июнь"),
-                      ("июл", "Июль"),
-                      ("авг", "Август"),
-                      ("сен", "Сентябрь"),
-                      ("окт", "Октябрь"),
-                      ("ноя", "Ноябрь"),
-                      ("дек", "Декабрь")]
+            MONTHS = [
+                ("янв", "Январь"),
+                ("фев", "Февраль"),
+                ("мар", "Март"),
+                ("апр", "Апрель"),
+                ("май", "Май"),
+                ("июн", "Июнь"),
+                ("июл", "Июль"),
+                ("авг", "Август"),
+                ("сен", "Сентябрь"),
+                ("окт", "Октябрь"),
+                ("ноя", "Ноябрь"),
+                ("дек", "Декабрь"),
+            ]
 
         expected = datetime(2015, 9, 10, 10, 20)
-        res = parse('10 Сентябрь 2015 10:20', parserinfo=rus_parserinfo())
-        assert res  == expected
+        res = parse("10 Сентябрь 2015 10:20", parserinfo=rus_parserinfo())
+        assert res == expected
 
     def testParseWithNulls(self):
         # This relies on the from __future__ import unicode_literals, because
         # explicitly specifying a unicode literal is a syntax error in Py 3.2
         # May want to switch to u'...' if we ever drop Python 3.2 support.
-        pstring = '\x00\x00August 29, 1924'
+        pstring = "\x00\x00August 29, 1924"
 
         assert parse(pstring) == datetime(1924, 8, 29)
 
     def testDateCommandFormat(self):
-        self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
-                               tzinfos=self.tzinfos),
-                         datetime(2003, 9, 25, 10, 36, 28,
-                                  tzinfo=self.brsttz))
+        self.assertEqual(
+            parse("Thu Sep 25 10:36:28 BRST 2003", tzinfos=self.tzinfos),
+            datetime(2003, 9, 25, 10, 36, 28, tzinfo=self.brsttz),
+        )
 
     def testDateCommandFormatReversed(self):
-        self.assertEqual(parse("2003 10:36:28 BRST 25 Sep Thu",
-                               tzinfos=self.tzinfos),
-                         datetime(2003, 9, 25, 10, 36, 28,
-                                  tzinfo=self.brsttz))
+        self.assertEqual(
+            parse("2003 10:36:28 BRST 25 Sep Thu", tzinfos=self.tzinfos),
+            datetime(2003, 9, 25, 10, 36, 28, tzinfo=self.brsttz),
+        )
 
     def testDateCommandFormatWithLong(self):
         if PY2:
-            self.assertEqual(parse("Thu Sep 25 10:36:28 BRST 2003",
-                                   tzinfos={"BRST": long(-10800)}),
-                             datetime(2003, 9, 25, 10, 36, 28,
-                                      tzinfo=self.brsttz))
+            self.assertEqual(
+                parse(
+                    "Thu Sep 25 10:36:28 BRST 2003",
+                    tzinfos={"BRST": long(-10800)},
+                ),
+                datetime(2003, 9, 25, 10, 36, 28, tzinfo=self.brsttz),
+            )
 
     def testISOFormatStrip2(self):
-        self.assertEqual(parse("2003-09-25T10:49:41+03:00"),
-                         datetime(2003, 9, 25, 10, 49, 41,
-                                  tzinfo=tzoffset(None, 10800)))
+        self.assertEqual(
+            parse("2003-09-25T10:49:41+03:00"),
+            datetime(2003, 9, 25, 10, 49, 41, tzinfo=tzoffset(None, 10800)),
+        )
 
     def testISOStrippedFormatStrip2(self):
-        self.assertEqual(parse("20030925T104941+0300"),
-                         datetime(2003, 9, 25, 10, 49, 41,
-                                  tzinfo=tzoffset(None, 10800)))
+        self.assertEqual(
+            parse("20030925T104941+0300"),
+            datetime(2003, 9, 25, 10, 49, 41, tzinfo=tzoffset(None, 10800)),
+        )
 
     def testAMPMNoHour(self):
         with pytest.raises(ParserError):
@@ -494,31 +602,44 @@ class ParserTest(unittest.TestCase):
             parse("January 25, 1921 23:13 PM")
 
     def testPertain(self):
-        self.assertEqual(parse("Sep 03", default=self.default),
-                         datetime(2003, 9, 3))
-        self.assertEqual(parse("Sep of 03", default=self.default),
-                         datetime(2003, 9, 25))
+        self.assertEqual(
+            parse("Sep 03", default=self.default), datetime(2003, 9, 3)
+        )
+        self.assertEqual(
+            parse("Sep of 03", default=self.default), datetime(2003, 9, 25)
+        )
 
     def testFuzzy(self):
-        s = "Today is 25 of September of 2003, exactly " \
+        s = (
+            "Today is 25 of September of 2003, exactly "
             "at 10:49:41 with timezone -03:00."
-        self.assertEqual(parse(s, fuzzy=True),
-                         datetime(2003, 9, 25, 10, 49, 41,
-                                  tzinfo=self.brsttz))
+        )
+        self.assertEqual(
+            parse(s, fuzzy=True),
+            datetime(2003, 9, 25, 10, 49, 41, tzinfo=self.brsttz),
+        )
 
     def testFuzzyWithTokens(self):
-        s1 = "Today is 25 of September of 2003, exactly " \
+        s1 = (
+            "Today is 25 of September of 2003, exactly "
             "at 10:49:41 with timezone -03:00."
-        self.assertEqual(parse(s1, fuzzy_with_tokens=True),
-                         (datetime(2003, 9, 25, 10, 49, 41,
-                                   tzinfo=self.brsttz),
-                         ('Today is ', 'of ', ', exactly at ',
-                          ' with timezone ', '.')))
+        )
+        self.assertEqual(
+            parse(s1, fuzzy_with_tokens=True),
+            (
+                datetime(2003, 9, 25, 10, 49, 41, tzinfo=self.brsttz),
+                ("Today is ", "of ", ", exactly at ", " with timezone ", "."),
+            ),
+        )
 
         s2 = "http://biz.yahoo.com/ipo/p/600221.html"
-        self.assertEqual(parse(s2, fuzzy_with_tokens=True),
-                         (datetime(2060, 2, 21, 0, 0, 0),
-                         ('http://biz.yahoo.com/ipo/p/', '.html')))
+        self.assertEqual(
+            parse(s2, fuzzy_with_tokens=True),
+            (
+                datetime(2060, 2, 21, 0, 0, 0),
+                ("http://biz.yahoo.com/ipo/p/", ".html"),
+            ),
+        )
 
     def testFuzzyAMPMProblem(self):
         # Sometimes fuzzy parsing results in AM/PM flag being set without
@@ -542,9 +663,10 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(res, datetime(1945, 1, 29, 14, 45))
 
     def testRandomFormat24(self):
-        self.assertEqual(parse("0:00 PM, PST", default=self.default,
-                               ignoretz=True),
-                         datetime(2003, 9, 25, 12, 0))
+        self.assertEqual(
+            parse("0:00 PM, PST", default=self.default, ignoretz=True),
+            datetime(2003, 9, 25, 12, 0),
+        )
 
     def testRandomFormat26(self):
         with pytest.warns(UnknownTimezoneWarning):
@@ -554,42 +676,66 @@ class ParserTest(unittest.TestCase):
 
     def testUnspecifiedDayFallback(self):
         # Test that for an unspecified day, the fallback behavior is correct.
-        self.assertEqual(parse("April 2009", default=datetime(2010, 1, 31)),
-                         datetime(2009, 4, 30))
+        self.assertEqual(
+            parse("April 2009", default=datetime(2010, 1, 31)),
+            datetime(2009, 4, 30),
+        )
 
     def testUnspecifiedDayFallbackFebNoLeapYear(self):
-        self.assertEqual(parse("Feb 2007", default=datetime(2010, 1, 31)),
-                         datetime(2007, 2, 28))
+        self.assertEqual(
+            parse("Feb 2007", default=datetime(2010, 1, 31)),
+            datetime(2007, 2, 28),
+        )
 
     def testUnspecifiedDayFallbackFebLeapYear(self):
-        self.assertEqual(parse("Feb 2008", default=datetime(2010, 1, 31)),
-                         datetime(2008, 2, 29))
+        self.assertEqual(
+            parse("Feb 2008", default=datetime(2010, 1, 31)),
+            datetime(2008, 2, 29),
+        )
 
     def testErrorType01(self):
         with pytest.raises(ParserError):
-            parse('shouldfail')
+            parse("shouldfail")
 
     def testCorrectErrorOnFuzzyWithTokens(self):
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/32/423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/04 +32423', fuzzy_with_tokens=True)
-        assertRaisesRegex(self, ParserError, 'Unknown string format',
-                          parse, '04/04/0d4', fuzzy_with_tokens=True)
+        assertRaisesRegex(
+            self,
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/32/423",
+            fuzzy_with_tokens=True,
+        )
+        assertRaisesRegex(
+            self,
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/04 +32423",
+            fuzzy_with_tokens=True,
+        )
+        assertRaisesRegex(
+            self,
+            ParserError,
+            "Unknown string format",
+            parse,
+            "04/04/0d4",
+            fuzzy_with_tokens=True,
+        )
 
     def testIncreasingCTime(self):
         # This test will check 200 different years, every month, every day,
         # every hour, every minute, every second, and every weekday, using
         # a delta of more or less 1 year, 1 month, 1 day, 1 minute and
         # 1 second.
-        delta = timedelta(days=365+31+1, seconds=1+60+60*60)
+        delta = timedelta(days=365 + 31 + 1, seconds=1 + 60 + 60 * 60)
         dt = datetime(1900, 1, 1, 0, 0, 0, 0)
         for i in range(200):
             assert parse(dt.ctime()) == dt
             dt += delta
 
     def testIncreasingISOFormat(self):
-        delta = timedelta(days=365+31+1, seconds=1+60+60*60)
+        delta = timedelta(days=365 + 31 + 1, seconds=1 + 60 + 60 * 60)
         dt = datetime(1900, 1, 1, 0, 0, 0, 0)
         for i in range(200):
             assert parse(dt.isoformat()) == dt
@@ -605,10 +751,24 @@ class ParserTest(unittest.TestCase):
     def testMicrosecondPrecisionErrorReturns(self):
         # One more precision issue, discovered by Eric Brown.  This should
         # be the last one, as we're no longer using floating points.
-        for ms in [100001, 100000, 99999, 99998,
-                    10001,  10000,  9999,  9998,
-                     1001,   1000,   999,   998,
-                      101,    100,    99,    98]:
+        for ms in [
+            100001,
+            100000,
+            99999,
+            99998,
+            10001,
+            10000,
+            9999,
+            9998,
+            1001,
+            1000,
+            999,
+            998,
+            101,
+            100,
+            99,
+            98,
+        ]:
             dt = datetime(2008, 2, 27, 21, 26, 1, ms)
             assert parse(dt.isoformat()) == dt
 
@@ -619,6 +779,7 @@ class ParserTest(unittest.TestCase):
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
             MONTHS[0] = ("Foo", "Foo")
+
         myparser = parser(myparserinfo())
         dt = myparser.parse("01/Foo/2007")
         assert dt == datetime(2007, 1, 1)
@@ -630,77 +791,78 @@ class ParserTest(unittest.TestCase):
         from dateutil.parser import parserinfo, parser
 
         class GermanParserInfo(parserinfo):
-            WEEKDAYS = [("Mo", "Montag"),
-                        ("Di", "Dienstag"),
-                        ("Mi", "Mittwoch"),
-                        ("Do", "Donnerstag"),
-                        ("Fr", "Freitag"),
-                        ("Sa", "Samstag"),
-                        ("So", "Sonntag")]
+            WEEKDAYS = [
+                ("Mo", "Montag"),
+                ("Di", "Dienstag"),
+                ("Mi", "Mittwoch"),
+                ("Do", "Donnerstag"),
+                ("Fr", "Freitag"),
+                ("Sa", "Samstag"),
+                ("So", "Sonntag"),
+            ]
 
         myparser = parser(GermanParserInfo())
         dt = myparser.parse("Sa 21. Jan 2017")
         self.assertEqual(dt, datetime(2017, 1, 21))
 
     def testNoYearFirstNoDayFirst(self):
-        dtstr = '090107'
+        dtstr = "090107"
 
         # Should be MMDDYY
-        self.assertEqual(parse(dtstr),
-                         datetime(2007, 9, 1))
+        self.assertEqual(parse(dtstr), datetime(2007, 9, 1))
 
-        self.assertEqual(parse(dtstr, yearfirst=False, dayfirst=False),
-                         datetime(2007, 9, 1))
+        self.assertEqual(
+            parse(dtstr, yearfirst=False, dayfirst=False), datetime(2007, 9, 1)
+        )
 
     def testYearFirst(self):
-        dtstr = '090107'
+        dtstr = "090107"
 
         # Should be MMDDYY
-        self.assertEqual(parse(dtstr, yearfirst=True),
-                         datetime(2009, 1, 7))
+        self.assertEqual(parse(dtstr, yearfirst=True), datetime(2009, 1, 7))
 
-        self.assertEqual(parse(dtstr, yearfirst=True, dayfirst=False),
-                         datetime(2009, 1, 7))
+        self.assertEqual(
+            parse(dtstr, yearfirst=True, dayfirst=False), datetime(2009, 1, 7)
+        )
 
     def testDayFirst(self):
-        dtstr = '090107'
+        dtstr = "090107"
 
         # Should be DDMMYY
-        self.assertEqual(parse(dtstr, dayfirst=True),
-                         datetime(2007, 1, 9))
+        self.assertEqual(parse(dtstr, dayfirst=True), datetime(2007, 1, 9))
 
-        self.assertEqual(parse(dtstr, yearfirst=False, dayfirst=True),
-                         datetime(2007, 1, 9))
+        self.assertEqual(
+            parse(dtstr, yearfirst=False, dayfirst=True), datetime(2007, 1, 9)
+        )
 
     def testDayFirstYearFirst(self):
-        dtstr = '090107'
+        dtstr = "090107"
         # Should be YYDDMM
-        self.assertEqual(parse(dtstr, yearfirst=True, dayfirst=True),
-                         datetime(2009, 7, 1))
+        self.assertEqual(
+            parse(dtstr, yearfirst=True, dayfirst=True), datetime(2009, 7, 1)
+        )
 
     def testUnambiguousYearFirst(self):
-        dtstr = '2015 09 25'
-        self.assertEqual(parse(dtstr, yearfirst=True),
-                         datetime(2015, 9, 25))
+        dtstr = "2015 09 25"
+        self.assertEqual(parse(dtstr, yearfirst=True), datetime(2015, 9, 25))
 
     def testUnambiguousDayFirst(self):
-        dtstr = '2015 09 25'
-        self.assertEqual(parse(dtstr, dayfirst=True),
-                         datetime(2015, 9, 25))
+        dtstr = "2015 09 25"
+        self.assertEqual(parse(dtstr, dayfirst=True), datetime(2015, 9, 25))
 
     def testUnambiguousDayFirstYearFirst(self):
-        dtstr = '2015 09 25'
-        self.assertEqual(parse(dtstr, dayfirst=True, yearfirst=True),
-                         datetime(2015, 9, 25))
+        dtstr = "2015 09 25"
+        self.assertEqual(
+            parse(dtstr, dayfirst=True, yearfirst=True), datetime(2015, 9, 25)
+        )
 
     def test_mstridx(self):
         # See GH408
-        dtstr = '2015-15-May'
-        self.assertEqual(parse(dtstr),
-                         datetime(2015, 5, 15))
+        dtstr = "2015-15-May"
+        self.assertEqual(parse(dtstr), datetime(2015, 5, 15))
 
     def test_idx_check(self):
-        dtstr = '2017-07-17 06:15:'
+        dtstr = "2017-07-17 06:15:"
         # Pre-PR, the trailing colon will cause an IndexError at 824-825
         # when checking `i < len_l` and then accessing `l[i+1]`
         res = parse(dtstr, fuzzy=True)
@@ -708,7 +870,7 @@ class ParserTest(unittest.TestCase):
 
     def test_hmBY(self):
         # See GH#483
-        dtstr = '02:17NOV2017'
+        dtstr = "02:17NOV2017"
         res = parse(dtstr, default=self.default)
         assert res == datetime(2017, 11, self.default.day, 2, 17)
 
@@ -719,7 +881,7 @@ class ParserTest(unittest.TestCase):
             parse(invalid)
 
     def test_era_trailing_year(self):
-        dstr = 'AD2001'
+        dstr = "AD2001"
         res = parse(dstr)
         assert res.year == 2001, res
 
@@ -735,7 +897,6 @@ class ParserTest(unittest.TestCase):
 
 
 class TestOutOfBounds(object):
-
     def test_no_year_zero(self):
         with pytest.raises(ParserError):
             parse("0000 Jun 20")
@@ -775,49 +936,53 @@ class TestParseUnimplementedCases(object):
         # Ref: github issue #487
         # The parser is choosing the wrong part for hour
         # causing datetime to raise an exception.
-        dtstr = '1237 PM BRST Mon Oct 30 2017'
+        dtstr = "1237 PM BRST Mon Oct 30 2017"
         res = parse(dtstr, tzinfo=self.tzinfos)
         assert res == datetime(2017, 10, 30, 12, 37, tzinfo=self.tzinfos)
 
     @pytest.mark.xfail
     def test_YmdH_M_S(self):
         # found in nasdaq's ftp data
-        dstr = '1991041310:19:24'
+        dstr = "1991041310:19:24"
         expected = datetime(1991, 4, 13, 10, 19, 24)
         res = parse(dstr)
         assert res == expected, (res, expected)
 
     @pytest.mark.xfail
     def test_first_century(self):
-        dstr = '0031 Nov 03'
+        dstr = "0031 Nov 03"
         expected = datetime(31, 11, 3)
         res = parse(dstr)
         assert res == expected, res
 
     @pytest.mark.xfail
     def test_era_trailing_year_with_dots(self):
-        dstr = 'A.D.2001'
+        dstr = "A.D.2001"
         res = parse(dstr)
         assert res.year == 2001, res
 
     @pytest.mark.xfail
     def test_ad_nospace(self):
         expected = datetime(6, 5, 19)
-        for dstr in [' 6AD May 19', ' 06AD May 19',
-                     ' 006AD May 19', ' 0006AD May 19']:
+        for dstr in [
+            " 6AD May 19",
+            " 06AD May 19",
+            " 006AD May 19",
+            " 0006AD May 19",
+        ]:
             res = parse(dstr)
             assert res == expected, (dstr, res)
 
     @pytest.mark.xfail
     def test_four_letter_day(self):
-        dstr = 'Frid Dec 30, 2016'
+        dstr = "Frid Dec 30, 2016"
         expected = datetime(2016, 12, 30)
         res = parse(dstr)
         assert res == expected
 
     @pytest.mark.xfail
     def test_non_date_number(self):
-        dstr = '1,700'
+        dstr = "1,700"
         with pytest.raises(ParserError):
             parse(dstr)
 
@@ -825,7 +990,7 @@ class TestParseUnimplementedCases(object):
     def test_on_era(self):
         # This could be classified as an "eras" test, but the relevant part
         # about this is the ` on `
-        dstr = '2:15 PM on January 2nd 1973 A.D.'
+        dstr = "2:15 PM on January 2nd 1973 A.D."
         expected = datetime(1973, 1, 2, 14, 15)
         res = parse(dstr)
         assert res == expected
@@ -853,8 +1018,10 @@ class TestParseUnimplementedCases(object):
     @pytest.mark.xfail
     def test_extraneous_year2(self):
         # This was found in the wild at insidertrading.org
-        dstr = ("Berylson Amy Smith 1998 Grantor Retained Annuity Trust "
-                "u/d/t November 2, 1998 f/b/o Jennifer L Berylson")
+        dstr = (
+            "Berylson Amy Smith 1998 Grantor Retained Annuity Trust "
+            "u/d/t November 2, 1998 f/b/o Jennifer L Berylson"
+        )
         res = parse(dstr, fuzzy_with_tokens=True)
         expected = datetime(1998, 11, 2)
         assert res == expected
@@ -891,68 +1058,72 @@ class TestTZVar(object):
     def test_parse_unambiguous_nonexistent_local(self):
         # When dates are specified "EST" even when they should be "EDT" in the
         # local time zone, we should still assign the local time zone
-        with TZEnvContext('EST+5EDT,M3.2.0/2,M11.1.0/2'):
+        with TZEnvContext("EST+5EDT,M3.2.0/2,M11.1.0/2"):
             dt_exp = datetime(2011, 8, 1, 12, 30, tzinfo=tz.tzlocal())
-            dt = parse('2011-08-01T12:30 EST')
+            dt = parse("2011-08-01T12:30 EST")
 
-            assert dt.tzname() == 'EDT'
+            assert dt.tzname() == "EDT"
             assert dt == dt_exp
 
     def test_tzlocal_in_gmt(self):
         # GH #318
-        with TZEnvContext('GMT0BST,M3.5.0,M10.5.0'):
+        with TZEnvContext("GMT0BST,M3.5.0,M10.5.0"):
             # This is an imaginary datetime in tz.tzlocal() but should still
             # parse using the GMT-as-alias-for-UTC rule
-            dt = parse('2004-05-01T12:00 GMT')
+            dt = parse("2004-05-01T12:00 GMT")
             dt_exp = datetime(2004, 5, 1, 12, tzinfo=tz.UTC)
 
             assert dt == dt_exp
 
     def test_tzlocal_parse_fold(self):
         # One manifestion of GH #318
-        with TZEnvContext('EST+5EDT,M3.2.0/2,M11.1.0/2'):
+        with TZEnvContext("EST+5EDT,M3.2.0/2,M11.1.0/2"):
             dt_exp = datetime(2011, 11, 6, 1, 30, tzinfo=tz.tzlocal())
             dt_exp = tz.enfold(dt_exp, fold=1)
-            dt = parse('2011-11-06T01:30 EST')
+            dt = parse("2011-11-06T01:30 EST")
 
             # Because this is ambiguous, until `tz.tzlocal() is tz.tzlocal()`
             # we'll just check the attributes we care about rather than
             # dt == dt_exp
             assert dt.tzname() == dt_exp.tzname()
             assert dt.replace(tzinfo=None) == dt_exp.replace(tzinfo=None)
-            assert getattr(dt, 'fold') == getattr(dt_exp, 'fold')
+            assert getattr(dt, "fold") == getattr(dt_exp, "fold")
             assert dt.astimezone(tz.UTC) == dt_exp.astimezone(tz.UTC)
 
 
 def test_parse_tzinfos_fold():
-    NYC = tz.gettz('America/New_York')
-    tzinfos = {'EST': NYC, 'EDT': NYC}
+    NYC = tz.gettz("America/New_York")
+    tzinfos = {"EST": NYC, "EDT": NYC}
 
     dt_exp = tz.enfold(datetime(2011, 11, 6, 1, 30, tzinfo=NYC), fold=1)
-    dt = parse('2011-11-06T01:30 EST', tzinfos=tzinfos)
+    dt = parse("2011-11-06T01:30 EST", tzinfos=tzinfos)
 
     assert dt == dt_exp
     assert dt.tzinfo is dt_exp.tzinfo
-    assert getattr(dt, 'fold') == getattr(dt_exp, 'fold')
+    assert getattr(dt, "fold") == getattr(dt_exp, "fold")
     assert dt.astimezone(tz.UTC) == dt_exp.astimezone(tz.UTC)
 
 
-@pytest.mark.parametrize('dtstr,dt', [
-    ('5.6h', datetime(2003, 9, 25, 5, 36)),
-    ('5.6m', datetime(2003, 9, 25, 0, 5, 36)),
-    # '5.6s' never had a rounding problem, test added for completeness
-    ('5.6s', datetime(2003, 9, 25, 0, 0, 5, 600000))
-])
+@pytest.mark.parametrize(
+    "dtstr,dt",
+    [
+        ("5.6h", datetime(2003, 9, 25, 5, 36)),
+        ("5.6m", datetime(2003, 9, 25, 0, 5, 36)),
+        # '5.6s' never had a rounding problem, test added for completeness
+        ("5.6s", datetime(2003, 9, 25, 0, 0, 5, 600000)),
+    ],
+)
 def test_rounding_floatlike_strings(dtstr, dt):
     assert parse(dtstr, default=datetime(2003, 9, 25)) == dt
 
 
-@pytest.mark.parametrize('value', ['1: test', 'Nan'])
+@pytest.mark.parametrize("value", ["1: test", "Nan"])
 def test_decimal_error(value):
     # GH 632, GH 662 - decimal.Decimal raises some non-ParserError exception
     # when constructed with an invalid value
     with pytest.raises(ParserError):
         parse(value)
+
 
 def test_parsererror_repr():
     # GH 991 — the __repr__ was not properly indented and so was never defined.
@@ -964,19 +1135,22 @@ def test_parsererror_repr():
     assert s == "ParserError('Problem with string: %s', '2019-01-01')"
 
 
-@pytest.mark.parametrize('dtstr,expected_offset_seconds', [
-    # GH #1478: UTC offset sign should not be reversed
-    # UTC-4 should mean UTC minus 4 hours, not UTC+4
-    ('2026-03-11 14:32:45 UTC-4', -4 * 3600),
-    ('2026-03-11 14:32:45 UTC+4', 4 * 3600),
-    ('2026-03-11 14:32:45 GMT-5', -5 * 3600),
-    ('2026-03-11 14:32:45 GMT+3', 3 * 3600),
-    ('2026-03-11 14:32:45 Z-4', -4 * 3600),
-    ('2026-03-11 14:32:45 Z+4', 4 * 3600),
-    # Standard numeric offsets should still work correctly
-    ('2026-03-11 14:32:45 -0300', -3 * 3600),
-    ('2026-03-11 14:32:45 +0300', 3 * 3600),
-])
+@pytest.mark.parametrize(
+    "dtstr,expected_offset_seconds",
+    [
+        # GH #1478: UTC offset sign should not be reversed
+        # UTC-4 should mean UTC minus 4 hours, not UTC+4
+        ("2026-03-11 14:32:45 UTC-4", -4 * 3600),
+        ("2026-03-11 14:32:45 UTC+4", 4 * 3600),
+        ("2026-03-11 14:32:45 GMT-5", -5 * 3600),
+        ("2026-03-11 14:32:45 GMT+3", 3 * 3600),
+        ("2026-03-11 14:32:45 Z-4", -4 * 3600),
+        ("2026-03-11 14:32:45 Z+4", 4 * 3600),
+        # Standard numeric offsets should still work correctly
+        ("2026-03-11 14:32:45 -0300", -3 * 3600),
+        ("2026-03-11 14:32:45 +0300", 3 * 3600),
+    ],
+)
 def test_utc_offset_not_reversed(dtstr, expected_offset_seconds):
     # GH #1478: UTC/GMT/Z followed by +/- offset should use the
     # literal offset sign, not POSIX convention reversal.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -962,3 +962,25 @@ def test_parsererror_repr():
     s = repr(ParserError("Problem with string: %s", "2019-01-01"))
 
     assert s == "ParserError('Problem with string: %s', '2019-01-01')"
+
+
+@pytest.mark.parametrize('dtstr,expected_offset_seconds', [
+    # GH #1478: UTC offset sign should not be reversed
+    # UTC-4 should mean UTC minus 4 hours, not UTC+4
+    ('2026-03-11 14:32:45 UTC-4', -4 * 3600),
+    ('2026-03-11 14:32:45 UTC+4', 4 * 3600),
+    ('2026-03-11 14:32:45 GMT-5', -5 * 3600),
+    ('2026-03-11 14:32:45 GMT+3', 3 * 3600),
+    ('2026-03-11 14:32:45 Z-4', -4 * 3600),
+    ('2026-03-11 14:32:45 Z+4', 4 * 3600),
+    # Standard numeric offsets should still work correctly
+    ('2026-03-11 14:32:45 -0300', -3 * 3600),
+    ('2026-03-11 14:32:45 +0300', 3 * 3600),
+])
+def test_utc_offset_not_reversed(dtstr, expected_offset_seconds):
+    # GH #1478: UTC/GMT/Z followed by +/- offset should use the
+    # literal offset sign, not POSIX convention reversal.
+    # Previously, "UTC-4" was incorrectly parsed as +04:00.
+    result = parse(dtstr)
+    actual_offset = result.tzinfo.utcoffset(result).total_seconds()
+    assert actual_offset == expected_offset_seconds


### PR DESCRIPTION
**Problem**

When parsing datetime strings like `'2026-03-11 14:32:45 UTC-4'`, the parser incorrectly reversed the offset sign, resulting in `+04:00` instead of the expected `-04:00`.

**Root Cause**

The parser applied POSIX timezone convention to UTC zone names (UTC, GMT, Z). In POSIX, `EST5` means the timezone is UTC-5 (not UTC+5), and `GMT+3` would mean UTC-3. However, modern UTC offset notation like `'UTC-4'` should mean UTC minus 4 hours literally, not POSIX convention.

**Fix**

This PR distinguishes between UTC zone names (UTC, GMT, Z) and other timezone abbreviations:
- For UTC/GMT/Z: preserve the literal offset sign (`'UTC-4'` → `-04:00`)
- For other abbreviations: keep POSIX convention as before

**Test Cases**

```python
parse('2026-03-11 14:32:45 UTC-4')  # → -04:00 (fixed)
parse('2026-03-11 14:32:45 UTC+4')  # → +04:00 (fixed)
parse('2026-03-11 14:32:45 GMT-5')  # → -05:00 (fixed)
parse('2026-03-11 14:32:45 Z+4')    # → +04:00 (fixed)
```

Added regression test `test_utc_offset_not_reversed` covering various UTC/GMT/Z offset combinations.

**Fixes**: #1478