### PR TITLE
Fix default microsecond being discarded when seconds are parsed

### DIFF
--- a/changelog.d/1032.bugfix.rst
+++ b/changelog.d/1032.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``parser.parse()`` discarding the ``default`` datetime's ``microsecond`` whenever the parsed string specified seconds without a fractional part, since ``_parsems()`` reported ``microsecond=0`` (rather than "unspecified") in that case, silently overriding a non-zero ``default.microsecond``. Reported by @kricka91 (gh issue #1032).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -1131,9 +1131,17 @@ class parser(object):
     #  of functions for the sake of customizability via subclassing.
 
     def _parsems(self, value):
-        """Parse a I[.F] seconds value into (seconds, microseconds)."""
+        """Parse a I[.F] seconds value into (seconds, microseconds).
+
+        The microsecond return value is None (not 0) when no fractional
+        part is present, so that the caller's None-check when merging in
+        the ``default`` datetime (see ``_build_naive``) correctly treats
+        an unspecified microsecond as unspecified, rather than silently
+        overriding a provided ``default.microsecond`` with 0 whenever
+        seconds are present without a fractional part. See GH #1032.
+        """
         if "." not in value:
-            return int(value), 0
+            return int(value), None
         else:
             i, f = value.split(".")
             return int(i), int(f.ljust(6, "0")[:6])

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -167,6 +167,30 @@ def test_parser_default(parsable_text, expected_datetime, assertion_message):
     assert parse(parsable_text, default=datetime(2003, 9, 25)) == expected_datetime, assertion_message
 
 
+@pytest.mark.parametrize("parsable_text,expected_microsecond", [
+    ("2020-02-15T12:34", 999999),
+    ("2020-02-15T12:34:23", 999999),
+    ("2020-02-15T12:34:23.5", 500000),
+    ("2020-02-15T12:34:23.000001", 1),
+])
+def test_parser_default_microsecond(parsable_text, expected_microsecond):
+    """
+    Regression test for
+    https://github.com/dateutil/dateutil/issues/1032
+
+    The default datetime's microsecond must be preserved whenever the
+    parsed string doesn't itself specify one -- including when the
+    string specifies seconds but no fractional part, which previously
+    caused _parsems() to report microsecond=0 (rather than
+    "unspecified"), silently overriding a non-zero default.microsecond.
+    A string that does specify its own (fractional-second-derived)
+    microsecond must still take precedence over the default.
+    """
+    default = datetime(2020, 12, 31, 23, 59, 59, 999999)
+    result = parse(parsable_text, default=default)
+    assert result.microsecond == expected_microsecond
+
+
 @pytest.mark.parametrize('sep', ['-', '.', '/', ' '])
 def test_parse_dayfirst(sep):
     expected = datetime(2003, 9, 10)


### PR DESCRIPTION
Fixes #1032.

`_parsems()` parses an `SS[.ffffff]` value into `(seconds, microseconds)`. When there's no fractional part, it returned `microsecond=0` rather than `None`. `_build_naive()` merges parsed fields into the caller-supplied `default` datetime via `default.replace(**repl)`, only including fields in `repl` that are not `None` on the parsed result. Since `_parsems()` always returned a concrete `0` (never `None`) for microsecond whenever seconds were present without a fractional part, this unconditionally included `microsecond=0` in `repl`, silently overriding any non-zero `default.microsecond` -- even though the input string never actually specified a microsecond value at all.

This only manifested when seconds were present in the input; parsing a string without seconds at all left `res.microsecond` as its natural `None` default, correctly preserving `default.microsecond`, which is why the bug was inconsistent depending on whether seconds happened to be present in the parsed string -- exactly as described in the issue.

**Fix**: return `None` instead of `0` for microsecond when there's no fractional part, so the same `None`-check `_build_naive` already uses correctly treats it as unspecified. All three call sites of `_parsems()` assign directly to the `res.second`/`res.microsecond` slots (which default to `None`), so this doesn't require any other changes.

**Testing**: verified against the exact reproduction in the issue: parsing a string with seconds but no fractional part now correctly preserves the default's microsecond, matching the existing (already-correct) behavior for strings without seconds at all. Also verified fractional seconds in the input still correctly take precedence over the default, and that parsing without an explicit default (or with an all-zero default) is unaffected.

Added a parametrized regression test covering: no seconds parsed, seconds without a fractional part, seconds with a fractional part, and an explicit tiny microsecond value -- asserting the default's microsecond is preserved in the first two cases and correctly overridden in the latter two. I confirmed the "seconds without a fractional part" case fails with the original code and passes with the fix; the other three cases pass in both. Ran the full existing `test_parser.py` suite (235 passed: 231 baseline + 4 new, 14 xfailed), no regressions.
