### PR TITLE
docs(parser): warn that non-datetime strings have undefined parse behaviour

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -577,6 +577,14 @@ class parser(object):
         :param timestr:
             Any date/time string using the supported formats.
 
+            .. warning::
+
+                Passing a string that does not represent a date or time has
+                **undefined behaviour** — the parser may return an arbitrary
+                result, raise :exc:`ParserError`, or silently produce an
+                incorrect date.  Only strings that actually represent a
+                date/time are guaranteed to be parsed correctly.
+
         :param default:
             The default datetime object, if this is a datetime object and not
             ``None``, elements specified in ``timestr`` replace elements in the


### PR DESCRIPTION
## Summary

Fixes #1270.

`parser.parse()` makes no guarantees about strings that don't represent a date/time — it may return something, raise `ParserError`, or silently produce a wrong date. This was only implicit in the docs.

Add a `.. warning::` admonition directly on the `timestr` parameter so users see this at a glance.