### PR TITLE
ci(docs): ignore timeanddate linkcheck 403

### DIFF
--- a/changelog.d/1487.misc.rst
+++ b/changelog.d/1487.misc.rst
@@ -1,0 +1,1 @@
+Ignored a bot-blocked ``timeanddate.com`` URL during Sphinx linkcheck to avoid CI-only docs failures. (gh pr #1487)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -286,6 +286,8 @@ linkcheck_ignore = [
     r'https://pgp.mit.edu',
     # MetaCPAN frequently returns 402 for automated link checkers
     r"https://metacpan.org/.*",
+    # timeanddate.com now rejects automated link checks with HTTP 403
+    r"https://www.timeanddate.com/time/zones/",
 ]
 
 # Reduce problems with ephemeral failures


### PR DESCRIPTION
## Summary
- ignore the `timeanddate.com/time/zones/` link during Sphinx linkcheck
- keep the docs content unchanged for readers while avoiding bot-blocked CI failures

## Why
The docs job is currently failing because Sphinx linkcheck treats `https://www.timeanddate.com/time/zones/` as broken when the site returns HTTP 403 to automated requests. This is a CI-only failure mode rather than a content regression.

## Validation
- reproduced the failure locally with `python -m sphinx -d .tox/docs_doctree docs .tox/docs_out -W --color -blinkcheck`
- verified the same command passes after this change
- verified `python -m sphinx -d .tox/docs_doctree docs .tox/docs_out -W --color -bhtml`
- verified `python setup.py check -r -s`

## Notes
- `dateutil`'s contributing guide suggests adding the changelog fragment after the PR number exists; I'll push that follow-up on this branch once the PR is created.