### PR TITLE
Reject ISO week numbers that do not exist in the given year

### DIFF
--- a/changelog.d/1551.bugfix.rst
+++ b/changelog.d/1551.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``isoparse`` accepting ISO week dates with a week number that does not exist in the given year (e.g. ``2021-W53``), which silently rolled over into a date in the following year instead of raising ``ValueError``. Reported by @Ev2geny (gh issue #1236). Fixed by @abhijeet117 (gh pr #1551).

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -305,7 +305,8 @@ class isoparser(object):
             The year in the ISO calendar
 
         :param week:
-            The week in the ISO calendar - range is [1, 53]
+            The week in the ISO calendar - range is [1, 53]. Week 53 is only
+            valid for years that actually have a 53rd ISO week.
 
         :param day:
             The day in the ISO calendar - range is [1 (MON), 7 (SUN)]
@@ -322,6 +323,12 @@ class isoparser(object):
         # Get week 1 for the specific year:
         jan_4 = date(year, 1, 4)   # Week 1 always has January 4th in it
         week_1 = jan_4 - timedelta(days=jan_4.isocalendar()[2] - 1)
+
+        # Not every year has a week 53: December 28th is always in the last
+        # ISO week of the year, so its ISO week number is the number of weeks
+        # in the year.
+        if week > date(year, 12, 28).isocalendar()[1]:
+            raise ValueError('Invalid week {} for year {}'.format(week, year))
 
         # Now add the specific number of weeks and days to get what we want
         week_offset = (week - 1) * 7 + (day - 1)

--- a/src/dateutil/parser/isoparser.py
+++ b/src/dateutil/parser/isoparser.py
@@ -328,7 +328,7 @@ class isoparser(object):
         # ISO week of the year, so its ISO week number is the number of weeks
         # in the year.
         if week > date(year, 12, 28).isocalendar()[1]:
-            raise ValueError('Invalid week {} for year {}'.format(week, year))
+            raise ValueError("Invalid week {} for year {}".format(week, year))
 
         # Now add the specific number of weeks and days to get what we want
         week_offset = (week - 1) * 7 + (day - 1)

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -178,12 +178,16 @@ TIME_ARGS = ('time_args',
         for _t, _tz in it.product([time(0), time(9, 30), time(14, 47)],
                                   TZOFFSETS)))
 
-@pytest.mark.parametrize('isocal,dt_expected',[
-    ((2017, 10), datetime(2017, 3, 6)),
-    ((2020, 1), datetime(2019, 12, 30)),    # ISO year != Cal year
-    ((2004, 53), datetime(2004, 12, 27)),   # Only half the week is in 2014
-    ((2020, 53), datetime(2020, 12, 28)),   # 2020 is a 53-week year
-])
+
+@pytest.mark.parametrize(
+    "isocal,dt_expected",
+    [
+        ((2017, 10), datetime(2017, 3, 6)),
+        ((2020, 1), datetime(2019, 12, 30)),  # ISO year != Cal year
+        ((2004, 53), datetime(2004, 12, 27)),  # Only half the week is in 2014
+        ((2020, 53), datetime(2020, 12, 28)),  # 2020 is a 53-week year
+    ],
+)
 def test_isoweek(isocal, dt_expected):
     # TODO: Figure out how to parametrize this on formats, too
     for fmt in ('{:04d}-W{:02d}', '{:04d}W{:02d}'):
@@ -240,42 +244,43 @@ def test_bytes(isostr, dt):
 
 ###
 # Invalid ISO strings
-@pytest.mark.parametrize('isostr,exception', [
-    ('201', ValueError),                        # ISO string too short
-    ('2012-0425', ValueError),                  # Inconsistent date separators
-    ('201204-25', ValueError),                  # Inconsistent date separators
-    ('20120425T0120:00', ValueError),           # Inconsistent time separators
-    ('20120425T01:2000', ValueError),           # Inconsistent time separators
-    ('14:3015', ValueError),                    # Inconsistent time separator
-    ('20120425T012500-334', ValueError),        # Wrong microsecond separator
-    ('2001-1', ValueError),                     # YYYY-M not valid
-    ('2012-04-9', ValueError),                  # YYYY-MM-D not valid
-    ('201204', ValueError),                     # YYYYMM not valid
-    ('20120411T03:30+', ValueError),            # Time zone too short
-    ('20120411T03:30+1234567', ValueError),     # Time zone too long
-    ('20120411T03:30-25:40', ValueError),       # Time zone invalid
-    ('2012-1a', ValueError),                    # Invalid month
-    ('20120411T03:30+00:60', ValueError),       # Time zone invalid minutes
-    ('20120411T03:30+00:61', ValueError),       # Time zone invalid minutes
-    ('20120411T033030.123456012:00',            # No sign in time zone
-        ValueError),
-    ('2012-W00', ValueError),                   # Invalid ISO week
-    ('2012-W55', ValueError),                   # Invalid ISO week
-    ('2021-W53', ValueError),                   # Week 53 does not exist in 2021
-    ('2021-W53-1', ValueError),                 # Week 53 does not exist in 2021
-    ('2021-W53-7', ValueError),                 # Week 53 does not exist in 2021
-    ('2012-W01-0', ValueError),                 # Invalid ISO week day
-    ('2012-W01-8', ValueError),                 # Invalid ISO week day
-    ('2013-000', ValueError),                   # Invalid ordinal day
-    ('2013-366', ValueError),                   # Invalid ordinal day
-    ('2013366', ValueError),                    # Invalid ordinal day
-    ('2014-03-12Т12:30:14', ValueError),        # Cyrillic T
-    ('2014-04-21T24:00:01', ValueError),        # Invalid use of 24 for midnight
-    ('2014_W01-1', ValueError),                 # Invalid separator
-    ('2014W01-1', ValueError),                  # Inconsistent use of dashes
-    ('2014-W011', ValueError),                  # Inconsistent use of dashes
-
-])
+@pytest.mark.parametrize(
+    "isostr,exception",
+    [
+        ("201", ValueError),  # ISO string too short
+        ("2012-0425", ValueError),  # Inconsistent date separators
+        ("201204-25", ValueError),  # Inconsistent date separators
+        ("20120425T0120:00", ValueError),  # Inconsistent time separators
+        ("20120425T01:2000", ValueError),  # Inconsistent time separators
+        ("14:3015", ValueError),  # Inconsistent time separator
+        ("20120425T012500-334", ValueError),  # Wrong microsecond separator
+        ("2001-1", ValueError),  # YYYY-M not valid
+        ("2012-04-9", ValueError),  # YYYY-MM-D not valid
+        ("201204", ValueError),  # YYYYMM not valid
+        ("20120411T03:30+", ValueError),  # Time zone too short
+        ("20120411T03:30+1234567", ValueError),  # Time zone too long
+        ("20120411T03:30-25:40", ValueError),  # Time zone invalid
+        ("2012-1a", ValueError),  # Invalid month
+        ("20120411T03:30+00:60", ValueError),  # Time zone invalid minutes
+        ("20120411T03:30+00:61", ValueError),  # Time zone invalid minutes
+        ("20120411T033030.123456012:00", ValueError),  # No sign in time zone
+        ("2012-W00", ValueError),  # Invalid ISO week
+        ("2012-W55", ValueError),  # Invalid ISO week
+        ("2021-W53", ValueError),  # Week 53 does not exist in 2021
+        ("2021-W53-1", ValueError),  # Week 53 does not exist in 2021
+        ("2021-W53-7", ValueError),  # Week 53 does not exist in 2021
+        ("2012-W01-0", ValueError),  # Invalid ISO week day
+        ("2012-W01-8", ValueError),  # Invalid ISO week day
+        ("2013-000", ValueError),  # Invalid ordinal day
+        ("2013-366", ValueError),  # Invalid ordinal day
+        ("2013366", ValueError),  # Invalid ordinal day
+        ("2014-03-12Т12:30:14", ValueError),  # Cyrillic T
+        ("2014-04-21T24:00:01", ValueError),  # Invalid use of 24 for midnight
+        ("2014_W01-1", ValueError),  # Invalid separator
+        ("2014W01-1", ValueError),  # Inconsistent use of dashes
+        ("2014-W011", ValueError),  # Inconsistent use of dashes
+    ],
+)
 def test_iso_raises(isostr, exception):
     with pytest.raises(exception):
         isoparse(isostr)

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -182,6 +182,7 @@ TIME_ARGS = ('time_args',
     ((2017, 10), datetime(2017, 3, 6)),
     ((2020, 1), datetime(2019, 12, 30)),    # ISO year != Cal year
     ((2004, 53), datetime(2004, 12, 27)),   # Only half the week is in 2014
+    ((2020, 53), datetime(2020, 12, 28)),   # 2020 is a 53-week year
 ])
 def test_isoweek(isocal, dt_expected):
     # TODO: Figure out how to parametrize this on formats, too
@@ -260,6 +261,9 @@ def test_bytes(isostr, dt):
         ValueError),
     ('2012-W00', ValueError),                   # Invalid ISO week
     ('2012-W55', ValueError),                   # Invalid ISO week
+    ('2021-W53', ValueError),                   # Week 53 does not exist in 2021
+    ('2021-W53-1', ValueError),                 # Week 53 does not exist in 2021
+    ('2021-W53-7', ValueError),                 # Week 53 does not exist in 2021
     ('2012-W01-0', ValueError),                 # Invalid ISO week day
     ('2012-W01-8', ValueError),                 # Invalid ISO week day
     ('2013-000', ValueError),                   # Invalid ordinal day


### PR DESCRIPTION
## Description

`isoparse(2021-W53-1)` currently returns `2022-01-03`: week 53 does not exist in 2021, but `_calculate_weekdate` only checked the 1-53 range and silently rolled over into the next year, unlike the equivalent CPython APIs (`date.fromisocalendar`, which raises for this input).

`_calculate_weekdate` now verifies that the requested week exists in the ISO calendar of the given year (the number of ISO weeks is the ISO week number of December 28th) and raises a `ValueError` otherwise.

Fixes #1236.

## Tests

Reproduced on master: `isoparse(2021-W53-1)` returned `2022-01-03`. Added regression cases for `2021-W53`, `2021-W53-1` and `2021-W53-7` raising `ValueError`, and a valid case for `2020-W53` (a 53-week year). Full test suite passes with the same result as master apart from the new tests.