### PR TITLE
Document weekday constants

### DIFF
--- a/changelog.d/1502.doc.rst
+++ b/changelog.d/1502.doc.rst
@@ -1,0 +1,1 @@
+Document the weekday constants shared by the ``rrule`` and ``relativedelta`` APIs.

--- a/docs/relativedelta.rst
+++ b/docs/relativedelta.rst
@@ -5,6 +5,48 @@ relativedelta
    :members:
    :undoc-members:
 
+Weekday constants
+-----------------
+
+``dateutil.relativedelta`` provides weekday constants for all days of the week.
+They are named with the first two letters of the weekday:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Constant
+     - Weekday
+     - Integer value
+   * - ``MO``
+     - Monday
+     - ``0``
+   * - ``TU``
+     - Tuesday
+     - ``1``
+   * - ``WE``
+     - Wednesday
+     - ``2``
+   * - ``TH``
+     - Thursday
+     - ``3``
+   * - ``FR``
+     - Friday
+     - ``4``
+   * - ``SA``
+     - Saturday
+     - ``5``
+   * - ``SU``
+     - Sunday
+     - ``6``
+
+These constants can be passed to the ``weekday`` argument. They also support
+positional forms such as ``MO(+1)`` or ``FR(-1)`` for selecting the nth weekday
+relative to the date being adjusted.
+
+The ``dateutil.rrule`` module exposes constants with the same names, but they
+are separate weekday instances. Import the constants from the module whose API
+you are using.
+
 .. testsetup:: relativedelta
 
 Examples

--- a/docs/rrule.rst
+++ b/docs/rrule.rst
@@ -23,6 +23,49 @@ Functions
 .. autofunction:: rrulestr
 
 
+Weekday constants
+-----------------
+
+``dateutil.rrule`` provides weekday constants for all days of the week.
+They are named with the first two letters of the weekday:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Constant
+     - Weekday
+     - Integer value
+   * - ``MO``
+     - Monday
+     - ``0``
+   * - ``TU``
+     - Tuesday
+     - ``1``
+   * - ``WE``
+     - Wednesday
+     - ``2``
+   * - ``TH``
+     - Thursday
+     - ``3``
+   * - ``FR``
+     - Friday
+     - ``4``
+   * - ``SA``
+     - Saturday
+     - ``5``
+   * - ``SU``
+     - Sunday
+     - ``6``
+
+These constants may be used anywhere the ``rrule`` API accepts a weekday,
+including ``wkst`` and ``byweekday``. They also support positional forms such
+as ``MO(+1)`` or ``FR(-1)`` for rules that need the nth weekday in a period.
+
+The ``dateutil.relativedelta`` module exposes constants with the same names,
+but they are separate weekday instances. Import the constants from the module
+whose API you are using.
+
+
 rrule examples
 --------------
 These examples were converted from the RFC.


### PR DESCRIPTION
## Summary

- add explicit weekday constant tables to the rrule and relativedelta docs
- clarify that the constants map MO through SU to integer values 0 through 6
- note that rrule and relativedelta expose same-named but separate weekday instances

Closes #685

## Validation

- Not run locally
- Static validation only: `git diff --check` and `git diff --cached --check`.