### PR TITLE
Raise ParserError instead of leaking decimal.InvalidOperation (fixes #1359, #1366)

### DIFF
--- a/changelog.d/1366.bugfix.rst
+++ b/changelog.d/1366.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``parser.parse()`` leaking a ``decimal.InvalidOperation`` exception
+instead of a ``ParserError`` when given a numeric token with more digits than
+the active decimal context precision (e.g. an over-long hour, minute, or
+second field). Such inputs are now rejected as a ``ParserError``. Reported by
+@pventuzelo and @senier (gh issues #1359, #1366).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -1145,6 +1145,13 @@ class parser(object):
             #  via `_to_decimal`
             if not decimal_value.is_finite():
                 raise ValueError("Converted decimal value is infinite or NaN")
+            # See GH 1359 and GH 1366: a value with more digits than the active
+            # decimal context precision constructs fine but raises
+            # decimal.InvalidOperation on later arithmetic such as ``value % 1``.
+            # Probe that operation here so an over-large numeric token is
+            # reported as a ValueError (and ultimately a ParserError) instead of
+            # leaking an ArithmeticError out of parse().
+            decimal_value % 1
         except Exception as e:
             msg = "Could not convert %s to decimal" % val
             six.raise_from(ValueError(msg), e)

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -118,15 +118,18 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset)
 
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
-@pytest.mark.parametrize('dt', tuple(DATETIMES))
-@pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
-@pytest.mark.parametrize('tzoffset', TZOFFSETS)
-@pytest.mark.parametrize('precision', list(range(3, 7)))
+
+
+@pytest.mark.parametrize("dt", tuple(DATETIMES))
+@pytest.mark.parametrize("date_fmt", YMD_FMTS)
+@pytest.mark.parametrize(
+    "time_fmt", [x + sep + "%f" for x in HMS_FMTS for sep in ".,"]
+)
+@pytest.mark.parametrize("tzoffset", TZOFFSETS)
+@pytest.mark.parametrize("precision", list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
     # Truncate the microseconds to the desired precision for the representation
-    dt = dt.replace(microsecond=int(round(dt.microsecond, precision-6)))
+    dt = dt.replace(microsecond=int(round(dt.microsecond, precision - 6)))
 
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset, precision)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -954,6 +954,24 @@ def test_decimal_error(value):
     with pytest.raises(ParserError):
         parse(value)
 
+
+@pytest.mark.parametrize('value', [
+    # GH 1366 - over-long numeric token in an HMS field
+    '19970902090807197090209080710h',
+    # GH 1359 - over-long numeric token in a colon-separated minute field
+    '12:99999999999999999999999999999999999',
+    b'9999999999999999999999999999999999999999939999999999999999999999999999'
+    b':99999999999999999999999999999',
+])
+def test_decimal_invalid_operation_error(value):
+    # GH 1359, GH 1366 - a numeric token with more digits than the decimal
+    # context precision constructs as a Decimal but raises
+    # decimal.InvalidOperation on later arithmetic (e.g. ``value % 1``). That
+    # ArithmeticError leaked out of parse() instead of being reported as a
+    # ParserError. Ensure it is now surfaced consistently.
+    with pytest.raises(ParserError):
+        parse(value)
+
 def test_parsererror_repr():
     # GH 991 — the __repr__ was not properly indented and so was never defined.
     # This tests the current behavior of the ParserError __repr__, but the

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -955,14 +955,17 @@ def test_decimal_error(value):
         parse(value)
 
 
-@pytest.mark.parametrize('value', [
-    # GH 1366 - over-long numeric token in an HMS field
-    '19970902090807197090209080710h',
-    # GH 1359 - over-long numeric token in a colon-separated minute field
-    '12:99999999999999999999999999999999999',
-    b'9999999999999999999999999999999999999999939999999999999999999999999999'
-    b':99999999999999999999999999999',
-])
+@pytest.mark.parametrize(
+    "value",
+    [
+        # GH 1366 - over-long numeric token in an HMS field
+        "19970902090807197090209080710h",
+        # GH 1359 - over-long numeric token in a colon-separated minute field
+        "12:99999999999999999999999999999999999",
+        b"9999999999999999999999999999999999999999939999999999999999999999999999"
+        b":99999999999999999999999999999",
+    ],
+)
 def test_decimal_invalid_operation_error(value):
     # GH 1359, GH 1366 - a numeric token with more digits than the decimal
     # context precision constructs as a Decimal but raises
@@ -971,6 +974,7 @@ def test_decimal_invalid_operation_error(value):
     # ParserError. Ensure it is now surfaced consistently.
     with pytest.raises(ParserError):
         parse(value)
+
 
 def test_parsererror_repr():
     # GH 991 — the __repr__ was not properly indented and so was never defined.


### PR DESCRIPTION
Fixes #1359, fixes #1366.

## Bug
`parse()` documents that it raises `ParserError` (a `ValueError` subclass) for invalid input. But a numeric token with more digits than the active decimal-context precision (28) constructs fine as a `Decimal`, then raises `decimal.InvalidOperation` (an `ArithmeticError`, **not** a `ValueError`) on later arithmetic like `value % 1`. That exception leaks out of `parse()`, bypassing every `except ParserError` / `except ValueError` handler. Reproduced on both reported inputs (#1359 `...9999...:9999...`, #1366 `19970902090807197090209080710h`).

## Fix
`_to_decimal()` is the single choke point every numeric time component flows through. Add a one-line probe (`decimal_value % 1`) inside its existing `try`, so an over-large token surfaces as `ValueError` — which the parser already funnels into `ParserError`. Fixes both issues in one place; no behavior change for valid input.

## Verification
- **Before:** both inputs raise `decimal.InvalidOperation` (not caught as `ParserError`/`ValueError`). **After:** both raise `ParserError`.
- Added a parametrized regression test next to `test_decimal_error` — fails before, passes after.
- Full suite: **2035 passed, 47 skipped, 17 xfailed**, 0 failures. Spot-checked ~9 valid inputs (ISO w/ offset, `13h30m45s`, `UTC-4`, `00:00:00.999999`, …) — all still parse.
