### PR TITLE
Make relativedelta.__hash__ consistent with __eq__ for weekday

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -90,6 +90,7 @@ switch, and thus all their contributions are dual-licensed.
 - Nicolas Évrard (gh: @nicoe) **D**
 - Nick Smith <nick.smith@MASKED>
 - Orson Adams <orson.network@MASKED> (gh: @parsethis) **D**
+- Osamaali313 (gh: @Osamaali313)
 - Paul Brown (gh: @pawl) **D**
 - Paul Dickson (gh @prdickson) **D**
 - Paul Ganssle <paul@ganssle.io> (gh: @pganssle) **R**

--- a/changelog.d/1540.bugfix.rst
+++ b/changelog.d/1540.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``relativedelta.__hash__`` so that objects which compare equal but
+differ only in a weekday's ``n`` being ``None``/``0``/``1`` (e.g. ``MO`` and
+``MO(1)``) also hash equally, restoring correct ``set``/``dict`` membership.
+Reported and fixed by @Osamaali313 (gh pr #1540).

--- a/src/dateutil/relativedelta.py
+++ b/src/dateutil/relativedelta.py
@@ -545,8 +545,14 @@ class relativedelta(object):
                 self.microsecond == other.microsecond)
 
     def __hash__(self):
+        # __eq__ treats a weekday with n in (None, 0, 1) as equal (not
+        # specifying n is the same as +1), so the hash must ignore that
+        # distinction to keep equal objects hashing equally.
+        weekday = self.weekday
+        if weekday is not None and (weekday.n or 1) == 1:
+            weekday = weekday.weekday
         return hash((
-            self.weekday,
+            weekday,
             self.years,
             self.months,
             self.days,

--- a/tests/test_relativedelta.py
+++ b/tests/test_relativedelta.py
@@ -650,6 +650,19 @@ class RelativeDeltaTest(unittest.TestCase):
         except:
             self.fail("relativedelta() failed to hash!")
 
+    def testHashableWeekdayEquivalence(self):
+        # A weekday with n in (None, 0, 1) compares equal (e.g. MO == MO(1)),
+        # so equal relativedeltas must hash equally and work in sets/dicts.
+        base = relativedelta(weekday=MO)
+        for wd in (MO(0), MO(1)):
+            other = relativedelta(weekday=wd)
+            self.assertEqual(base, other)
+            self.assertEqual(hash(base), hash(other))
+            self.assertIn(other, {base})
+        # A different explicit count is a different object and must not collide.
+        self.assertNotEqual(base, relativedelta(weekday=MO(2)))
+        self.assertNotIn(relativedelta(weekday=MO(2)), {base})
+
     def testDayOfMonthPlus(self):
         assert [
             date(2021, 1, 28) + relativedelta(months=1),


### PR DESCRIPTION
### Summary

`relativedelta.__eq__` treats a weekday whose `n` is in `(None, 0, 1)` as equal (`MO == MO(1)`, since the docstring notes *"Not specifying it is the same as specifying +1"*), but `__hash__` hashed the raw `weekday` object. So two `relativedelta`s that compare equal can hash differently, which violates the equal-objects-equal-hash invariant and makes set/dict membership silently wrong:

```python
from dateutil.relativedelta import relativedelta, MO

a = relativedelta(weekday=MO)
b = relativedelta(weekday=MO(1))

a == b              # True
hash(a) == hash(b)  # False  <- bug
b in {a}            # False  <- bug
```

### Fix

Normalize the `(None, 0, 1)` weekday equivalence class in `__hash__` so equal objects hash equally. Weekdays with other explicit counts (e.g. `MO(2)`, `MO(-1)`) keep the full `weekday` object, so distinct values still hash distinctly. Added a regression test (`testHashableWeekdayEquivalence`).
