### PR TITLE
Keep later fuzzy times in skipped tokens

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -737,7 +737,9 @@ class parser(object):
 
                 if value is not None:
                     # Numeric token
-                    i = self._parse_numeric_token(l, i, info, ymd, res, fuzzy)
+                    i = self._parse_numeric_token(
+                        l, i, info, ymd, res, fuzzy, skipped_idxs
+                    )
 
                 # Check weekday
                 elif info.weekday(l[i]) is not None:
@@ -872,7 +874,7 @@ class parser(object):
         else:
             return res, None
 
-    def _parse_numeric_token(self, tokens, idx, info, ymd, res, fuzzy):
+    def _parse_numeric_token(self, tokens, idx, info, ymd, res, fuzzy, skipped_idxs):
         # Token is a number
         value_repr = tokens[idx]
         try:
@@ -937,6 +939,16 @@ class parser(object):
 
         elif idx + 2 < len_l and tokens[idx + 1] == ':':
             # HH:MM[:SS[.ss]]
+            if fuzzy and res.hour is not None:
+                skipped_idxs.extend([idx, idx + 1, idx + 2])
+
+                if idx + 4 < len_l and tokens[idx + 3] == ':':
+                    skipped_idxs.extend([idx + 3, idx + 4])
+                    idx += 2
+
+                idx += 2
+                return idx
+
             res.hour = int(value)
             value = self._to_decimal(tokens[idx + 2])  # TODO: try/except for this?
             (res.minute, res.second) = self._parse_min_sec(value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -520,6 +520,16 @@ class ParserTest(unittest.TestCase):
                          (datetime(2060, 2, 21, 0, 0, 0),
                          ('http://biz.yahoo.com/ipo/p/', '.html')))
 
+    def testFuzzyWithTokensSkipsLaterTime(self):
+        self.assertEqual(
+            parse(
+                "from 13:45 to 17:15",
+                fuzzy_with_tokens=True,
+                default=self.default,
+            ),
+            (datetime(2003, 9, 25, 13, 45), ('from ', ' to 17:15')),
+        )
+
     def testFuzzyAMPMProblem(self):
         # Sometimes fuzzy parsing results in AM/PM flag being set without
         # hours - if it's fuzzy it should ignore that.


### PR DESCRIPTION
## Summary
- avoid overwriting an already-parsed fuzzy time when a later `HH:MM` fragment is encountered
- return that later time fragment as skipped fuzzy text instead
- add a regression test around `from 13:45 to 17:15` and keep the existing fuzzy error checks green

Partially addresses #1063.

## Validation
- reproduced `parse("from 13:45 to 17:15", fuzzy_with_tokens=True)` returning the later time before the change
- `PYTHONPATH=src python3 -m pytest tests/test_parser.py -k Fuzzy -o markers="no_cover: no cover"`
- `PYTHONPATH=src python3 -m pytest tests/test_parser.py -k CorrectErrorOnFuzzyWithTokens -o markers="no_cover: no cover"`