### PR TITLE
Validate rrule interval types eagerly

### DIFF
--- a/changelog.d/1496.bugfix.rst
+++ b/changelog.d/1496.bugfix.rst
@@ -1,0 +1,3 @@
+Raised ``TypeError`` at construction time when ``rrule()`` receives a
+non-integer ``interval``. Reported by @owenhollands (gh issue #1438). Fixed by
+@Mirochill (gh pr #1496)

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -445,6 +445,8 @@ class rrule(rrulebase):
         self._dtstart = dtstart
         self._tzinfo = dtstart.tzinfo
         self._freq = freq
+        if not isinstance(interval, integer_types):
+            raise TypeError("interval must be an integer")
         self._interval = interval
         self._count = count
 

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -2303,6 +2303,9 @@ class RRuleTest(unittest.TestCase):
                              [datetime(1998, 1, 5, 9, 0),
                               datetime(2004, 1, 5, 9, 0)])
 
+    def testNonIntegerInterval(self):
+        self.assertRaises(TypeError, rrule, WEEKLY, interval="1")
+
     def testHourlyBadRRule(self):
         """
         When `byhour` is specified with `freq=HOURLY`, there are certain


### PR DESCRIPTION
## Summary
- reject non-integer `rrule(interval=...)` values at construction time
- add a regression covering `interval=1`

## Why
`rrule()` currently accepts values such as `interval=1`, but they only fail later when the rule is iterated. That can move the error far away from the bad input and make the failure much harder to diagnose. This closes that gap by validating the interval eagerly.

Closes #1438.

## Validation
- Not run locally
- Awaiting remote CI from the repository.