### PR TITLE
Fix TypeError for bare GMT/UTC in tzstr (#1402)

### DIFF
--- a/changelog.d/1402.bugfix.rst
+++ b/changelog.d/1402.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a ``TypeError`` raised when constructing a ``tz.tzstr`` from a bare ``GMT`` or ``UTC`` string (which carries no explicit offset). These now behave like UTC (offset 0), consistent with other bare abbreviations such as ``EST``. Reported by @gabe-sherman (gh issue #1402). Fixed by @apoorvdarshan (gh pr #1530).

--- a/src/dateutil/tz/tz.py
+++ b/src/dateutil/tz/tz.py
@@ -1089,7 +1089,10 @@ class tzstr(tzrange):
         # Here we break the compatibility with the TZ variable handling.
         # GMT-3 actually *means* the timezone -3.
         if res.stdabbr in ("GMT", "UTC") and not posix_offset:
-            res.stdoffset *= -1
+            # A bare "GMT"/"UTC" has no explicit offset (stdoffset is None), so
+            # treat it as 0 like any other abbreviation rather than raising a
+            # TypeError from ``None *= -1`` (GH #1402).
+            res.stdoffset = -res.stdoffset if res.stdoffset is not None else 0
 
         # We must initialize it first, since _delta() needs
         # _std_offset and _dst_offset set. Use False in start/end

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -1436,6 +1436,24 @@ class TZStrTest(unittest.TestCase, TzFoldMixin):
         self.assertEqual(datetime(2003, 4, 6, 2, 00,
                                   tzinfo=tz.tzstr(str("EST5EDT"))).tzname(), "EDT")
 
+    def testStrGMTUTCWithoutOffset(self):
+        # A bare "GMT"/"UTC" has no explicit offset and used to raise a
+        # TypeError (``None *= -1``); it should behave like UTC (offset 0),
+        # as other bare abbreviations already do. See GH #1402.
+        for name in ("GMT", "UTC", "GMT,4;3/4"):
+            dt = datetime(2020, 6, 1, 12, 0, tzinfo=tz.tzstr(name))
+            self.assertEqual(dt.utcoffset(), timedelta(0))
+
+        # Explicit offsets are unaffected: GMT-3 still means the -3 timezone.
+        self.assertEqual(
+            datetime(2020, 6, 1, tzinfo=tz.tzstr("GMT-3")).utcoffset(),
+            timedelta(hours=-3),
+        )
+        self.assertEqual(
+            datetime(2020, 6, 1, tzinfo=tz.tzstr("GMT+3")).utcoffset(),
+            timedelta(hours=3),
+        )
+
     def testStrInequality(self):
         TZS1 = tz.tzstr('EST5EDT4')
 


### PR DESCRIPTION
Fixes #1402.

## Problem

`tz.tzstr("GMT")` and `tz.tzstr("UTC")` raise a `TypeError`:

```python
>>> from dateutil.tz import tzstr
>>> tzstr("GMT")
TypeError: unsupported operand type(s) for *=: 'NoneType' and 'int'
>>> tzstr("UTC")
TypeError: ...
>>> tzstr("EST")      # every other bare abbreviation works fine
tzstr('EST')
```

A bare `GMT`/`UTC` has no explicit offset, so `parser._parsetz` returns a result with `stdoffset is None`. The GMT/UTC-specific negation then does `None *= -1`:

```python
if res.stdabbr in ("GMT", "UTC") and not posix_offset:
    res.stdoffset *= -1
```

This went unnoticed because `gettz("GMT")`/`gettz("UTC")` resolve via the system zoneinfo *file*, never touching `tzstr`. The reported `gettz("GMT,4;3/4")` crash (#1402) is the same root cause — that string parses identically to a bare `"GMT"`.

## Fix

Treat GMT/UTC without an explicit offset as `0` (like other bare abbreviations, e.g. `tzstr("EST")` is already offset 0), so they resolve to UTC instead of crashing:

```python
res.stdoffset = -res.stdoffset if res.stdoffset is not None else 0
```

Explicit offsets are unchanged — `GMT-3` still means the `-3` timezone, `GMT+3` the `+3`.

```python
>>> tzstr("GMT")            # offset 0
>>> tzstr("UTC")            # offset 0
>>> gettz("GMT,4;3/4")      # no longer raises
>>> tzstr("GMT-3")          # unchanged: -3
```

## Testing

- Added `TZStrTest.testStrGMTUTCWithoutOffset` (bare `GMT`/`UTC`/`GMT,4;3/4` → offset 0; `GMT-3`/`GMT+3` unchanged). It raises `TypeError` on `main` and passes with this change.
- `tests/test_tz.py` and `tests/test_parser.py`: the failure set is identical with and without this change (the pre-existing failures in this environment are `zoneinfo` I/O `UserWarning`s turned into errors by `filterwarnings=error`, unrelated to this change); the parser suite is fully green (232 passed). My new test passes.
- `flake8` introduces no new findings on the changed lines. Added a `changelog.d/1402.bugfix.rst` fragment.

---

*Disclosure: this change was prepared with the assistance of an AI tool (Claude Code). I reproduced the issue, implemented and verified the fix and tests, ran the suites and linter, and take responsibility for the contribution and will respond to review feedback personally.*
