### PR TITLE
Reject malformed 000A year tokens

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -989,7 +989,11 @@ class parser(object):
                 ymd.append(value)
             idx += 1
 
-        elif info.ampm(tokens[idx + 1]) is not None and (0 <= value < 24):
+        elif (
+            info.ampm(tokens[idx + 1]) is not None
+            and len_li <= 2
+            and (0 <= value < 24)
+        ):
             # 12am
             hour = int(value)
             res.hour = self._adjust_ampm(hour, info.ampm(tokens[idx + 1]))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -718,6 +718,10 @@ class ParserTest(unittest.TestCase):
         with pytest.raises(ParserError):
             parse(invalid)
 
+    def test_validate_bogus_year_with_ampm_suffix(self):
+        with pytest.raises(ParserError):
+            parse("000A-01-01T00:00:00")
+
     def test_era_trailing_year(self):
         dstr = 'AD2001'
         res = parse(dstr)


### PR DESCRIPTION
## Summary
- stop treating three-digit numeric tokens followed by bare `A`/`P` as adjacent am/pm shorthands
- preserve valid `10am`/`10pm` parsing while rejecting `000A-01-01T00:00:00`
- add a regression test next to the existing malformed-year validation

Closes #640.

## Validation
- reproduced `parse("000A-01-01T00:00:00")` returning a default-date time instead of failing before the change
- verified `10am` and `10pm` still parse correctly
- `PYTHONPATH=src python3 -m pytest tests/test_parser.py -k "validate_hour or validate_bogus_year_with_ampm_suffix or parser_default" -o markers="no_cover: no cover"`