### PR TITLE
Add parser regression test for illegal month

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -55,6 +55,7 @@ switch, and thus all their contributions are dual-licensed.
 - Gökçen Nurlu <gnurlu1@bloomberg.net> (gh: @gokcennurlu) **D**
 - Grant Garrett-Grossman <grantlycee@gmail.com> (gh: @FakeNameSE) **D**
 - Gustavo Niemeyer <gustavo@niemeyer.net> (gh: @niemeyer)
+- Hongkuan Lin (gh: @lin-hongkuan) **D**
 - Holger Joukl <holger.joukl@MASKED> (gh: @hjoukl)
 - Hugo van Kemenade (gh: @hugovk) **D**
 - Igor <mrigor83@MASKED>

--- a/changelog.d/1108.bugfix.rst
+++ b/changelog.d/1108.bugfix.rst
@@ -1,0 +1,2 @@
+Added regression coverage to ensure parsing ``19/040400`` raises
+``ParserError`` instead of leaking a lower-level exception.

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -118,12 +118,15 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset)
 
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
-@pytest.mark.parametrize('dt', tuple(DATETIMES))
-@pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
-@pytest.mark.parametrize('tzoffset', TZOFFSETS)
-@pytest.mark.parametrize('precision', list(range(3, 7)))
+
+
+@pytest.mark.parametrize("dt", tuple(DATETIMES))
+@pytest.mark.parametrize("date_fmt", YMD_FMTS)
+@pytest.mark.parametrize(
+    "time_fmt", tuple(x + sep + "%f" for x in HMS_FMTS for sep in ".,")
+)
+@pytest.mark.parametrize("tzoffset", TZOFFSETS)
+@pytest.mark.parametrize("precision", list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
     # Truncate the microseconds to the desired precision for the representation
     dt = dt.replace(microsecond=int(round(dt.microsecond, precision-6)))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -748,6 +748,10 @@ class TestOutOfBounds(object):
         with pytest.raises(ParserError):
             parse("0-100")
 
+    def test_illegal_month_error_with_large_dayfirst_candidate(self):
+        with pytest.raises(ParserError):
+            parse("19/040400")
+
     def test_day_sanity(self, fuzzy):
         dstr = "2014-15-25"
         with pytest.raises(ParserError):


### PR DESCRIPTION
## Summary of changes

Add regression coverage for the invalid parser input from #1108. Current `master` correctly raises `ParserError` for `parse("19/040400")`; this test locks in that behavior so a lower-level exception does not leak again.

Closes #1108

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details

Validation run locally:

- `PYTHONPATH=src python -m pytest tests/test_parser.py::TestOutOfBounds::test_illegal_month_error_with_large_dayfirst_candidate tests/test_parser.py::TestOutOfBounds` - 12 passed
- `PYTHONPATH=src python -m pytest tests/test_parser.py` - 228 passed, 3 skipped, 14 xfailed, 1 unrelated failure because the source checkout is missing `src/dateutil/zoneinfo/dateutil-zoneinfo.tar.gz` for `test_parse_tzinfos_fold`