### PR TITLE
Reject zero rrule intervals

### DIFF
--- a/changelog.d/1495.bugfix.rst
+++ b/changelog.d/1495.bugfix.rst
@@ -1,0 +1,2 @@
+Prevented ``INTERVAL=0`` recurrence rules from entering an infinite loop.
+Reported by @jmbarbier (gh issue #1441). Fixed by @Mirochill (gh pr #1495)

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -445,6 +445,8 @@ class rrule(rrulebase):
         self._dtstart = dtstart
         self._tzinfo = dtstart.tzinfo
         self._freq = freq
+        if interval == 0:
+            raise ValueError("interval must not be 0")
         self._interval = interval
         self._count = count
 

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -45,6 +45,11 @@ class RRuleTest(unittest.TestCase):
         )
         self.assertEqual(str(rrulestr(rr_str)), rr_str)
 
+    def testStrZeroInterval(self):
+        with self.assertRaises(ValueError):
+            rrulestr("DTSTART:19970902T090000\n"
+                     "RRULE:FREQ=YEARLY;COUNT=3;INTERVAL=0")
+
     def testYearly(self):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,
@@ -70,6 +75,13 @@ class RRuleTest(unittest.TestCase):
                          [datetime(1997, 9, 2, 9, 0),
                           datetime(2097, 9, 2, 9, 0),
                           datetime(2197, 9, 2, 9, 0)])
+
+    def testZeroInterval(self):
+        with self.assertRaises(ValueError):
+            rrule(YEARLY,
+                  count=3,
+                  interval=0,
+                  dtstart=datetime(1997, 9, 2, 9, 0))
 
     def testYearlyByMonth(self):
         self.assertEqual(list(rrule(YEARLY,

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -47,8 +47,10 @@ class RRuleTest(unittest.TestCase):
 
     def testStrZeroInterval(self):
         with self.assertRaises(ValueError):
-            rrulestr("DTSTART:19970902T090000\n"
-                     "RRULE:FREQ=YEARLY;COUNT=3;INTERVAL=0")
+            rrulestr(
+                "DTSTART:19970902T090000\n"
+                "RRULE:FREQ=YEARLY;COUNT=3;INTERVAL=0"
+            )
 
     def testYearly(self):
         self.assertEqual(list(rrule(YEARLY,
@@ -78,10 +80,9 @@ class RRuleTest(unittest.TestCase):
 
     def testZeroInterval(self):
         with self.assertRaises(ValueError):
-            rrule(YEARLY,
-                  count=3,
-                  interval=0,
-                  dtstart=datetime(1997, 9, 2, 9, 0))
+            rrule(
+                YEARLY, count=3, interval=0, dtstart=datetime(1997, 9, 2, 9, 0)
+            )
 
     def testYearlyByMonth(self):
         self.assertEqual(list(rrule(YEARLY,


### PR DESCRIPTION
## Summary
- reject `INTERVAL=0` while constructing an `rrule`
- add regression coverage for both direct construction and `rrulestr()` parsing
- keep negative intervals untouched because the existing implementation still has code paths that explicitly account for them

Fixes #1441

## Validation
- Not run locally
- awaiting GitHub CI