### PR TITLE
Preserve fractional day and time fields in relativedelta multiplication

### DIFF
--- a/changelog.d/1318.bugfix.rst
+++ b/changelog.d/1318.bugfix.rst
@@ -1,0 +1,4 @@
+``relativedelta`` multiplication no longer truncates the fractional part of the
+``days``, ``hours``, ``minutes``, ``seconds`` and ``microseconds`` fields, so for
+example ``relativedelta(days=1.5) * 1`` correctly stays ``days=1.5`` instead of
+becoming ``days=1``. ``years`` and ``months`` remain integral, as before.

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -498,22 +498,24 @@ class relativedelta(object):
         except TypeError:
             return NotImplemented
 
-        return self.__class__(years=int(self.years * f),
-                             months=int(self.months * f),
-                             days=int(self.days * f),
-                             hours=int(self.hours * f),
-                             minutes=int(self.minutes * f),
-                             seconds=int(self.seconds * f),
-                             microseconds=int(self.microseconds * f),
-                             leapdays=self.leapdays,
-                             year=self.year,
-                             month=self.month,
-                             day=self.day,
-                             weekday=self.weekday,
-                             hour=self.hour,
-                             minute=self.minute,
-                             second=self.second,
-                             microsecond=self.microsecond)
+        return self.__class__(
+            years=int(self.years * f),
+            months=int(self.months * f),
+            days=self.days * f,
+            hours=self.hours * f,
+            minutes=self.minutes * f,
+            seconds=self.seconds * f,
+            microseconds=self.microseconds * f,
+            leapdays=self.leapdays,
+            year=self.year,
+            month=self.month,
+            day=self.day,
+            weekday=self.weekday,
+            hour=self.hour,
+            minute=self.minute,
+            second=self.second,
+            microsecond=self.microsecond,
+        )
 
     __rmul__ = __mul__
 

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -274,6 +274,25 @@ class RelativeDeltaTest(unittest.TestCase):
         self.assertEqual(datetime(2000, 1, 1) + 28 * relativedelta(days=1),
                          datetime(2000, 1, 29))
 
+    def testMultiplicationFractional(self):
+        # GH issue #1318: multiplication used to truncate the fractional part of
+        # the day and time fields (e.g. relativedelta(days=1.5) * 1 -> days=1).
+        self.assertEqual(relativedelta(days=1.5) * 1, relativedelta(days=1.5))
+        self.assertEqual(relativedelta(hours=1.5) * 1, relativedelta(hours=1.5))
+        self.assertEqual(
+            relativedelta(days=1, hours=6) * 0.5,
+            relativedelta(days=0.5, hours=3),
+        )
+        self.assertEqual(
+            datetime(2000, 1, 1) + relativedelta(days=1.5) * 1,
+            datetime(2000, 1, 2, 12, 0),
+        )
+        # years and months must stay integral, so they are still coerced to int.
+        self.assertEqual(
+            relativedelta(years=2, months=2) * 1.5,
+            relativedelta(years=3, months=3),
+        )
+
     def testMultiplicationUnsupportedType(self):
         self.assertIs(relativedelta(days=1) * NotAValue, NotAValue)
 


### PR DESCRIPTION
Fixes #1318

`relativedelta.__mul__` coerced every field with `int()`, so multiplying a `relativedelta` that has a fractional day or time component silently truncated it:

```python
>>> relativedelta(days=1.5) * 1
relativedelta(days=+1)   # the half day is lost
```

The constructor already supports fractional `days`, `hours`, `minutes`, `seconds` and `microseconds` (only `years` and `months` are required to be integers), so multiplication should preserve those fractions. This drops the `int()` coercion for those five fields while keeping `years`/`months` integral:

```python
>>> relativedelta(days=1.5) * 1
relativedelta(days=+1.5)
```

Added a regression test (`testMultiplicationFractional`) covering fractional days/time, the integral `years`/`months` behavior, and a datetime round-trip, plus a changelog entry. The full `relativedelta` test suite still passes.
