### PR TITLE
Exclude timeanddate.com from automated link checker

### DIFF
--- a/changelog.d/1499.misc.rst
+++ b/changelog.d/1499.misc.rst
@@ -1,0 +1,1 @@
+Skip link checking for timeanddate.com, which is currently giving a 403 for the bot, but working when run manually. (gh pr #1499)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -286,6 +286,8 @@ linkcheck_ignore = [
     r'https://pgp.mit.edu',
     # MetaCPAN frequently returns 402 for automated link checkers
     r"https://metacpan.org/.*",
+    # timeanddate.com is now returning 403 for the automated link checker
+    r"https://www\.timeanddate.com/.*",
 ]
 
 # Reduce problems with ephemeral failures


### PR DESCRIPTION
## Summary of changes

The link I'm seeing from timeanddate.com is giving us a 403, but when I check it manually it works. I'm guessing the issue is that it's showing up as a bot of some sort and timeanddate is trying to limit scraping.

### Pull Request Checklist
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
