### PR TITLE
Fix UTC/GMT offset sign parsing

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -61,6 +61,7 @@ switch, and thus all their contributions are dual-licensed.
 - Ionuț Ciocîrlan <jdxlark@MASKED>
 - Jacqueline Chen <jacqueline415@outlook.com> (gh: @jachen20) **D**
 - Jake Chorley (gh: @jakec-github) **D**
+- Jam Balaya (gh: @JamBalaya56562) **D**
 - Jakub Kulík (gh: @kulikjak) **D**
 - Jan Studený <jendas1@MASKED>
 - Jay Weisskopf <jay@jayschwa.net> (gh: @jayschwa) **D**

--- a/changelog.d/1478.bugfix.rst
+++ b/changelog.d/1478.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed sign inversion when parsing literal UTC/GMT offsets such as ``UTC-4`` or ``GMT+04:00`` (gh issue #1478).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -800,12 +800,13 @@ class parser(object):
                     # logic so that timezone parsing code will get it
                     # right.
                     if i + 1 < len_l and l[i + 1] in ('+', '-'):
-                        l[i + 1] = ('+', '-')[l[i + 1] == '+']
-                        res.tzoffset = None
                         if info.utczone(res.tzname):
-                            # With something like GMT+3, the timezone
-                            # is *not* GMT.
+                            # With something like UTC-4, the offset is literal.
                             res.tzname = None
+                            res.tzoffset = None
+                        else:
+                            l[i + 1] = ("+", "-")[l[i + 1] == "+"]
+                            res.tzoffset = None
 
                 # Check for a numbered timezone
                 elif res.hour is not None and l[i] in ('+', '-'):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,22 +2,24 @@
 from __future__ import unicode_literals
 
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
-from six import assertRaisesRegex, PY2
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+from six import PY2, assertRaisesRegex
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -221,6 +223,27 @@ def test_parse_with_tzoffset(dstr, expected):
     # In these cases, we are _not_ passing a tzinfos arg
     result = parse(dstr)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "dstr,expected_offset",
+    [
+        ("2026-03-11 14:32:45 UTC-4", -4 * 3600),
+        ("2026-03-11 14:32:45 UTC+4", 4 * 3600),
+        ("2026-03-11 14:32:45 UTC-04:00", -4 * 3600),
+        ("2026-03-11 14:32:45 UTC+04:00", 4 * 3600),
+        ("2026-03-11 14:32:45 GMT-5", -5 * 3600),
+        ("2026-03-11 14:32:45 GMT+5", 5 * 3600),
+    ],
+)
+def test_parse_utc_offset_sign(dstr, expected_offset):
+    result = parse(dstr)
+    assert result.utcoffset().total_seconds() == expected_offset
+
+
+def test_parse_named_zone_offset_inversion_preserved():
+    result = parse("2003-09-25 10:49:41 BRST+3")
+    assert result.utcoffset().total_seconds() == -3 * 3600
 
 
 class TestFormat(object):
@@ -614,7 +637,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -627,7 +650,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [("Mo", "Montag"),


### PR DESCRIPTION
## Summary of changes

This fixes sign handling for literal UTC/GMT offsets parsed by `dateutil.parser.parse()`.

Issue #1478 reports that inputs such as `2026-03-11 14:32:45 UTC-4` are currently parsed as `+04:00`, while `UTC+4` is parsed as `-04:00`. For UTC/GMT/Z-style zones, the trailing numeric offset should be interpreted literally, so this change skips the existing POSIX-style sign inversion for those zones while preserving it for non-UTC named zones such as `BRST+3`.

Vivarium reproduction: https://aletheia-works.github.io/vivarium/repro/dateutil/1478/

The current Vivarium reproduction does not yet verify that this branch fixes the issue, but that verification support has already been created in Vivarium: https://github.com/aletheia-works/vivarium/pull/266

Closes #1478

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
