### PR TITLE
Fix bare except clauses in win.py and test_relativedelta.py

### DIFF
--- a/src/dateutil/tz/win.py
+++ b/src/dateutil/tz/win.py
@@ -116,7 +116,7 @@ class tzres(object):
         name_splt = tzname_str.split(',-')
         try:
             offset = int(name_splt[1])
-        except:
+        except (ValueError, IndexError):
             raise ValueError("Malformed timezone string.")
 
         return self.load_name(offset)

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -647,7 +647,7 @@ class RelativeDeltaTest(unittest.TestCase):
     def testHashable(self):
         try:
             {relativedelta(minute=1): 'test'}
-        except:
+        except Exception:
             self.fail("relativedelta() failed to hash!")
 
     def testDayOfMonthPlus(self):


### PR DESCRIPTION
Replace bare `except:` clauses with specific exception types:

- `src/dateutil/tz/win.py`: replaced with `except (ValueError, IndexError):`
- `tests/test_relativedelta.py`: replaced with `except Exception:`

Bare `except:` catches BaseException (including SystemExit/KeyboardInterrupt), masking serious errors.