### PR TITLE
chore: declare Python 3.14 support in classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
     Topic :: Software Development :: Libraries
 
 [options]


### PR DESCRIPTION
Add Python 3.14 Trove classifier so packaging metadata reflects current support.