### PR TITLE
Validate week number against the actual number of ISO weeks in the year

### DIFF
--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -319,6 +319,15 @@ class isoparser(object):
         if not 0 < day < 8:     # Range is 1-7
             raise ValueError('Invalid weekday: {}'.format(day))
 
+        # Dec 28 is always in the last ISO week of the year
+        max_week = date(year, 12, 28).isocalendar()[1]
+        if week > max_week:
+            raise ValueError(
+                'Week {} is not valid for year {} (max week: {})'.format(
+                    week, year, max_week
+                )
+            )
+
         # Get week 1 for the specific year:
         jan_4 = date(year, 1, 4)   # Week 1 always has January 4th in it
         week_1 = jan_4 - timedelta(days=jan_4.isocalendar()[2] - 1)

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -260,6 +260,8 @@ def test_bytes(isostr, dt):
         ValueError),
     ('2012-W00', ValueError),                   # Invalid ISO week
     ('2012-W55', ValueError),                   # Invalid ISO week
+    ('2021-W53', ValueError),                   # Week 53 doesn't exist in 2021
+    ('2021-W53-1', ValueError),                 # Week 53 doesn't exist in 2021
     ('2012-W01-0', ValueError),                 # Invalid ISO week day
     ('2012-W01-8', ValueError),                 # Invalid ISO week day
     ('2013-000', ValueError),                   # Invalid ordinal day


### PR DESCRIPTION
Fixes #1236

## Problem

`isoparse("2021-W53-1")` silently returned `2022-01-03` instead of raising `ValueError`. Year 2021 only has 52 ISO weeks, so week 53 is invalid for that year.

The existing range check (`0 < week < 54`) only rejects values ≥ 54, but does not account for the fact that most years have only 52 weeks.

## Fix

After the range check, compute the actual maximum week for the year using the well-known identity: **December 28 is always in the last ISO week of the year**, so `date(year, 12, 28).isocalendar()[1]` gives the correct maximum week number. If the requested week exceeds that, raise `ValueError`.

```python
max_week = date(year, 12, 28).isocalendar()[1]
if week > max_week:
    raise ValueError(
        'Week {} is not valid for year {} (max week: {})'.format(week, year, max_week)
    )
```

This logic was suggested by @pganssle in the issue thread, and mirrors the validation in CPython's `datetime.fromisoformat`.

Years that genuinely have 53 weeks (e.g. 2004, 2009, 2015, 2020) are unaffected — existing test cases for those years continue to pass.

## Tests

Added two entries to the `test_iso_raises` parametrize list:
- `'2021-W53'` → `ValueError`
- `'2021-W53-1'` → `ValueError`