### PR TITLE
Document parser byte decoding behavior

### DIFF
--- a/changelog.d/1498.doc.rst
+++ b/changelog.d/1498.doc.rst
@@ -1,0 +1,3 @@
+Documented how byte inputs are decoded by the parser, including the
+``UnicodeDecodeError`` raised for invalid UTF-8. Reported by @pventuzelo
+(gh issue #1358). Fixed by @Mirochill (gh pr #1498).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -575,7 +575,8 @@ class parser(object):
         Parse the date/time string into a :class:`datetime.datetime` object.
 
         :param timestr:
-            Any date/time string using the supported formats.
+            Any date/time string using the supported formats. Bytes and
+            bytearray inputs are decoded as UTF-8 before parsing.
 
         :param default:
             The default datetime object, if this is a datetime object and not
@@ -627,6 +628,9 @@ class parser(object):
 
         :raises TypeError:
             Raised for non-string or character stream input.
+
+        :raises UnicodeDecodeError:
+            Raised when bytes or bytearray inputs cannot be decoded as UTF-8.
 
         :raises OverflowError:
             Raised if the parsed date exceeds the largest valid C integer on
@@ -1274,7 +1278,8 @@ def parse(timestr, parserinfo=None, **kwargs):
     ``parserinfo`` parameters.
 
     :param timestr:
-        A string containing a date/time stamp.
+        A string containing a date/time stamp. Bytes and bytearray inputs are
+        decoded as UTF-8 before parsing.
 
     :param parserinfo:
         A :class:`parserinfo` object containing parameters for the parser.
@@ -1357,6 +1362,9 @@ def parse(timestr, parserinfo=None, **kwargs):
         Raised for invalid or unknown string formats, if the provided
         :class:`tzinfo` is not in a valid format, or if an invalid date would
         be created.
+
+    :raises UnicodeDecodeError:
+        Raised when bytes or bytearray inputs cannot be decoded as UTF-8.
 
     :raises OverflowError:
         Raised if the parsed date exceeds the largest valid C integer on


### PR DESCRIPTION
## Summary
- clarify that `parse()` decodes `bytes` and `bytearray` inputs as UTF-8 before parsing
- document that invalid byte input can raise `UnicodeDecodeError`
- keep the public behavior unchanged while making the parser contract explicit

## Validation
- Not run locally
- static validation: `git diff --check`

Refs #1358