### PR TITLE
Fix rrule byweekno for days in the previous year's last ISO week

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -132,5 +132,6 @@ switch, and thus all their contributions are dual-licensed.
 - Labrys <labrys.git@gmail.com> (gh: @labrys) **R**
 - ms-boom <ms-boom@MASKED>
 - ryanss <ryanssdev@MASKED> (gh: @ryanss) **R**
+- Vineeth Sai <vineethsai4444@gmail.com> (gh: @vineethsaivs)
 
 Unless someone has deliberately given permission to publish their e-mail, I have masked the domain names. If you are not on this list and believe you should be, or you *are* on this list and your information is inaccurate, please e-mail the current maintainer or the mailing list (dateutil@python.org) with your name, e-mail (if desired) and GitHub (if desired / applicable), as you would like them displayed. Additionally, please indicate if you are willing to dual license your old contributions under Apache 2.0.

--- a/changelog.d/1537.bugfix.rst
+++ b/changelog.d/1537.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed ``rrule`` with ``byweekno`` misattributing the first days of a year that
+belong to the last ISO week of the previous year. The last week number of the
+previous year was computed from the current year's length instead of the
+previous year's, so e.g. ``byweekno=52`` skipped and ``byweekno=53`` wrongly
+included 2011-01-01/02 (ISO week 52 of 2010). Reported and fixed by
+@vineethsaivs (gh pr #1537).

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -1204,10 +1204,15 @@ class _iterinfo(object):
                         lyearlen = 365+calendar.isleap(year-1)
                         if lno1wkst >= 4:
                             lno1wkst = 0
-                            lnumweeks = 52+(lyearlen +
-                                            (lyearweekday-rr._wkst) % 7) % 7//4
+                            # Number of days in last year, plus the days it
+                            # got from the year before.
+                            lwyearlen = lyearlen + (lyearweekday - rr._wkst) % 7
                         else:
-                            lnumweeks = 52+(self.yearlen-no1wkst) % 7//4
+                            # Number of days in last year, minus the days it
+                            # left in the year before.
+                            lwyearlen = lyearlen - lno1wkst
+                        ldiv, lmod = divmod(lwyearlen, 7)
+                        lnumweeks = ldiv + lmod // 4
                     else:
                         lnumweeks = -1
                     if lnumweeks in rr._byweekno:

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -301,6 +301,36 @@ class RRuleTest(unittest.TestCase):
                           datetime(2004, 12, 27, 9, 0),
                           datetime(2009, 12, 28, 9, 0)])
 
+    def testYearlyByWeekNoLastWeekOfPrevYear(self):
+        # The first days of a year may belong to the last ISO week of the
+        # *previous* year, so that week number must be derived from the
+        # previous year's length. 2011-01-01 and 2011-01-02 are ISO week 52
+        # of 2010 (2010 has no week 53), so byweekno=52 must yield them and
+        # byweekno=53 must not.
+        self.assertEqual(
+            list(
+                rrule(
+                    YEARLY,
+                    count=2,
+                    byweekno=52,
+                    byweekday=(SA, SU),
+                    dtstart=datetime(2011, 1, 1, 9, 0),
+                )
+            ),
+            [datetime(2011, 1, 1, 9, 0), datetime(2011, 1, 2, 9, 0)],
+        )
+        self.assertEqual(
+            list(
+                rrule(
+                    YEARLY,
+                    byweekno=53,
+                    dtstart=datetime(2011, 1, 1, 9, 0),
+                    until=datetime(2011, 1, 10, 9, 0),
+                )
+            ),
+            [],
+        )
+
     def testYearlyByHour(self):
         self.assertEqual(list(rrule(YEARLY,
                               count=3,


### PR DESCRIPTION
### Summary

`rrule(..., byweekno=...)` misattributes the first days of a year that actually belong to the **last ISO week of the previous year**.

`_iterinfo.rebuild()` computes `lnumweeks`, the last week number of the previous year, to decide whether early-January spillover days should be marked for a given `byweekno`. It computed that value from the **current** year's length with a hardcoded `52`:

```python
if lno1wkst >= 4:
    lno1wkst = 0
    lnumweeks = 52+(lyearlen + (lyearweekday-rr._wkst) % 7) % 7//4
else:
    lnumweeks = 52+(self.yearlen-no1wkst) % 7//4   # uses THIS year's yearlen/no1wkst
```

The parallel current-year block a few lines above already does it correctly, using `divmod` on the week-adjusted length. Because the previous-year block used the wrong year's variables (and hardcoded 52 instead of the real `div`), `lnumweeks` came out one too high in some years.

### Reproduction

`2011-01-01` and `2011-01-02` are ISO week **52 of 2010** (2010 has no week 53), confirmed by `date.isocalendar()`:

```python
>>> from dateutil.rrule import rrule, YEARLY, SA, SU
>>> from datetime import datetime
>>> list(rrule(YEARLY, count=2, byweekno=52, byweekday=(SA, SU),
...            dtstart=datetime(2011, 1, 1, 9, 0)))
# before: [datetime(2011, 12, 31, 9, 0), datetime(2012, 1, 1, 9, 0)]   # skips Jan 1/2
# after:  [datetime(2011, 1, 1, 9, 0),  datetime(2011, 1, 2, 9, 0)]    # correct
>>> list(rrule(YEARLY, byweekno=53, dtstart=datetime(2011, 1, 1, 9, 0),
...            until=datetime(2011, 1, 10, 9, 0)))
# before: [datetime(2011, 1, 1, 9, 0), datetime(2011, 1, 2, 9, 0)]     # week 53 does not exist
# after:  []                                                            # correct
```

### Fix

Compute the previous year's week count the same way the current-year block does, from the previous year's `lyearlen` / `lno1wkst`:

```python
if lno1wkst >= 4:
    lno1wkst = 0
    lwyearlen = lyearlen+(lyearweekday-rr._wkst) % 7
else:
    lwyearlen = lyearlen-lno1wkst
ldiv, lmod = divmod(lwyearlen, 7)
lnumweeks = ldiv+lmod//4
```

### Validation

- New regression test `testYearlyByWeekNoLastWeekOfPrevYear` (fails before, passes after).
- A systematic cross-check of `byweekno=N` against Python's own `date.isocalendar()` over every week of 1998-2034 had mismatches only in **2011 and 2022** before this change and **zero** after.
- The full `tests/test_rrule.py` suite passes: **562 passed, 1 xfailed** (the 561 pre-existing tests plus the new regression test). The documented `testYearlyByWeekNoAndWeekDay53` still returns its exact expected values.

Includes an `AUTHORS.md` entry and a `changelog.d` news fragment.