### PR TITLE
Raise ValueError for an RRULE string missing FREQ

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -47,6 +47,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         python-version: [
           "3.8",

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -132,5 +132,6 @@ switch, and thus all their contributions are dual-licensed.
 - Labrys <labrys.git@gmail.com> (gh: @labrys) **R**
 - ms-boom <ms-boom@MASKED>
 - ryanss <ryanssdev@MASKED> (gh: @ryanss) **R**
+- santhreal (gh: @santhreal)
 
 Unless someone has deliberately given permission to publish their e-mail, I have masked the domain names. If you are not on this list and believe you should be, or you *are* on this list and your information is inaccurate, please e-mail the current maintainer or the mailing list (dateutil@python.org) with your name, e-mail (if desired) and GitHub (if desired / applicable), as you would like them displayed. Additionally, please indicate if you are willing to dual license your old contributions under Apache 2.0.

--- a/changelog.d/1538.bugfix.rst
+++ b/changelog.d/1538.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``rrulestr`` raising a bare ``TypeError`` instead of ``ValueError`` when the rule string omits the required ``FREQ`` component. Fixed by @santhreal (gh pr #1538).

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -1558,6 +1558,8 @@ class _rrulestr(object):
                 raise ValueError("unknown parameter '%s'" % name)
             except (KeyError, ValueError):
                 raise ValueError("invalid '%s': %s" % (name, value))
+        if "freq" not in rrkwargs:
+            raise ValueError("Missing FREQ in RRULE")
         return rrule(dtstart=dtstart, cache=cache, **rrkwargs)
 
     def _parse_date_value(self, date_value, parms, rule_tzids,

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -121,7 +121,7 @@ DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
 @pytest.mark.parametrize('dt', tuple(DATETIMES))
 @pytest.mark.parametrize('date_fmt', YMD_FMTS)
 @pytest.mark.parametrize(
-    'time_fmt', [x + sep + '%f' for x in HMS_FMTS for sep in '.,']
+    "time_fmt", [x + sep + "%f" for x in HMS_FMTS for sep in ".,"]
 )
 @pytest.mark.parametrize('tzoffset', TZOFFSETS)
 @pytest.mark.parametrize('precision', list(range(3, 7)))

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -120,8 +120,9 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
 @pytest.mark.parametrize('dt', tuple(DATETIMES))
 @pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
+@pytest.mark.parametrize(
+    'time_fmt', [x + sep + '%f' for x in HMS_FMTS for sep in '.,']
+)
 @pytest.mark.parametrize('tzoffset', TZOFFSETS)
 @pytest.mark.parametrize('precision', list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -3007,6 +3007,12 @@ class RRuleTest(unittest.TestCase):
                           "RRULE:FREQ=YEARLY;"
                           "UNTIL=TheCowsComeHome;BYDAY=1TU,-1TH\n"))
 
+    def testStrNoFreq(self):
+        # FREQ is required by RFC 5545; without it rrulestr used to leak a TypeError.
+        for rule in ("COUNT=5", "BYDAY=MO", "INTERVAL=2", "RRULE:COUNT=5"):
+            with self.assertRaises(ValueError):
+                rrulestr(rule)
+
     def testStrUntilMustBeUTC(self):
         with self.assertRaises(ValueError):
             list(rrulestr("DTSTART;TZID=America/New_York:19970902T090000\n"


### PR DESCRIPTION
FREQ is a required part of an RRULE per RFC 5545. `rrulestr` on a rule string without it forwarded the parsed kwargs straight to `rrule()`, which raised a bare `TypeError: rrule.__init__() missing 1 required positional argument: 'freq'` instead of the `ValueError` used for other malformed rules.

```python
from dateutil.rrule import rrulestr
rrulestr("COUNT=5")  # was: TypeError; now: ValueError("Missing FREQ in RRULE")
```

I will add the `changelog.d` fragment and an AUTHORS entry in a follow-up commit now that the PR number is known.