### PR TITLE
Skip numeric tails in fuzzy timestamp parsing

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -737,7 +737,9 @@ class parser(object):
 
                 if value is not None:
                     # Numeric token
-                    i = self._parse_numeric_token(l, i, info, ymd, res, fuzzy)
+                    i = self._parse_numeric_token(
+                        l, i, info, ymd, res, fuzzy, skipped_idxs
+                    )
 
                 # Check weekday
                 elif info.weekday(l[i]) is not None:
@@ -788,6 +790,18 @@ class parser(object):
 
                     elif fuzzy:
                         skipped_idxs.append(i)
+
+                elif (
+                    fuzzy
+                    and res.hour is not None
+                    and res.tzname is None
+                    and res.tzoffset is None
+                    and (i - 1) in skipped_idxs
+                    and (i - 2) in skipped_idxs
+                    and l[i].isalpha()
+                    and l[i].upper() == l[i]
+                ):
+                    skipped_idxs.append(i)
 
                 # Check for a timezone name
                 elif self._could_be_tzname(res.hour, res.tzname, res.tzoffset, l[i]):
@@ -872,7 +886,7 @@ class parser(object):
         else:
             return res, None
 
-    def _parse_numeric_token(self, tokens, idx, info, ymd, res, fuzzy):
+    def _parse_numeric_token(self, tokens, idx, info, ymd, res, fuzzy, skipped_idxs):
         # Token is a number
         value_repr = tokens[idx]
         try:
@@ -984,6 +998,16 @@ class parser(object):
                 hour = int(value)
                 res.hour = self._adjust_ampm(hour, info.ampm(tokens[idx + 2]))
                 idx += 1
+            elif (
+                fuzzy
+                and len(ymd) == 3
+                and res.hour is not None
+                and idx + 2 < len_l
+                and info.jump(tokens[idx + 1])
+                and tokens[idx + 2].isalpha()
+                and tokens[idx + 2].upper() == tokens[idx + 2]
+            ):
+                skipped_idxs.extend([idx, idx + 1])
             else:
                 # Year, month or day
                 ymd.append(value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -520,6 +520,12 @@ class ParserTest(unittest.TestCase):
                          (datetime(2060, 2, 21, 0, 0, 0),
                          ('http://biz.yahoo.com/ipo/p/', '.html')))
 
+        s3 = "2018-08-14 08:41:31.181 1288 ERROR"
+        self.assertEqual(
+            parse(s3, fuzzy_with_tokens=True),
+            (datetime(2018, 8, 14, 8, 41, 31, 181000), (' ', ' 1288 ERROR')),
+        )
+
     def testFuzzyAMPMProblem(self):
         # Sometimes fuzzy parsing results in AM/PM flag being set without
         # hours - if it's fuzzy it should ignore that.


### PR DESCRIPTION
## Summary
- treat a trailing numeric fragment plus following all-caps token as fuzzy leftovers once a full timestamp has already been parsed
- avoid the previous failure mode where the numeric tail poisoned the parse and the word was reinterpreted as an unknown timezone
- add a regression case for `2018-08-14 08:41:31.181 1288 ERROR` to the existing fuzzy-token tests

Closes #803.

## Validation
- reproduced `parse("2018-08-14 08:41:31.181 1288 ERROR", fuzzy_with_tokens=True)` failing before the change
- `PYTHONPATH=src python3 -m pytest tests/test_parser.py -k "FuzzyWithTokens or FuzzyAMPMProblem or CorrectErrorOnFuzzyWithTokens" -o markers="no_cover: no cover"`