### PR TITLE
Parse dashed time segments after an ISO T separator

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -884,7 +884,21 @@ class parser(object):
 
         len_l = len(tokens)
 
-        if (len(ymd) == 3 and len_li in (2, 4) and
+        if (
+            len(ymd) == 3
+            and idx > 0
+            and tokens[idx - 1] == 'T'
+            and idx + 4 < len_l
+            and tokens[idx + 1] == tokens[idx + 3] == '-'
+            and tokens[idx + 2].isdigit()
+            and tokens[idx + 4].isdigit()
+        ):
+            res.hour = int(value)
+            res.minute = int(tokens[idx + 2])
+            res.second = int(tokens[idx + 4])
+            idx += 4
+
+        elif (len(ymd) == 3 and len_li in (2, 4) and
             res.hour is None and
             (idx + 1 >= len_l or
              (tokens[idx + 1] != ':' and

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -718,6 +718,11 @@ class ParserTest(unittest.TestCase):
         with pytest.raises(ParserError):
             parse(invalid)
 
+    def test_parse_dashed_time_after_t_separator(self):
+        assert parse("2016-06-01T02-01-00+00-00") == datetime(
+            2016, 6, 1, 2, 1, tzinfo=tz.UTC
+        )
+
     def test_era_trailing_year(self):
         dstr = 'AD2001'
         res = parse(dstr)


### PR DESCRIPTION
## Summary
- recognize `HH-MM-SS` immediately after an ISO-style `T` separator
- avoid the previous partial parse that dropped the minute and folded the tail into timezone handling
- add a regression test for `2016-06-01T02-01-00+00-00`

Closes #845.

## Validation
- reproduced `parse("2016-06-01T02-01-00+00-00")` returning `02:00:00+00:00` before the change
- `PYTHONPATH=src python3 -m pytest tests/test_parser.py -k "parse_dashed_time_after_t_separator or parser_default" -o markers="no_cover: no cover"`