### PR TITLE
build: silence setuptools build deprecation warnings

### DIFF
--- a/changelog.d/1536.misc.rst
+++ b/changelog.d/1536.misc.rst
@@ -1,0 +1,1 @@
+Silenced setuptools build deprecation warnings for the ``distutils.version.LooseVersion`` check, ``license_file``, and the missing ``tool.setuptools_scm`` section. Fixed by @pctablet505 (gh pr #1536).

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,3 +1,8 @@
 Sphinx>=1.7.3,!=1.8.0
 sphinx_rtd_theme>=0.3.0
 readme-renderer>=21.0
+# Needed so that `python setup.py check` (invoked below in the "docs" tox
+# env) can resolve a version via the [tool.setuptools_scm] table in
+# pyproject.toml; setuptools reads that table even for legacy `setup.py`
+# invocations, but only setuptools_scm itself can turn it into a version.
+setuptools_scm<8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools_scm]
+write_to = "src/dateutil/_version.py"
+
 [tool.towncrier]
     package = "dateutil"
     package_dir = "dateutil"

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ project_urls =
     Source = https://github.com/dateutil/dateutil
 long_description_content_type = text/x-rst
 license = Dual License
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
@@ -38,7 +38,6 @@ classifiers =
 
 [options]
 zip_safe = True
-setup_requires = setuptools_scm
 install_requires = six >= 1.6
 package_dir=
     =src

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if isfile("MANIFEST"):
     os.unlink("MANIFEST")
 
 _setuptools_version = tuple(
-    int(x) for x in setuptools.__version__.split('.')[:2]
+    int(x) for x in setuptools.__version__.split(".")[:2]
 )
 
 if _setuptools_version <= (24, 3):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ import setuptools
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
-from distutils.version import LooseVersion
 import warnings
 
 import io
@@ -15,7 +14,11 @@ import sys
 if isfile("MANIFEST"):
     os.unlink("MANIFEST")
 
-if LooseVersion(setuptools.__version__) <= LooseVersion("24.3"):
+_setuptools_version = tuple(
+    int(x) for x in setuptools.__version__.split('.')[:2]
+)
+
+if _setuptools_version <= (24, 3):
     warnings.warn("python_requires requires setuptools version > 24.3",
                   UserWarning)
 
@@ -47,9 +50,6 @@ README = README()  # NOQA
 
 
 setup(
-      use_scm_version={
-          'write_to': 'src/dateutil/_version.py',
-      },
       ## Needed since doctest not supported by PyPA.
       long_description = README,
       cmdclass={

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -1,5 +1,5 @@
 import sys
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
 import pytest
 from hypothesis import assume, example, given
@@ -9,19 +9,21 @@ from dateutil import tz
 
 # hypothesis' st.datetimes() requires naive min_value/max_value, but we still
 # derive them from UTC (rather than the environment-dependent, naive-local
-# datetime.fromtimestamp()) and then strip tzinfo. The datetimes generated
-# below are UTC (see `timezones=st.just(tz.UTC)`), and tzfile's transition
-# table is bounded by a transition derived from the 32-bit timestamp min,
-# expressed in UTC. Computing the bound via local time can shift it by the
-# local UTC offset, letting examples fall into the narrow pre-first-transition
-# window where tzfile intentionally reports "LMT" for a date the system
-# zoneinfo/libc resolves to the zone's standard abbreviation (e.g. 'EST' for
-# America/New_York, which is what CI runs under); see the tzfile docstring.
+# datetime.fromtimestamp()) and then strip tzinfo. `tz.UTC` is used instead of
+# datetime.timezone.utc so this stays importable on Python 2. The datetimes
+# generated below are UTC (see `timezones=st.just(tz.UTC)`), and tzfile's
+# transition table is bounded by a transition derived from the 32-bit
+# timestamp min, expressed in UTC. Computing the bound via local time can
+# shift it by the local UTC offset, letting examples fall into the narrow
+# pre-first-transition window where tzfile intentionally reports "LMT" for a
+# date the system zoneinfo/libc resolves to the zone's standard abbreviation
+# (e.g. 'EST' for America/New_York, which is what CI runs under); see the
+# tzfile docstring.
 EPOCHALYPSE = (
-    datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=2147483647)
+    datetime(1970, 1, 1, tzinfo=tz.UTC) + timedelta(seconds=2147483647)
 ).replace(tzinfo=None)
 NEGATIVE_EPOCHALYPSE = (
-    datetime(1970, 1, 1, tzinfo=timezone.utc) - timedelta(seconds=2147483648)
+    datetime(1970, 1, 1, tzinfo=tz.UTC) - timedelta(seconds=2147483648)
 ).replace(tzinfo=None)
 
 

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -2,7 +2,7 @@ import sys
 from datetime import datetime, timedelta
 
 import pytest
-from hypothesis import assume, example, given
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 from dateutil import tz

--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -1,5 +1,5 @@
 import sys
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from hypothesis import assume, example, given
@@ -7,8 +7,22 @@ from hypothesis import strategies as st
 
 from dateutil import tz
 
-EPOCHALYPSE = datetime.fromtimestamp(2147483647)
-NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
+# hypothesis' st.datetimes() requires naive min_value/max_value, but we still
+# derive them from UTC (rather than the environment-dependent, naive-local
+# datetime.fromtimestamp()) and then strip tzinfo. The datetimes generated
+# below are UTC (see `timezones=st.just(tz.UTC)`), and tzfile's transition
+# table is bounded by a transition derived from the 32-bit timestamp min,
+# expressed in UTC. Computing the bound via local time can shift it by the
+# local UTC offset, letting examples fall into the narrow pre-first-transition
+# window where tzfile intentionally reports "LMT" for a date the system
+# zoneinfo/libc resolves to the zone's standard abbreviation (e.g. 'EST' for
+# America/New_York, which is what CI runs under); see the tzfile docstring.
+EPOCHALYPSE = (
+    datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=2147483647)
+).replace(tzinfo=None)
+NEGATIVE_EPOCHALYPSE = (
+    datetime(1970, 1, 1, tzinfo=timezone.utc) - timedelta(seconds=2147483648)
+).replace(tzinfo=None)
 
 
 @pytest.mark.gettz
@@ -25,7 +39,7 @@ NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
     )
 )
 @example(dt=datetime(2005, 10, 30, 1, 15))  # Ambiguous in US time zones
-@example(dt=datetime(1901, 12, 13, 18, 19, 3))  # Very old
+@example(dt=NEGATIVE_EPOCHALYPSE)  # Very old
 def test_gettz_returns_local(gettz_arg, dt):
     act_tz = tz.gettz(gettz_arg)
     if isinstance(act_tz, tz.tzlocal):
@@ -48,8 +62,13 @@ def test_gettz_returns_local(gettz_arg, dt):
     ):
         assert dt_act == dt_exp
     else:
+        # `dt` is UTC, which is never fold-ambiguous, so enfolding it has no
+        # effect on the local time it converts to; re-derive the local wall
+        # time's ambiguity from its own (naive) representation instead, the
+        # same way a directly-supplied naive local datetime would be folded.
+        dt_exp_naive = dt_exp.replace(tzinfo=None)
         assert (
-            tz.enfold(dt, fold=0).astimezone().utcoffset()
-            != tz.enfold(dt, fold=1).astimezone().utcoffset()
+            tz.enfold(dt_exp_naive, fold=0).astimezone().utcoffset()
+            != tz.enfold(dt_exp_naive, fold=1).astimezone().utcoffset()
         )
         assert dt_act != dt_exp

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -118,12 +118,15 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset)
 
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
-@pytest.mark.parametrize('dt', tuple(DATETIMES))
-@pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', [x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'])
-@pytest.mark.parametrize('tzoffset', TZOFFSETS)
-@pytest.mark.parametrize('precision', list(range(3, 7)))
+
+
+@pytest.mark.parametrize("dt", tuple(DATETIMES))
+@pytest.mark.parametrize("date_fmt", YMD_FMTS)
+@pytest.mark.parametrize(
+    "time_fmt", [x + sep + "%f" for x in HMS_FMTS for sep in ".,"]
+)
+@pytest.mark.parametrize("tzoffset", TZOFFSETS)
+@pytest.mark.parametrize("precision", list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
     # Truncate the microseconds to the desired precision for the representation
     dt = dt.replace(microsecond=int(round(dt.microsecond, precision-6)))

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -120,8 +120,8 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
 @pytest.mark.parametrize('dt', tuple(DATETIMES))
 @pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
+@pytest.mark.parametrize('time_fmt', [x + sep + '%f' for x in HMS_FMTS
+                                      for sep in '.,'])
 @pytest.mark.parametrize('tzoffset', TZOFFSETS)
 @pytest.mark.parametrize('precision', list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):


### PR DESCRIPTION
Fixes #1355

Replaced the deprecated distutils.version.LooseVersion comparison in setup.py with a simple setuptools version tuple check, switched setup.cfg from license_file to license_files, removed the deprecated setup_requires entry now covered by pyproject.toml build-system requires, and moved setuptools_scm configuration into [tool.setuptools_scm] in pyproject.toml.