### PR TITLE
Drop freezegun test dependency

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -39,6 +39,7 @@ switch, and thus all their contributions are dual-licensed.
 - Christopher Cordero <ccordero@pm.me> (gh: cs-cordero) **D**
 - Christopher Corley <cscorley@MASKED>
 - Claudio Canepa <ccanepacc@MASKED>
+- ColumbusLabs (gh: @ColumbusLabs)
 - Corey Girard <corey.r.girard@gmail.com> (gh: @coreygirard) **D**
 - Cosimo Lupo <cosimo@anthrotype.com> (gh: @anthrotype) **D**
 - Daniel Lemm (gh: @ffe4) **D**

--- a/changelog.d/1543.misc.rst
+++ b/changelog.d/1543.misc.rst
@@ -1,0 +1,1 @@
+Remove the test dependency on ``freezegun``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ known_third_party=[
     "pytest",
     "hypothesis",
     "six",
-    "freezegun",
     "mock",
 ]
 multi_line_output=3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 six
 pytest >= 3.0; python_version != '3.3'
 pytest-cov >= 2.0.0
-freezegun ; python_version != '3.3'
 hypothesis >= 3.30
 coverage
 mock ; python_version < '3.0'

--- a/requirements/3.3/constraints.txt
+++ b/requirements/3.3/constraints.txt
@@ -2,7 +2,6 @@ attrs==18.2.0
 colorama==0.3.9
 coverage==4.5.3
 enum34==1.1.6
-freezegun==0.3.10
 hypothesis==3.30.4
 pip==10.0.1
 pluggy==0.5.2

--- a/requirements/3.3/requirements-dev.txt
+++ b/requirements/3.3/requirements-dev.txt
@@ -2,7 +2,6 @@ virtualenv<16.0
 setuptools<40.0
 tox<3.8.0
 pytest<3.3
-freezegun<0.3.11
 hypothesis >= 3.30
 coverage
 pytest-cov >= 2.0.0

--- a/tests/_common.py
+++ b/tests/_common.py
@@ -1,12 +1,45 @@
 from __future__ import unicode_literals
 import os
-import time
-import subprocess
-import warnings
-import tempfile
 import pickle
+import subprocess
+import tempfile
+import time
+import warnings
+from contextlib import contextmanager
+from datetime import datetime
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 import pytest
+import six
+
+
+class _DatetimeMeta(type):
+    def __instancecheck__(cls, instance):
+        return isinstance(instance, datetime)
+
+
+def _fixed_datetime(now):
+    @six.add_metaclass(_DatetimeMeta)
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return now.replace(tzinfo=None)
+            else:
+                return now.astimezone(tz)
+
+    return FixedDateTime
+
+
+@contextmanager
+def mock_datetime_now(target, now):
+    """Patch a module's ``datetime`` class to return a fixed current time."""
+    with mock.patch(target, _fixed_datetime(now)):
+        yield
 
 
 class PicklableMixin(object):

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -1,21 +1,34 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from datetime import datetime, date
 import unittest
+from datetime import date, datetime
+
+import pytest
 from six import PY2
 
 from dateutil import tz
 from dateutil.rrule import (
-    rrule, rruleset, rrulestr,
-    YEARLY, MONTHLY, WEEKLY, DAILY,
-    HOURLY, MINUTELY, SECONDLY,
-    MO, TU, WE, TH, FR, SA, SU
+    DAILY,
+    FR,
+    HOURLY,
+    MINUTELY,
+    MO,
+    MONTHLY,
+    SA,
+    SECONDLY,
+    SU,
+    TH,
+    TU,
+    WE,
+    WEEKLY,
+    YEARLY,
+    rrule,
+    rruleset,
+    rrulestr,
 )
 
 from ._common import mock_datetime_now
-
-import pytest
 
 
 @pytest.mark.rrule
@@ -4622,8 +4635,7 @@ def test_generated_aware_dtstart():
 
     with mock_datetime_now("dateutil.rrule.datetime.datetime", dtstart_exp):
         rule_without_dtstart = rrule(freq=HOURLY, until=UNTIL)
-        rule_with_dtstart = rrule(freq=HOURLY, dtstart=dtstart_exp,
-                                  until=UNTIL)
+        rule_with_dtstart = rrule(freq=HOURLY, dtstart=dtstart_exp, until=UNTIL)
         assert list(rule_without_dtstart) == list(rule_with_dtstart)
 
 
@@ -4633,9 +4645,9 @@ def test_generated_aware_dtstart():
 def test_generated_aware_dtstart_rrulestr():
     now = datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC)
     with mock_datetime_now("dateutil.rrule.datetime.datetime", now):
-        rrule_without_dtstart = rrule(freq=HOURLY,
-                                      until=datetime(2018, 3, 6, 8, 0,
-                                                     tzinfo=tz.UTC))
+        rrule_without_dtstart = rrule(
+            freq=HOURLY, until=datetime(2018, 3, 6, 8, 0, tzinfo=tz.UTC)
+        )
         rrule_r = rrulestr(str(rrule_without_dtstart))
 
         assert list(rrule_r) == list(rrule_without_dtstart)

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -13,7 +13,7 @@ from dateutil.rrule import (
     MO, TU, WE, TH, FR, SA, SU
 )
 
-from freezegun import freeze_time
+from ._common import mock_datetime_now
 
 import pytest
 
@@ -4616,27 +4616,29 @@ class RRuleTest(unittest.TestCase):
 
 
 @pytest.mark.rrule
-@freeze_time(datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC))
 def test_generated_aware_dtstart():
     dtstart_exp = datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC)
     UNTIL = datetime(2018, 3, 6, 8, 0, tzinfo=tz.UTC)
 
-    rule_without_dtstart = rrule(freq=HOURLY, until=UNTIL)
-    rule_with_dtstart = rrule(freq=HOURLY, dtstart=dtstart_exp, until=UNTIL)
-    assert list(rule_without_dtstart) == list(rule_with_dtstart)
+    with mock_datetime_now("dateutil.rrule.datetime.datetime", dtstart_exp):
+        rule_without_dtstart = rrule(freq=HOURLY, until=UNTIL)
+        rule_with_dtstart = rrule(freq=HOURLY, dtstart=dtstart_exp,
+                                  until=UNTIL)
+        assert list(rule_without_dtstart) == list(rule_with_dtstart)
 
 
 @pytest.mark.rrule
 @pytest.mark.rrulestr
 @pytest.mark.xfail(reason="rrulestr loses time zone, gh issue #637")
-@freeze_time(datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC))
 def test_generated_aware_dtstart_rrulestr():
-    rrule_without_dtstart = rrule(freq=HOURLY,
-                                  until=datetime(2018, 3, 6, 8, 0,
-                                                 tzinfo=tz.UTC))
-    rrule_r = rrulestr(str(rrule_without_dtstart))
+    now = datetime(2018, 3, 6, 5, 36, tzinfo=tz.UTC)
+    with mock_datetime_now("dateutil.rrule.datetime.datetime", now):
+        rrule_without_dtstart = rrule(freq=HOURLY,
+                                      until=datetime(2018, 3, 6, 8, 0,
+                                                     tzinfo=tz.UTC))
+        rrule_r = rrulestr(str(rrule_without_dtstart))
 
-    assert list(rrule_r) == list(rrule_without_dtstart)
+        assert list(rrule_r) == list(rrule_without_dtstart)
 
 
 @pytest.mark.rruleset

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,24 +7,29 @@ from dateutil import utils
 from dateutil.tz import UTC
 from dateutil.utils import within_delta
 
-from freezegun import freeze_time
+from ._common import mock_datetime_now
 
 NYC = tz.gettz("America/New_York")
 
 
-@freeze_time(datetime(2014, 12, 15, 1, 21, 33, 4003))
 def test_utils_today():
-    assert utils.today() == datetime(2014, 12, 15, 0, 0, 0)
+    now = datetime(2014, 12, 15, 1, 21, 33, 4003)
+    with mock_datetime_now("dateutil.utils.datetime", now):
+        assert utils.today() == datetime(2014, 12, 15, 0, 0, 0)
 
 
-@freeze_time(datetime(2014, 12, 15, 12), tz_offset=5)
 def test_utils_today_tz_info():
-    assert utils.today(NYC) == datetime(2014, 12, 15, 0, 0, 0, tzinfo=NYC)
+    now = datetime(2014, 12, 15, 17, tzinfo=UTC)
+    with mock_datetime_now("dateutil.utils.datetime", now):
+        assert utils.today(NYC) == datetime(2014, 12, 15, 0, 0, 0,
+                                            tzinfo=NYC)
 
 
-@freeze_time(datetime(2014, 12, 15, 23), tz_offset=5)
 def test_utils_today_tz_info_different_day():
-    assert utils.today(UTC) == datetime(2014, 12, 16, 0, 0, 0, tzinfo=UTC)
+    now = datetime(2014, 12, 16, 4, tzinfo=UTC)
+    with mock_datetime_now("dateutil.utils.datetime", now):
+        assert utils.today(UTC) == datetime(2014, 12, 16, 0, 0, 0,
+                                            tzinfo=UTC)
 
 
 def test_utils_default_tz_info_naive():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,15 +21,13 @@ def test_utils_today():
 def test_utils_today_tz_info():
     now = datetime(2014, 12, 15, 17, tzinfo=UTC)
     with mock_datetime_now("dateutil.utils.datetime", now):
-        assert utils.today(NYC) == datetime(2014, 12, 15, 0, 0, 0,
-                                            tzinfo=NYC)
+        assert utils.today(NYC) == datetime(2014, 12, 15, 0, 0, 0, tzinfo=NYC)
 
 
 def test_utils_today_tz_info_different_day():
     now = datetime(2014, 12, 16, 4, tzinfo=UTC)
     with mock_datetime_now("dateutil.utils.datetime", now):
-        assert utils.today(UTC) == datetime(2014, 12, 16, 0, 0, 0,
-                                            tzinfo=UTC)
+        assert utils.today(UTC) == datetime(2014, 12, 16, 0, 0, 0, tzinfo=UTC)
 
 
 def test_utils_default_tz_info_naive():


### PR DESCRIPTION
## Summary of changes

Replace the five freezegun-based tests with a small datetime mock helper in `tests/_common.py`, then remove freezegun from the development requirements and isort configuration. The helper patches only the datetime lookup used by each module and preserves aware, naive, and `isinstance` behavior.

Closes #923

## Verification

- `python -m pytest tests/test_utils.py tests/test_rrule.py -q` — 568 passed, 1 xfailed
- `git diff --check`
- Full suite with the pinned timezone fixture — 2031 passed, 47 skipped, 17 xfailed, plus one pre-existing macOS local-time property failure reproduced against clean `origin/master`

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details