### PR TITLE
fix: round extra fractional-second digits instead of truncating

### DIFF
--- a/changelog.d/1549.bugfix.rst
+++ b/changelog.d/1549.bugfix.rst
@@ -1,0 +1,1 @@
+Round extra fractional-second digits in ``parser.parse`` and ``isoparse`` instead of truncating them. (gh-1545, gh-1546, gh-1549)

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -55,6 +55,26 @@ __all__ = ["parse", "parserinfo", "ParserError"]
 # TODO: pandas.core.tools.datetimes imports this explicitly.  Might be worth
 # making public and/or figuring out if there is something we can
 # take off their plate.
+
+def _round_fraction_to_us(seconds, frac_digits):
+    """Round a fractional-second digit string to microseconds.
+
+    ISO-8601 allows more than 6 fraction digits. Truncating them silently
+    returns the wrong instant (e.g. 0.1234567 -> 123456us instead of 123457).
+    """
+    if not frac_digits:
+        return seconds, 0
+    if len(frac_digits) <= 6:
+        return seconds, int(frac_digits.ljust(6, "0"))
+    microseconds = int(frac_digits[:6])
+    if frac_digits[6] >= "5":
+        microseconds += 1
+    if microseconds >= 1000000:
+        seconds += 1
+        microseconds = 0
+    return seconds, microseconds
+
+
 class _timelex(object):
     # Fractional seconds are sometimes split by a comma
     _split_decimal = re.compile("([.,])")
@@ -1136,7 +1156,8 @@ class parser(object):
             return int(value), 0
         else:
             i, f = value.split(".")
-            return int(i), int(f.ljust(6, "0")[:6])
+            seconds, microseconds = _round_fraction_to_us(int(i), f)
+            return seconds, microseconds
 
     def _to_decimal(self, val):
         try:

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -10,6 +10,7 @@ ISO-8601 specification.
 from datetime import datetime, timedelta, time, date
 import calendar
 from dateutil import tz
+from dateutil.parser._parser import _round_fraction_to_us
 
 from functools import wraps
 
@@ -366,8 +367,12 @@ class isoparser(object):
                 if not frac:
                     continue
 
-                us_str = frac.group(1)[:6]  # Truncate to microseconds
-                components[comp] = int(us_str) * 10**(6 - len(us_str))
+                us_raw = frac.group(1)
+                if isinstance(us_raw, bytes):
+                    us_raw = us_raw.decode('ascii')
+                seconds, microseconds = _round_fraction_to_us(components[2], us_raw)
+                components[2] = seconds
+                components[comp] = microseconds
                 pos += len(frac.group())
 
         if pos < len_str:

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -507,3 +507,13 @@ def test_isotime_raises(isostr, exception):
     iparser = isoparser()
     with pytest.raises(exception):
         iparser.parse_isotime(isostr)
+
+
+def test_isoparse_rounds_fractional_seconds():
+    from datetime import datetime
+    from dateutil.parser import isoparse
+
+    assert isoparse("2020-01-01T00:00:00.1234567").microsecond == 123457
+    assert isoparse("2020-01-01T00:00:00.1234564").microsecond == 123456
+    assert isoparse("2020-01-01T00:00:00.123456").microsecond == 123456
+    assert isoparse("2020-01-01T00:00:00.9999997") == datetime(2020, 1, 1, 0, 0, 1)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -962,3 +962,14 @@ def test_parsererror_repr():
     s = repr(ParserError("Problem with string: %s", "2019-01-01"))
 
     assert s == "ParserError('Problem with string: %s', '2019-01-01')"
+
+
+def test_parse_rounds_fractional_seconds():
+    from datetime import datetime
+    from dateutil.parser import parse
+
+    assert parse("2020-01-01 00:00:00.1234567").microsecond == 123457
+    assert parse("2020-01-01 00:00:00.1234564").microsecond == 123456
+    assert parse("2020-01-01 00:00:00.123456").microsecond == 123456
+    dt = parse("2020-01-01 00:00:00.9999997")
+    assert dt == datetime(2020, 1, 1, 0, 0, 1)


### PR DESCRIPTION
## Summary

`parser.parse` and `isoparse` both dropped digits after the 6th fractional-second place. That returns the wrong instant:

```python
parser.parse("2020-01-01 00:00:00.1234567").microsecond  # was 123456, should be 123457
```

ISO-8601 allows more than 6 fraction digits. This change rounds to the nearest microsecond (half up) and carries into the next second when needed.

Fixes #1546
Fixes #1545

## Test plan

- [x] `test_parse_rounds_fractional_seconds`
- [x] `test_isoparse_rounds_fractional_seconds`