### PR TITLE
Reject out-of-range timezone offsets in parser.parse() (fixes #1508)

### DIFF
--- a/changelog.d/1508.bugfix.rst
+++ b/changelog.d/1508.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``parser.parse()`` silently accepting out-of-range timezone offsets
+(minutes ``>= 60`` or a total offset ``>= 24`` hours, e.g. ``+0060`` or
+``+2400``), which produced incorrect or unusable ("toxic") datetimes. These
+inputs are now rejected, consistent with ``isoparse()``.
+Reported and fixed by @vineethsaivs (gh issue #1508).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -829,6 +829,12 @@ class parser(object):
                     else:
                         raise ValueError(timestr)
 
+                    if hour_offset > 23 or min_offset > 59:
+                        # Reject out-of-range offsets (e.g. +0060, +2400) so they
+                        # fail like isoparse() instead of silently producing a
+                        # wrong or unusable ("toxic") tzoffset.
+                        raise ValueError(timestr)
+
                     res.tzoffset = signal * (hour_offset * 3600 + min_offset * 60)
 
                     # Look for a timezone name between parenthesis

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,22 +2,24 @@
 from __future__ import unicode_literals
 
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
-from six import assertRaisesRegex, PY2
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+from six import PY2, assertRaisesRegex
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -221,6 +223,39 @@ def test_parse_with_tzoffset(dstr, expected):
     # In these cases, we are _not_ passing a tzinfos arg
     result = parse(dstr)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "dstr",
+    [
+        "2024-01-15T12:00:00+0060",  # minutes >= 60
+        "2024-01-15T12:00:00+0099",
+        "2024-01-15T12:00:00+05:60",  # minutes >= 60, with colon
+        "2024-01-15T12:00:00+2400",  # total offset >= 24h
+        "2024-01-15T12:00:00+9900",
+    ],
+)
+def test_parse_rejects_out_of_range_tzoffset(dstr):
+    # Out-of-range offsets must be rejected like isoparse(), rather than silently
+    # producing a wrong or unusable ("toxic") tzoffset. See GH #1508.
+    with pytest.raises(ParserError):
+        parse(dstr)
+
+
+@pytest.mark.parametrize(
+    "dstr,expected_offset",
+    [
+        ("2024-01-15T12:00:00+0000", 0),
+        (
+            "2024-01-15T12:00:00+2359",
+            23 * 3600 + 59 * 60,
+        ),  # largest valid offset
+        ("2024-01-15T12:00:00+05:45", 5 * 3600 + 45 * 60),
+    ],
+)
+def test_parse_accepts_boundary_tzoffset(dstr, expected_offset):
+    # Valid boundary offsets must still parse.
+    assert parse(dstr).utcoffset().total_seconds() == expected_offset
 
 
 class TestFormat(object):
@@ -614,7 +649,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -627,7 +662,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [("Mo", "Montag"),


### PR DESCRIPTION
## Summary

Fixes #1508.

`parser.parse()` silently accepts timezone offsets whose minutes component is `>= 60`, or whose total offset is `>= 24` hours, producing a wrong offset or a "toxic" datetime (parses fine, then raises `ValueError` on every later method call). This is inconsistent with `isoparse()` and stdlib `datetime.fromisoformat()`, which reject them.

```python
>>> from dateutil.parser import parse
>>> parse("2024-01-15T12:00:00+0060").isoformat()
'2024-01-15T12:00:00+01:00'          # wrong: input said +00:60
>>> parse("2024-01-15T12:00:00+2400") # parses, but is unusable
>>> _.isoformat()
ValueError: offset must be strictly between -24h and +24h
```

## Fix

In `_parser.py`, after extracting `hour_offset` / `min_offset` for a numeric timezone, reject the offset when `hour_offset > 23` or `min_offset > 59` (raising `ValueError`, which `_parse` already funnels into a `ParserError`, exactly like the adjacent malformed-offset branch). `isoparser.py` already performs the equivalent checks.

## Tests

`test_parse_rejects_out_of_range_tzoffset` (`+0060`, `+0099`, `+05:60`, `+2400`, `+9900`) and `test_parse_accepts_boundary_tzoffset` (`+0000`, `+2359`, `+05:45`). The reject cases fail on `master` and pass with this change; the full `tests/test_parser.py` suite passes (239 passed, 14 xfailed) with no regressions. Added a `changelog.d` fragment.
