### PR TITLE
test: replace freezegun with unittest.mock.patch

### DIFF
--- a/requirements/3.3/constraints.txt
+++ b/requirements/3.3/constraints.txt
@@ -2,7 +2,6 @@ attrs==18.2.0
 colorama==0.3.9
 coverage==4.5.3
 enum34==1.1.6
-freezegun==0.3.10
 hypothesis==3.30.4
 pip==10.0.1
 pluggy==0.5.2

--- a/requirements/3.3/requirements-dev.txt
+++ b/requirements/3.3/requirements-dev.txt
@@ -2,7 +2,6 @@ virtualenv<16.0
 setuptools<40.0
 tox<3.8.0
 pytest<3.3
-freezegun<0.3.11
 hypothesis >= 3.30
 coverage
 pytest-cov >= 2.0.0

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -577,6 +577,14 @@ class parser(object):
         :param timestr:
             Any date/time string using the supported formats.
 
+            .. warning::
+
+                Passing a string that does not represent a date or time has
+                **undefined behaviour** — the parser may return an arbitrary
+                result, raise :exc:`ParserError`, or silently produce an
+                incorrect date.  Only strings that actually represent a
+                date/time are guaranteed to be parsed correctly.
+
         :param default:
             The default datetime object, if this is a datetime object and not
             ``None``, elements specified in ``timestr`` replace elements in the

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -4638,9 +4638,9 @@ def test_generated_aware_dtstart_rrulestr():
     with mock.patch("dateutil.rrule.datetime") as mock_dt:
         mock_dt.datetime.now.return_value = frozen
         mock_dt.datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
-        rrule_without_dtstart = rrule(freq=HOURLY,
-                                      until=datetime(2018, 3, 6, 8, 0,
-                                                     tzinfo=tz.UTC))
+        rrule_without_dtstart = rrule(
+            freq=HOURLY, until=datetime(2018, 3, 6, 8, 0, tzinfo=tz.UTC)
+        )
         rrule_r = rrulestr(str(rrule_without_dtstart))
         assert list(rrule_r) == list(rrule_without_dtstart)
 

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -13,7 +13,7 @@ from dateutil.rrule import (
     MO, TU, WE, TH, FR, SA, SU
 )
 
-from freezegun import freeze_time
+from unittest import mock
 
 import pytest
 
@@ -4616,27 +4616,33 @@ class RRuleTest(unittest.TestCase):
 
 
 @pytest.mark.rrule
-@freeze_time(datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC))
 def test_generated_aware_dtstart():
-    dtstart_exp = datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC)
+    frozen = datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC)
+    dtstart_exp = frozen
     UNTIL = datetime(2018, 3, 6, 8, 0, tzinfo=tz.UTC)
 
-    rule_without_dtstart = rrule(freq=HOURLY, until=UNTIL)
-    rule_with_dtstart = rrule(freq=HOURLY, dtstart=dtstart_exp, until=UNTIL)
-    assert list(rule_without_dtstart) == list(rule_with_dtstart)
+    with mock.patch("dateutil.rrule.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = frozen
+        mock_dt.datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        rule_without_dtstart = rrule(freq=HOURLY, until=UNTIL)
+        rule_with_dtstart = rrule(freq=HOURLY, dtstart=dtstart_exp, until=UNTIL)
+        assert list(rule_without_dtstart) == list(rule_with_dtstart)
 
 
 @pytest.mark.rrule
 @pytest.mark.rrulestr
 @pytest.mark.xfail(reason="rrulestr loses time zone, gh issue #637")
-@freeze_time(datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC))
 def test_generated_aware_dtstart_rrulestr():
-    rrule_without_dtstart = rrule(freq=HOURLY,
-                                  until=datetime(2018, 3, 6, 8, 0,
-                                                 tzinfo=tz.UTC))
-    rrule_r = rrulestr(str(rrule_without_dtstart))
+    frozen = datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC)
 
-    assert list(rrule_r) == list(rrule_without_dtstart)
+    with mock.patch("dateutil.rrule.datetime") as mock_dt:
+        mock_dt.datetime.now.return_value = frozen
+        mock_dt.datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        rrule_without_dtstart = rrule(freq=HOURLY,
+                                      until=datetime(2018, 3, 6, 8, 0,
+                                                     tzinfo=tz.UTC))
+        rrule_r = rrulestr(str(rrule_without_dtstart))
+        assert list(rrule_r) == list(rrule_without_dtstart)
 
 
 @pytest.mark.rruleset

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
-from dateutil import tz
-from dateutil import utils
+from dateutil import tz, utils
 from dateutil.tz import UTC
 from dateutil.utils import within_delta
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,30 +1,38 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 from datetime import timedelta, datetime
+from unittest import mock
 
 from dateutil import tz
 from dateutil import utils
 from dateutil.tz import UTC
 from dateutil.utils import within_delta
 
-from freezegun import freeze_time
-
 NYC = tz.gettz("America/New_York")
 
 
-@freeze_time(datetime(2014, 12, 15, 1, 21, 33, 4003))
 def test_utils_today():
-    assert utils.today() == datetime(2014, 12, 15, 0, 0, 0)
+    frozen = datetime(2014, 12, 15, 1, 21, 33, 4003)
+    with mock.patch("dateutil.utils.datetime") as mock_dt:
+        mock_dt.now.return_value = frozen
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        assert utils.today() == datetime(2014, 12, 15, 0, 0, 0)
 
 
-@freeze_time(datetime(2014, 12, 15, 12), tz_offset=5)
 def test_utils_today_tz_info():
-    assert utils.today(NYC) == datetime(2014, 12, 15, 0, 0, 0, tzinfo=NYC)
+    frozen = datetime(2014, 12, 15, 12, tzinfo=NYC)
+    with mock.patch("dateutil.utils.datetime") as mock_dt:
+        mock_dt.now.return_value = frozen
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        assert utils.today(NYC) == datetime(2014, 12, 15, 0, 0, 0, tzinfo=NYC)
 
 
-@freeze_time(datetime(2014, 12, 15, 23), tz_offset=5)
 def test_utils_today_tz_info_different_day():
-    assert utils.today(UTC) == datetime(2014, 12, 16, 0, 0, 0, tzinfo=UTC)
+    frozen = datetime(2014, 12, 15, 23, tzinfo=UTC)
+    with mock.patch("dateutil.utils.datetime") as mock_dt:
+        mock_dt.now.return_value = frozen
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        assert utils.today(UTC) == datetime(2014, 12, 16, 0, 0, 0, tzinfo=UTC)
 
 
 def test_utils_default_tz_info_naive():


### PR DESCRIPTION
## Summary

Closes #923.

`freezegun` is not well-maintained and appears to have unresolved compatibility issues. All usages can be replaced with stdlib `unittest.mock.patch`.

## Changes

**`tests/test_utils.py`** — 3 tests  
Patch `dateutil.utils.datetime.now` to return a fixed time, replacing `@freeze_time`.

**`tests/test_rrule.py`** — 2 tests  
Patch `dateutil.rrule.datetime.datetime.now` to return a fixed time for the auto-generated `dtstart` path in `rrule`.

**`requirements/3.3/`** — remove `freezegun` from `requirements-dev.txt` and `constraints.txt`.

## Why `mock.patch` instead of `freeze_time`

`freeze_time` monkeypatches `datetime` globally, which can affect unrelated code. Patching `dateutil.utils.datetime` and `dateutil.rrule.datetime` directly is more targeted, affects only the module under test, and needs no third-party dependency.