### PR TITLE
fix: correct dayfirst behavior when yearfirst is True

### DIFF
--- a/changelog.d/1448.bugfix.rst
+++ b/changelog.d/1448.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed issue where ``dayfirst`` behavior was not correctly applied when
+``yearfirst=True``. Previously, when ``yearfirst=True`` and ``dayfirst=True``,
+dates where the day component was greater than 12 (e.g. ``09/25/07``) would
+be incorrectly parsed as YMD instead of YDM. Reported and fixed by
+@algojogacor (gh issue #1448).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -549,7 +549,9 @@ class _ymd(list):
             else:
                 if (self[0] > 31 or
                     self.ystridx == 0 or
-                        (yearfirst and self[1] <= 12 and self[2] <= 31)):
+                        (yearfirst and (
+                            (not dayfirst and self[1] <= 12 and self[2] <= 31) or
+                            (dayfirst and self[1] <= 31 and self[2] <= 12)))):
                     # 99-01-01
                     if dayfirst and self[2] <= 12:
                         year, day, month = self

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -678,6 +678,24 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(parse(dtstr, yearfirst=True, dayfirst=True),
                          datetime(2009, 7, 1))
 
+    def testDayFirstYearFirst_day_gt_12(self):
+        # GH#1448: dayfirst with yearfirst should use YDM format
+        # even when day > 12
+        dtstr = '092507'
+        # Should be YYDDMM: year=09, day=25, month=07
+        self.assertEqual(parse(dtstr, yearfirst=True, dayfirst=True),
+                         datetime(2009, 7, 25))
+
+        # Also test with 4-digit year
+        dtstr = '2009 25 07'
+        self.assertEqual(parse(dtstr, yearfirst=True, dayfirst=True),
+                         datetime(2009, 7, 25))
+
+        # And with slashes
+        dtstr = '09/25/07'
+        self.assertEqual(parse(dtstr, yearfirst=True, dayfirst=True),
+                         datetime(2009, 7, 25))
+
     def testUnambiguousYearFirst(self):
         dtstr = '2015 09 25'
         self.assertEqual(parse(dtstr, yearfirst=True),


### PR DESCRIPTION
## Summary

Fixes #1448: The `dayfirst` parameter was not properly honored when `yearfirst=True`.

## Bug Description

When both `yearfirst=True` and `dayfirst=True`, the documentation states that the parser should distinguish between YDM and YMD formats. However, the implementation at `resolve_ymd()` had a condition that checked if the middle element was `<= 12` (treating it as a potential month), but when `dayfirst=True`, the middle element is the **day** — not the month. For day values > 12, this condition failed and the parser fell back to non-yearfirst MDY logic.

### Example

```python
from dateutil.parser import parse

# Bug: returns datetime(2007, 9, 25) instead of expected datetime(2009, 7, 25)
parse("092507", yearfirst=True, dayfirst=True)
```

## Fix

Changed the condition to check `self[1] <= 31 and self[2] <= 12` when `dayfirst=True`, instead of `self[1] <= 12 and self[2] <= 31`.

## Changes

- **`src/dateutil/parser/_parser.py`**: Updated condition in `resolve_ymd()` to properly handle dayfirst when yearfirst is True
- **`tests/test_parser.py`**: Added test cases for yearfirst+dayfirst with day > 12
- **`changelog.d/1448.bugfix.rst`**: Changelog entry