### PR TITLE
Fix leap-day parsing when the year appears last

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -926,6 +926,24 @@ class parser(object):
                 if len_li > 12:
                     res.second = int(s[12:])
 
+        elif (
+            '.' in value_repr
+            and ymd.has_month
+            and not ymd.has_day
+            and not ymd.has_year
+        ):
+            first, second = value_repr.split('.', 1)
+
+            if first.isdigit() and second.isdigit():
+                if len(first) > 2:
+                    ymd.append(first, 'Y')
+                    ymd.append(second)
+                    idx += 1
+                elif len(second) > 2:
+                    ymd.append(first)
+                    ymd.append(second, 'Y')
+                    idx += 1
+
         elif self._find_hms_idx(idx, tokens, info, allow_jump=True) is not None:
             # HH[ ]h or MM[ ]m or SS[.ss][ ]s
             hms_idx = self._find_hms_idx(idx, tokens, info, allow_jump=True)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -185,6 +185,15 @@ def test_parse_yearfirst(sep):
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    "dstr",
+    ["February 29,2016", "February 2016,29"],
+)
+def test_parse_leap_year_with_year_last(dstr):
+    default = datetime(2017, 2, 1)
+    assert parse(dstr, default=default) == datetime(2016, 2, 29)
+
+
 @pytest.mark.parametrize('dstr,expected', [
     ("Thu Sep 25 10:36:28 BRST 2003", datetime(2003, 9, 25, 10, 36, 28)),
     ("1996.07.10 AD at 15:08:56 PDT", datetime(1996, 7, 10, 15, 8, 56)),


### PR DESCRIPTION
## Summary
- preserve both numeric components when a textual month is followed by a comma-normalized numeric token
- handle `February 29,2016` and `February 2016,29` as month/day/year inputs instead of truncating the year
- add regression tests for the two reported formats

Closes #1156.

## Validation
- reproduced both failures locally with `parse(..., default=datetime(2017, 2, 1))` before the change
- `PYTHONPATH=src python3 -m pytest tests/test_parser.py -k leap_year_with_year_last -o markers="no_cover: no cover"`
- `PYTHONPATH=src python3 -m pytest tests/test_parser.py::test_parser_default -o markers="no_cover: no cover"`