### PR TITLE
Run tests in America/New_York

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -95,9 +95,13 @@ jobs:
       TOXENV: py
       PIP_TRUSTED_HOST: pypi.python.org
       SUDO: ${{ !matrix.use-container && 'sudo' || '' }}
+      TZ: ${{ !startsWith(matrix.os, 'windows-latest') && 'America/New_York' || null }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Set timezone (Windows)
+        if: startsWith(matrix.os, 'windows-latest')
+        run: tzutil /s "Eastern Standard Time"
       - if: ${{ !matrix.use-container }}
         name: Set up Python ${{ matrix.python-version }} on ${{ matrix.os }} (non-containers)
         uses: actions/setup-python@v5
@@ -125,15 +129,15 @@ jobs:
         run: |
           curl https://get.enterprisedb.com/postgresql/postgresql-9.5.21-2-windows-x64-binaries.zip --output $env:GITHUB_WORKSPACE\postgresql9.5.21.zip
           unzip -oq $env:GITHUB_WORKSPACE\postgresql9.5.21.zip -d .postgresql
-        if: runner.os == 'Windows'
+        if: startsWith(matrix.os, 'windows')
       - name: Run updatezinfo.py (Windows)
         run: |
           $env:Path += ";$env:GITHUB_WORKSPACE\.postgresql\pgsql\bin"
           ci_tools/retry.bat python updatezinfo.py
-        if: runner.os == 'Windows'
+        if: startsWith(matrix.os, 'windows')
       - name: Run updatezinfo.py (Unix)
         run: ./ci_tools/retry.sh python updatezinfo.py
-        if: runner.os != 'Windows'
+        if: "!startsWith(matrix.os, 'windows')"
       - name: Run tox
         run: python -m tox
       - name: Generate coverage.xml
@@ -156,11 +160,15 @@ jobs:
         toxenv: ["docs", "tz", "precommit"]
     env:
       TOXENV: ${{ matrix.toxenv }}
+      TZ: ${{ !startsWith(matrix.os, 'windows-latest') && 'America/New_York' || null }}
 
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Set timezone (Windows)
+        if: startsWith(matrix.os, 'windows-latest')
+        run: tzutil /s "Eastern Standard Time"
       - name: ${{ matrix.toxenv }}
         uses: actions/setup-python@v5
         with:

--- a/changelog.d/1501.misc.rst
+++ b/changelog.d/1501.misc.rst
@@ -1,0 +1,1 @@
+Adjust time zone property test so that it works properly in the face of ambiguous and imaginary times, and start running CI tests in America/New_York so that this actually comes up sometimes. (gh pr #1501)

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -1,33 +1,55 @@
+import sys
 from datetime import datetime, timedelta
 
 import pytest
-import six
-from hypothesis import assume, given
+from hypothesis import assume, example, given
 from hypothesis import strategies as st
 
-from dateutil import tz as tz
+from dateutil import tz
 
 EPOCHALYPSE = datetime.fromtimestamp(2147483647)
 NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
 
 
 @pytest.mark.gettz
-@pytest.mark.skipif(six.PY2, reason="Not supported on Python 2")
+@pytest.mark.skipif(
+    sys.version_info < (3, 6), reason="Not supported on Python 2"
+)
 @pytest.mark.parametrize("gettz_arg", [None, ""])
 # TODO: Remove bounds when GH #590 is resolved
 @given(
     dt=st.datetimes(
-        min_value=NEGATIVE_EPOCHALYPSE, max_value=EPOCHALYPSE, timezones=st.just(tz.UTC),
+        min_value=NEGATIVE_EPOCHALYPSE,
+        max_value=EPOCHALYPSE,
+        timezones=st.just(tz.UTC),
     )
 )
+@example(dt=datetime(2005, 10, 30, 1, 15))  # Ambiguous in US time zones
+@example(dt=datetime(1901, 12, 13, 18, 19, 3))  # Very old
 def test_gettz_returns_local(gettz_arg, dt):
     act_tz = tz.gettz(gettz_arg)
     if isinstance(act_tz, tz.tzlocal):
         return
 
-    dt_act = dt.astimezone(tz.gettz(gettz_arg))
+    dt_act = dt.astimezone(act_tz)
     dt_exp = dt.astimezone()
 
-    assert dt_act == dt_exp
+    assert dt_act.astimezone(tz.UTC) == dt_exp.astimezone(tz.UTC)
     assert dt_act.tzname() == dt_exp.tzname()
     assert dt_act.utcoffset() == dt_exp.utcoffset()
+
+    # According to PEP 495, if the value of fold would change the return value
+    # of utcoffset(), comparisons with the datetime always return false, so we
+    # must handle the case of ambiguous and imaginary datetimes here for the
+    # property to remain valid.
+    if (
+        tz.enfold(dt_act, fold=0).utcoffset()
+        == tz.enfold(dt_act, fold=1).utcoffset()
+    ):
+        assert dt_act == dt_exp
+    else:
+        assert (
+            tz.enfold(dt, fold=0).astimezone().utcoffset()
+            != tz.enfold(dt, fold=1).astimezone().utcoffset()
+        )
+        assert dt_act != dt_exp

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -1,33 +1,33 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from ._common import PicklableMixin
-from ._common import TZEnvContext, TZWinContext
-from ._common import ComparesEqual
 
-from datetime import datetime, timedelta
-from datetime import time as dt_time
-from datetime import tzinfo
-from six import PY2
-from io import BytesIO, StringIO
-import unittest
-
-import sys
 import base64
 import copy
 import gc
+import os
+import sys
+import unittest
 import weakref
-
+from datetime import datetime
+from datetime import time as dt_time
+from datetime import timedelta, tzinfo
 from functools import partial
+from io import BytesIO, StringIO
+
+from six import PY2
+
+from ._common import ComparesEqual, PicklableMixin, TZEnvContext, TZWinContext
 
 IS_WIN = sys.platform.startswith('win')
 
 import pytest
 
-# dateutil imports
-from dateutil.relativedelta import relativedelta, SU, TH
-from dateutil.parser import parse
 from dateutil import tz as tz
 from dateutil import zoneinfo
+from dateutil.parser import parse
+
+# dateutil imports
+from dateutil.relativedelta import SU, TH, relativedelta
 
 try:
     from dateutil import tzwin
@@ -1072,6 +1072,10 @@ class GettzTest(unittest.TestCase, TzFoldMixin):
 
         assert NYC1 is NYC2
 
+    @pytest.mark.xfail(
+        IS_WIN and ("/" in os.environ.get("TZ", "")),
+        reason="On Windows IANA zones are currently always singletons",
+    )
     def testGettzCacheTzLocal(self):
         local1 = tz.gettz()
         local2 = tz.gettz()

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
 [testenv]
 description = run the unit tests with pytest under {basepython}
 setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
-passenv = DATEUTIL_MAY_CHANGE_TZ, TOXENV, CI, APPVEYOR, APPVEYOR_*, CODECOV_*, SYSTEM_*, AGENT_*, BUILD_*, TF_BUILD
+passenv = DATEUTIL_MAY_CHANGE_TZ, TOXENV, CI, APPVEYOR, APPVEYOR_*, CODECOV_*, SYSTEM_*, AGENT_*, BUILD_*, TF_BUILD, TZ
 commands = python -m pytest {posargs: "{toxinidir}/tests" "{toxinidir}/docs" --cov-config="{toxinidir}/tox.ini" --cov=dateutil}
 deps = -rrequirements-dev.txt
 
@@ -86,11 +86,10 @@ commands =
 description = Run the tests against the master of the tz database
 basepython = python3.13
 deps = -r {toxinidir}/requirements-dev.txt
-# TODO: Remove the TZ = UTC requirement
 setenv =
     DATEUTIL_TZPATH = {envtmpdir}/tzdir/usr/share/zoneinfo
     TZDIR = {envtmpdir}/tzdir/usr/share/zoneinfo
-    TZ = UTC
+passenv = TZ
 changedir = {toxworkdir}
 allowlist_externals =
     {toxinidir}/ci_tools/run_tz_master_env.sh


### PR DESCRIPTION
## Summary of changes

This is a more interesting time zone than UTC because it has some folds and ambiguous times. Some of the tests have been tending to fail on local runs because the property tests don't work when there are folds and ambiguous times.

Ideally we would use a random time zone for each run or something, but for now America/New_York is better than UTC in terms of exercising edge cases.

### Pull Request Checklist
- [X] Changes have tests
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
