### PR TITLE
fix: validate timezone offset components in parser.parse()

### DIFF
--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -829,6 +829,20 @@ class parser(object):
                     else:
                         raise ValueError(timestr)
 
+                    # Validate timezone offset components to prevent
+                    # silent acceptance of invalid offsets (e.g. minutes >= 60
+                    # or hours >= 24), matching isoparse() behavior.
+                    if not (0 <= min_offset < 60):
+                        raise ValueError(
+                            f"minute offset in timezone must be in 0..59, "
+                            f"got {min_offset}"
+                        )
+                    if not (0 <= hour_offset < 24):
+                        raise ValueError(
+                            f"hour offset in timezone must be in 0..23, "
+                            f"got {hour_offset}"
+                        )
+
                     res.tzoffset = signal * (hour_offset * 3600 + min_offset * 60)
 
                     # Look for a timezone name between parenthesis

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -120,8 +120,8 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
 @pytest.mark.parametrize('dt', tuple(DATETIMES))
 @pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
+@pytest.mark.parametrize('time_fmt', [x + sep + '%f' for x in HMS_FMTS
+                                      for sep in '.,'])
 @pytest.mark.parametrize('tzoffset', TZOFFSETS)
 @pytest.mark.parametrize('precision', list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):


### PR DESCRIPTION
## Description

parser.parse() silently accepted invalid timezone offsets where
minutes >= 60 or hours >= 24, producing incorrect or 'toxic'
datetime objects. This fix adds validation to match isoparse()
behavior.

## Changes
- Added validation in  to check:
  - 
  - 
- Raises  for invalid offsets

Fixes dateutil/dateutil#1508