### PR TITLE
Re-enable testEqualAmbiguousComparison on Python 3.7+

### DIFF
--- a/changelog.d/1552.misc.rst
+++ b/changelog.d/1552.misc.rst
@@ -1,0 +1,1 @@
+Re-enabled ``testEqualAmbiguousComparison`` on Python 3.7+ (it guarded a CPython 3.6-era fold-comparison bug fixed in 3.7).

--- a/tests/test_tz.py
+++ b/tests/test_tz.py
@@ -416,7 +416,7 @@ class TzFoldMixin(object):
         self._test_imaginary_time(datetime(2012, 4, 1, 3, 30),
                                   'Australia/Sydney', True)
 
-    @unittest.skip("Known failure in Python 3.6.")
+    @unittest.skipIf(sys.version_info < (3, 7), "Known failure in Python 3.6.")
     def testEqualAmbiguousComparison(self):
         tzname = self._get_tzname('Australia/Sydney')
 


### PR DESCRIPTION
`TzFoldMixin.testEqualAmbiguousComparison` is skipped unconditionally:

```python
@unittest.skip("Known failure in Python 3.6.")
```

The failure it guards against was a CPython 3.6-era bug in comparing ambiguous (fold) datetimes across separately-instantiated copies of the same zone (PEP 495 fold semantics), fixed in CPython 3.7+. On every supported modern Python the assertion holds, so the test is dead coverage for six subclasses (`GettzTest`, `ZoneInfoGettzTest`, `TZRangeTest`, `TZStrTest`, `TZICalTest`, `TzLocalNixTest`).

This switches the blanket skip to a version guard so the test runs again on 3.7+ while still skipping on the legacy interpreters CI continues to test:

```python
@unittest.skipIf(sys.version_info < (3, 7), "Known failure in Python 3.6.")
```

(`sys` is already imported.) The re-enabled test uses real `gettz(...)` zone objects, so it exercises the actual fold-comparison path — CI on this PR confirms it passes across the modern matrix.
