### PR TITLE
Document zoneinfo setup before testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,4 +109,11 @@ This will pass the `-m tzstr` parameter to `pytest`, running only the tests with
 
 The tests can also be run directly by running `pytest` or `python -m pytest` in the root directory. This will be likely be less thorough but is often faster and is a good first pass to check your changes.
 
+If your checkout does not yet contain
+`src/dateutil/zoneinfo/dateutil-zoneinfo.tar.gz`, run
+`python updatezinfo.py` once from the repository root before running the test
+suite. This downloads the timezone data archive and rebuilds the bundled
+zoneinfo file used by the tests; the script requires the `zic` executable to be
+available on your `PATH`.
+
 All GitHub pull requests are automatically tested using [GitHub Actions](https://github.com/dateutil/dateutil/actions/) and [Appveyor](https://ci.appveyor.com/project/dateutil/dateutil).

--- a/changelog.d/1497.doc.rst
+++ b/changelog.d/1497.doc.rst
@@ -1,0 +1,3 @@
+Documented the one-time ``python updatezinfo.py`` setup step needed before
+running tests when the bundled zoneinfo archive is missing. Reported by
+@KingMob (gh issue #1395). Fixed by @Mirochill (gh pr #1497)


### PR DESCRIPTION
## Summary
- document the one-time `python updatezinfo.py` step needed when a checkout is missing the bundled zoneinfo archive
- note that the helper rebuilds the archive used by the tests and requires `zic` on `PATH`

## Why
A fresh checkout can fail before contributors reach the normal test workflow if `src/dateutil/zoneinfo/dateutil-zoneinfo.tar.gz` has not been generated yet. The contribution guide currently explains how to install dependencies and run tests, but not the prerequisite zoneinfo bootstrap step reported in #1395.

## Validation
- Not run locally
- I limited validation to static inspection of `updatezinfo.py`, `src/dateutil/zoneinfo/rebuild.py`, and the surrounding contributor documentation.