### PR TITLE
Parse compact millisecond time tokens after dates

### DIFF
--- a/changelog.d/1493.bugfix.rst
+++ b/changelog.d/1493.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed parsing of compact ``HHMMSSfff`` time tokens that follow a complete date.
+Reported by @HydrogenDeuterium (gh issue #1442). Fixed by @Mirochill
+(gh pr #1493).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -902,7 +902,7 @@ class parser(object):
             res.hour = int(s[:2])
             res.minute = int(s[2:4])
             res.second = int(s[4:6])
-            res.microsecond = int(s[6:].ljust(6, '0')[:6])
+            res.microsecond = int(s[6:].ljust(6, "0")[:6])
 
         elif len_li == 6 or (len_li > 6 and tokens[idx].find('.') == 6):
             # YYMMDD or HHMMSS[.ss]

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -896,6 +896,14 @@ class parser(object):
             if len_li == 4:
                 res.minute = int(s[2:])
 
+        elif len(ymd) == 3 and len_li == 9 and res.hour is None:
+            # HHMMSSfff after a complete date, e.g. 20010203 040506789
+            s = tokens[idx]
+            res.hour = int(s[:2])
+            res.minute = int(s[2:4])
+            res.second = int(s[4:6])
+            res.microsecond = int(s[6:].ljust(6, '0')[:6])
+
         elif len_li == 6 or (len_li > 6 and tokens[idx].find('.') == 6):
             # YYMMDD or HHMMSS[.ss]
             s = tokens[idx]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,22 +2,24 @@
 from __future__ import unicode_literals
 
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
-from six import assertRaisesRegex, PY2
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+from six import PY2, assertRaisesRegex
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -619,7 +621,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -632,7 +634,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [("Mo", "Montag"),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -185,6 +185,11 @@ def test_parse_yearfirst(sep):
     assert result == expected
 
 
+def test_parse_compact_time_with_milliseconds():
+    result = parse("20010203 040506789")
+    assert result == datetime(2001, 2, 3, 4, 5, 6, 789000)
+
+
 @pytest.mark.parametrize('dstr,expected', [
     ("Thu Sep 25 10:36:28 BRST 2003", datetime(2003, 9, 25, 10, 36, 28)),
     ("1996.07.10 AD at 15:08:56 PDT", datetime(1996, 7, 10, 15, 8, 56)),


### PR DESCRIPTION
Fixes #1442.

## Summary
- recognize `HHMMSSfff` compact time tokens when they follow a complete date
- keep the existing compact date/time parsing rules unchanged for other token shapes
- add a regression test for `parse("20010203 040506789")`
- add the required towncrier bugfix fragment

## Validation
- Not run locally
- Awaiting remote CI signal on this PR.