### PR TITLE
Fix isoparser parametrization for pytest 9

### DIFF
--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -118,12 +118,15 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset)
 
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
-@pytest.mark.parametrize('dt', tuple(DATETIMES))
-@pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
-@pytest.mark.parametrize('tzoffset', TZOFFSETS)
-@pytest.mark.parametrize('precision', list(range(3, 7)))
+
+
+@pytest.mark.parametrize("dt", tuple(DATETIMES))
+@pytest.mark.parametrize("date_fmt", YMD_FMTS)
+@pytest.mark.parametrize(
+    "time_fmt", tuple(x + sep + "%f" for x in HMS_FMTS for sep in ".,")
+)
+@pytest.mark.parametrize("tzoffset", TZOFFSETS)
+@pytest.mark.parametrize("precision", list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
     # Truncate the microseconds to the desired precision for the representation
     dt = dt.replace(microsecond=int(round(dt.microsecond, precision-6)))


### PR DESCRIPTION
## Summary

Wrap the generated `time_fmt` parameter set in `tuple(...)` so pytest receives a concrete collection during parametrization.

## Why

Pytest 9 warns when `parametrize` is given a non-collection iterable, and this repository treats warnings as errors. Pytest 10 is expected to remove the compatibility path entirely.

## Impact

The test data, order, and coverage remain unchanged; the generator is only materialized before pytest consumes it.

## Validation

- `python3 -m pytest tests/test_isoparser.py -q`
- `TZ=America/New_York python3 -m pytest tests -q`
- `TZ=America/New_York python3 -m tox -e py -- tests/test_isoparser.py -q`