### PR TITLE
Reject non-str reads in the tokenizer instead of looping forever

### DIFF
--- a/changelog.d/1428.bugfix.rst
+++ b/changelog.d/1428.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``parser.parse()`` looping forever and allocating memory without bound when passed a stream-like object whose ``read()`` method never returns an empty string, such as a ``MagicMock``. It now raises a ``TypeError`` as soon as a non-``str`` value comes back from ``read()``. Reported by @pete-kirkham (gh issue #1428). Fixed by @afonsojanu (gh pr #1553).

--- a/src/dateutil/parser/_parser.py
+++ b/src/dateutil/parser/_parser.py
@@ -74,6 +74,21 @@ class _timelex(object):
         self.tokenstack = []
         self.eof = False
 
+    def _read_char(self):
+        nextchar = self.instream.read(1)
+        if not isinstance(nextchar, text_type):
+            # The instream duck-type check in __init__ only looks for a
+            # `read` attribute, which passes for anything that auto-vivifies
+            # attributes (e.g. a MagicMock accidentally reaching parse()).
+            # Left unchecked, a stream like that never yields a falsy value,
+            # so the tokenizer loop below never terminates and keeps
+            # allocating tokens until memory runs out.
+            raise TypeError(
+                "invalid stream: instream.read() must return str, got "
+                "{itype} instead".format(itype=nextchar.__class__.__name__)
+            )
+        return nextchar
+
     def get_token(self):
         """
         This function breaks the time string into lexical units (tokens), which
@@ -103,9 +118,9 @@ class _timelex(object):
             if self.charstack:
                 nextchar = self.charstack.pop(0)
             else:
-                nextchar = self.instream.read(1)
+                nextchar = self._read_char()
                 while nextchar == '\x00':
-                    nextchar = self.instream.read(1)
+                    nextchar = self._read_char()
 
             if not nextchar:
                 self.eof = True

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,22 +2,24 @@
 from __future__ import unicode_literals
 
 import itertools
-from datetime import datetime, timedelta
-import unittest
 import sys
-
-from dateutil import tz
-from dateutil.tz import tzoffset
-from dateutil.parser import parse, parserinfo
-from dateutil.parser import ParserError
-from dateutil.parser import UnknownTimezoneWarning
-
-from ._common import TZEnvContext
-
-from six import assertRaisesRegex, PY2
+import unittest
+from datetime import datetime, timedelta
 from io import StringIO
 
 import pytest
+from six import PY2, assertRaisesRegex
+
+from dateutil import tz
+from dateutil.parser import (
+    ParserError,
+    UnknownTimezoneWarning,
+    parse,
+    parserinfo,
+)
+from dateutil.tz import tzoffset
+
+from ._common import TZEnvContext
 
 # Platform info
 IS_WIN = sys.platform.startswith('win')
@@ -321,6 +323,20 @@ class TestInputTypes(object):
         expected = datetime(2014, 1, 19)
         assert res == expected
 
+    def test_mock_stream_rejected(self):
+        # GH#1428: a MagicMock has a `read` attribute (it auto-vivifies
+        # any attribute access), so it used to pass the duck-typing check
+        # in _timelex.__init__ and then feed non-str tokens into the
+        # tokenizer forever, since a MagicMock is never falsy. This should
+        # fail fast with a clear TypeError instead of looping.
+        try:
+            from unittest.mock import MagicMock
+        except ImportError:
+            from mock import MagicMock
+
+        with pytest.raises(TypeError):
+            parse(MagicMock())
+
     def test_parse_stream(self):
         dstr = StringIO('2014 January 19')
 
@@ -614,7 +630,7 @@ class ParserTest(unittest.TestCase):
 
     def testCustomParserInfo(self):
         # Custom parser info wasn't working, as Michael Elsdörfer discovered.
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class myparserinfo(parserinfo):
             MONTHS = parserinfo.MONTHS[:]
@@ -627,7 +643,7 @@ class ParserTest(unittest.TestCase):
         # Horacio Hoyos discovered that day names shorter than 3 characters,
         # for example two letter German day name abbreviations, don't work:
         # https://github.com/dateutil/dateutil/issues/343
-        from dateutil.parser import parserinfo, parser
+        from dateutil.parser import parser, parserinfo
 
         class GermanParserInfo(parserinfo):
             WEEKDAYS = [("Mo", "Montag"),


### PR DESCRIPTION
Fixes #1428.

If something that isn't a string or a real character stream reaches `parse()`, `_timelex.__init__` only checks for a `read` attribute before accepting it. That passes for anything that auto-vivifies attributes, like a `MagicMock`, which is exactly how this got reported: a test suite accidentally passed a mock object into `parse()` instead of a real value.

Once that happens, `get_token()` calls `self.instream.read(1)` in a loop waiting for a falsy value to signal EOF. A `MagicMock` is never falsy and never returns a real empty string, so the loop never terminates, and it keeps allocating memory the whole time until the process runs out and the test suite just hangs with no useful error, which is what made this so hard to track down originally.

`_timelex` now checks that `read()` actually returned a `str` on every call, and raises a clear `TypeError` the moment it doesn't, instead of looping.

Added a regression test that reproduces the exact scenario from the issue (a `MagicMock` reaching `parse()`), verified against both the fixed and unfixed code with a bounded subprocess timeout, since the whole point of the bug is that it doesn't fail cleanly without the fix.