### PR TITLE
Parse EXIF-style colon-separated dates

### DIFF
--- a/changelog.d/1494.bugfix.rst
+++ b/changelog.d/1494.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed parsing of EXIF-style ``YYYY:MM:DD HH:MM:SS`` date/time strings.
+Reported by @fizbin (gh issue #1446). Fixed by @Mirochill (gh pr #1494).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -935,9 +935,13 @@ class parser(object):
                 # already set?
                 self._assign_hms(res, value_repr, hms)
 
-        elif (len_li == 4 and idx + 4 < len_l and
-              tokens[idx + 1] == tokens[idx + 3] == ':' and
-              tokens[idx + 2].isdigit() and tokens[idx + 4].isdigit()):
+        elif (
+            len_li == 4
+            and idx + 4 < len_l
+            and tokens[idx + 1] == tokens[idx + 3] == ":"
+            and tokens[idx + 2].isdigit()
+            and tokens[idx + 4].isdigit()
+        ):
             # YYYY:MM:DD, e.g. the format used in EXIF metadata
             ymd.append(value_repr, 'Y')
             ymd.append(tokens[idx + 2])

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -943,7 +943,7 @@ class parser(object):
             and tokens[idx + 4].isdigit()
         ):
             # YYYY:MM:DD, e.g. the format used in EXIF metadata
-            ymd.append(value_repr, 'Y')
+            ymd.append(value_repr, "Y")
             ymd.append(tokens[idx + 2])
             ymd.append(tokens[idx + 4])
             idx += 4

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -935,6 +935,15 @@ class parser(object):
                 # already set?
                 self._assign_hms(res, value_repr, hms)
 
+        elif (len_li == 4 and idx + 4 < len_l and
+              tokens[idx + 1] == tokens[idx + 3] == ':' and
+              tokens[idx + 2].isdigit() and tokens[idx + 4].isdigit()):
+            # YYYY:MM:DD, e.g. the format used in EXIF metadata
+            ymd.append(value_repr, 'Y')
+            ymd.append(tokens[idx + 2])
+            ymd.append(tokens[idx + 4])
+            idx += 4
+
         elif idx + 2 < len_l and tokens[idx + 1] == ':':
             # HH:MM[:SS[.ss]]
             res.hour = int(value)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,22 +2,24 @@
 from __future__ import unicode_literals
 
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
-from six import assertRaisesRegex, PY2
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+from six import PY2, assertRaisesRegex
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -619,7 +621,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -632,7 +634,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [("Mo", "Montag"),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -185,6 +185,11 @@ def test_parse_yearfirst(sep):
     assert result == expected
 
 
+def test_parse_exif_datetime():
+    result = parse("2024:03:29 07:19:05")
+    assert result == datetime(2024, 3, 29, 7, 19, 5)
+
+
 @pytest.mark.parametrize('dstr,expected', [
     ("Thu Sep 25 10:36:28 BRST 2003", datetime(2003, 9, 25, 10, 36, 28)),
     ("1996.07.10 AD at 15:08:56 PDT", datetime(1996, 7, 10, 15, 8, 56)),


### PR DESCRIPTION
Fixes #1446.

## Summary
- recognize `YYYY:MM:DD` date prefixes before the generic `HH:MM[:SS]` path
- preserve the existing colon-based time parsing for actual time tokens
- add a regression test for `parse("2024:03:29 07:19:05")`
- add the required towncrier bugfix fragment

## Validation
- Not run locally
- Awaiting remote CI signal on this PR.