### PR TITLE
Fix parser docs signature

### DIFF
--- a/changelog.d/1503.doc.rst
+++ b/changelog.d/1503.doc.rst
@@ -1,0 +1,1 @@
+Fix the parser documentation directive so the ``parse()`` signature includes ``timestr``.

--- a/docs/parser.rst
+++ b/docs/parser.rst
@@ -7,7 +7,7 @@ parser
 Functions
 ---------
 
-.. automethod:: dateutil.parser.parse
+.. autofunction:: dateutil.parser.parse
 
 .. automethod:: dateutil.parser.isoparse
 


### PR DESCRIPTION
## Summary

- switch the parser page directive for `dateutil.parser.parse` from `automethod` to `autofunction`
- keep the exported `parse(timestr, parserinfo=None, **kwargs)` signature from omitting `timestr` in generated docs
- add a towncrier documentation fragment

Closes #1120

## Validation

- Not run locally
- Static validation only: `git diff --check` and `git diff --cached --check`.