### PR TITLE
Clarify the MLK Day documentation exercise

### DIFF
--- a/changelog.d/1550.doc.rst
+++ b/changelog.d/1550.doc.rst
@@ -1,0 +1,2 @@
+Clarified the Martin Luther King Day exercise to require explicitly specifying
+January. Reported by @pganssle (gh issue #775). Fixed by @nightcityblade (gh pr #1550).

--- a/docs/exercises/index.rst
+++ b/docs/exercises/index.rst
@@ -21,6 +21,9 @@ Martin Luther King Day
 
     How would you generate a :doc:`recurrence rule <../rrule>` that generates Martin Luther King Day, starting from its first observance in 1986?
 
+    **Bonus:** Make sure that the rule explicitly specifies January rather than
+    relying on the month supplied in ``dtstart``.
+
 
 **Test Script**
 
@@ -239,4 +242,3 @@ To solve this exercise, copy-paste this script into a document, change anything 
 .. raw:: html
 
     </details>
-


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

Clarify the Martin Luther King Day exercise with a bonus requirement that the recurrence rule specify January explicitly instead of inferring it from `dtstart`.

Closes #775

### Pull Request Checklist
- [x] Changes have tests
- [x] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md) — N/A for this documentation-only clarification
- [x] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details

## Validation

- `pre-commit run --files docs/exercises/index.rst changelog.d/1550.doc.rst`
- `sphinx-build -W --keep-going -b html ...`
- `.venv/bin/towncrier build --draft`
- `git diff --check upstream/master...HEAD`
