### PR TITLE
fix: fuzzy_with_tokens does not return unused numerical tokens

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -873,6 +873,12 @@ class parser(object):
             return res, None
 
     def _parse_numeric_token(self, tokens, idx, info, ymd, res, fuzzy):
+        if fuzzy:
+            # Store unused numerical tokens in skipped_tokens
+            skipped_tokens = getattr(self, 'skipped_tokens', None)
+            if skipped_tokens is None:
+                skipped_tokens = self.skipped_tokens = []
+            skipped_tokens.append(tokens[idx])
         # Token is a number
         value_repr = tokens[idx]
         try:


### PR DESCRIPTION
Closes #1063

## Summary of changes

This PR fixes an issue where `fuzzy_with_tokens` was not returning unused numerical tokens. The problem arose in two cases: when `_parse_numeric_token` exited without using a token, and when parsing strings with multiple times, where previous times were overwritten without being added to the token list.

### Pull Request Checklist
- [X] Changes have tests
- [X] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [X] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details

Closes #1521