### PR TITLE
rrule: seek daily between queries near the lower bound

### DIFF
--- a/changelog.d/1557.feature.rst
+++ b/changelog.d/1557.feature.rst
@@ -1,0 +1,3 @@
+Improved the performance of ``rrule.between()`` for uncached daily recurrence
+rules whose lower bound is far from ``DTSTART``. Reported by @jelly (gh issue
+#654). Fixed by @mercury125 (gh pr #1557).

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -110,6 +110,10 @@ class rrulebase(object):
         else:
             return self._iter_cached()
 
+    def _iter_from(self, dt):
+        """Return an iterator positioned near *dt* when supported."""
+        return iter(self)
+
     def _invalidate_cache(self):
         if self._cache is not None:
             self._cache = []
@@ -275,6 +279,8 @@ class rrulebase(object):
         list, if they are found in the recurrence set. """
         if self._cache_complete:
             gen = self._cache
+        elif self._cache is None:
+            gen = self._iter_from(after)
         else:
             gen = self
         started = False
@@ -772,6 +778,36 @@ class rrule(rrulebase):
         new_kwargs.update(self._original_rule)
         new_kwargs.update(kwargs)
         return rrule(**new_kwargs)
+
+    def _iter_from(self, dt):
+        # between() discards every occurrence through its lower bound.  For a
+        # daily rule with no COUNT, move an equivalent rule near the last
+        # aligned interval instead of replaying from DTSTART.
+        if (type(self) is not rrule or
+                self._freq != DAILY or self._count is not None or
+                not isinstance(dt, datetime.datetime) or
+                not isinstance(self._interval, integer_types) or
+                self._interval <= 0):
+            return self._iter()
+
+        dtstart = self._dtstart
+        if (dt.tzinfo is None) != (dtstart.tzinfo is None):
+            return self._iter()
+
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(dtstart.tzinfo)
+
+        elapsed_days = (dt.date() - dtstart.date()).days
+        elapsed_intervals = elapsed_days // self._interval
+        if elapsed_intervals <= 0:
+            return self._iter()
+
+        # Start one complete interval earlier.  The iterator suppresses times
+        # before DTSTART on its first day, which could otherwise drop an
+        # explicit BYHOUR value that is still after the between() bound.
+        seek_start = dtstart + datetime.timedelta(
+            days=(elapsed_intervals - 1) * self._interval)
+        return self.replace(dtstart=seek_start)._iter()
 
     def _iter(self):
         year, month, day, hour, minute, second, weekday, yearday, _ = \

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -791,11 +791,30 @@ class rrule(rrulebase):
             return self._iter()
 
         dtstart = self._dtstart
-        if (dt.tzinfo is None) != (dtstart.tzinfo is None):
-            return self._iter()
+        if dt.tzinfo is not dtstart.tzinfo:
+            dt_offset = dt.utcoffset()
+            dtstart_offset = dtstart.utcoffset()
 
-        if dt.tzinfo is not None:
-            dt = dt.astimezone(dtstart.tzinfo)
+            # Python treats a datetime whose utcoffset() is None as naive,
+            # even when it has a tzinfo object.  Mixed naive/aware values retain
+            # the legacy comparison behavior; two naive values use wall time.
+            if (dt_offset is None) != (dtstart_offset is None):
+                return self._iter()
+
+            if dt_offset is not None:
+                # There is nothing to seek past when the bound precedes
+                # DTSTART.
+                if dt <= dtstart:
+                    return self._iter()
+
+                # astimezone() may overflow while normalizing through UTC near
+                # datetime's representational limits, even when source and
+                # target offsets are equal.  Keep boundary years outside the
+                # seek optimization's supported domain.
+                if dt.year in (datetime.MINYEAR, datetime.MAXYEAR):
+                    return self._iter()
+
+                dt = dt.astimezone(dtstart.tzinfo)
 
         elapsed_days = (dt.date() - dtstart.date()).days
         elapsed_intervals = elapsed_days // self._interval

--- a/src/dateutil/rrule.py
+++ b/src/dateutil/rrule.py
@@ -783,11 +783,14 @@ class rrule(rrulebase):
         # between() discards every occurrence through its lower bound.  For a
         # daily rule with no COUNT, move an equivalent rule near the last
         # aligned interval instead of replaying from DTSTART.
-        if (type(self) is not rrule or
-                self._freq != DAILY or self._count is not None or
-                not isinstance(dt, datetime.datetime) or
-                not isinstance(self._interval, integer_types) or
-                self._interval <= 0):
+        if (
+            type(self) is not rrule
+            or self._freq != DAILY
+            or self._count is not None
+            or not isinstance(dt, datetime.datetime)
+            or not isinstance(self._interval, integer_types)
+            or self._interval <= 0
+        ):
             return self._iter()
 
         dtstart = self._dtstart
@@ -825,7 +828,8 @@ class rrule(rrulebase):
         # before DTSTART on its first day, which could otherwise drop an
         # explicit BYHOUR value that is still after the between() bound.
         seek_start = dtstart + datetime.timedelta(
-            days=(elapsed_intervals - 1) * self._interval)
+            days=(elapsed_intervals - 1) * self._interval
+        )
         return self.replace(dtstart=seek_start)._iter()
 
     def _iter(self):

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -118,12 +118,15 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset)
 
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
-@pytest.mark.parametrize('dt', tuple(DATETIMES))
-@pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
-@pytest.mark.parametrize('tzoffset', TZOFFSETS)
-@pytest.mark.parametrize('precision', list(range(3, 7)))
+
+
+@pytest.mark.parametrize("dt", tuple(DATETIMES))
+@pytest.mark.parametrize("date_fmt", YMD_FMTS)
+@pytest.mark.parametrize(
+    "time_fmt", tuple(x + sep + "%f" for x in HMS_FMTS for sep in ".,")
+)
+@pytest.mark.parametrize("tzoffset", TZOFFSETS)
+@pytest.mark.parametrize("precision", list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
     # Truncate the microseconds to the desired precision for the representation
     dt = dt.replace(microsecond=int(round(dt.microsecond, precision-6)))

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -2592,6 +2592,72 @@ class RRuleTest(unittest.TestCase):
                           datetime(1997, 9, 5, 9, 0),
                           datetime(1997, 9, 6, 9, 0)])
 
+    def testBetweenDailyDistantStart(self):
+        rr = rrule(DAILY,
+                   dtstart=datetime(2000, 1, 1),
+                   until=datetime(2030, 1, 1))
+
+        self.assertEqual(
+            rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1)),
+            [datetime(2020, 1, day) for day in range(2, 32)])
+
+    def testBetweenDailyDistantStartInterval(self):
+        rr = rrule(DAILY,
+                   interval=3,
+                   dtstart=datetime(2000, 1, 2, 9),
+                   until=datetime(2030, 1, 1))
+
+        self.assertEqual(
+            rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1)),
+            [datetime(2020, 1, day, 9) for day in range(2, 30, 3)])
+
+    def testBetweenDailyDistantStartEarlierByHour(self):
+        rr = rrule(DAILY,
+                   byhour=(8, 20),
+                   dtstart=datetime(2000, 1, 1, 9),
+                   until=datetime(2030, 1, 1))
+
+        self.assertEqual(
+            rr.between(datetime(2020, 1, 1, 7),
+                       datetime(2020, 1, 1, 21)),
+            [datetime(2020, 1, 1, 8), datetime(2020, 1, 1, 20)])
+
+    def testBetweenDailyDistantStartDifferentTimezone(self):
+        nyc = tz.gettz('America/New_York')
+        rr = rrule(DAILY,
+                   dtstart=datetime(2000, 1, 1, 23, 30, tzinfo=nyc),
+                   until=datetime(2030, 1, 1, 23, 30, tzinfo=nyc))
+
+        self.assertEqual(
+            rr.between(datetime(2020, 7, 2, 2, tzinfo=tz.UTC),
+                       datetime(2020, 7, 2, 5, tzinfo=tz.UTC)),
+            [datetime(2020, 7, 1, 23, 30, tzinfo=nyc)])
+
+    def testBetweenDailyDistantStartPopulatesCache(self):
+        start = datetime(2000, 1, 1)
+        rr = rrule(DAILY,
+                   dtstart=start,
+                   until=datetime(2030, 1, 1),
+                   cache=True)
+
+        rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1))
+
+        self.assertEqual(rr._cache[0], start)
+        self.assertGreater(len(rr._cache), 7000)
+
+    def testBetweenDailyDistantStartPreservesSubclassIterator(self):
+        expected = datetime(2020, 1, 15)
+
+        class CustomRRule(rrule):
+            def _iter(self):
+                yield expected
+
+        rr = CustomRRule(DAILY, dtstart=datetime(2000, 1, 1))
+
+        self.assertEqual(
+            rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1)),
+            [expected])
+
     def testCachePre(self):
         rr = rrule(DAILY, count=15, cache=True,
                    dtstart=datetime(1997, 9, 2, 9, 0))

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -2633,6 +2633,49 @@ class RRuleTest(unittest.TestCase):
                        datetime(2020, 7, 2, 5, tzinfo=tz.UTC)),
             [datetime(2020, 7, 1, 23, 30, tzinfo=nyc)])
 
+    def testBetweenDailyDifferentTimezoneAtDatetimeMin(self):
+        west = tz.tzoffset('west-14', -14 * 60 * 60)
+        rr = rrule(DAILY,
+                   dtstart=datetime(1, 1, 1, tzinfo=west),
+                   until=datetime(1, 1, 10, tzinfo=west))
+
+        self.assertEqual(
+            rr.between(datetime.min.replace(tzinfo=tz.UTC),
+                       datetime(1, 1, 3, tzinfo=tz.UTC)),
+            [datetime(1, 1, day, tzinfo=west) for day in (1, 2)])
+
+    def testBetweenDailyDifferentTimezoneAtDatetimeMax(self):
+        east = tz.tzoffset('east-14', 14 * 60 * 60)
+        rr = rrule(DAILY,
+                   dtstart=datetime(9999, 12, 20, tzinfo=east),
+                   until=datetime.max.replace(tzinfo=east))
+
+        self.assertEqual(
+            rr.between(datetime.max.replace(tzinfo=tz.UTC),
+                       datetime.max.replace(tzinfo=tz.UTC)),
+            [])
+
+    def testBetweenDailyDifferentFloatingTimezones(self):
+        from datetime import tzinfo
+
+        class FloatingTZ(tzinfo):
+            def utcoffset(self, dt):
+                return None
+
+            def dst(self, dt):
+                return None
+
+        start_tz = FloatingTZ()
+        bound_tz = FloatingTZ()
+        rr = rrule(DAILY,
+                   dtstart=datetime(2000, 1, 1, tzinfo=start_tz),
+                   until=datetime(2030, 1, 1, tzinfo=start_tz))
+
+        self.assertEqual(
+            rr.between(datetime(2020, 1, 1, tzinfo=bound_tz),
+                       datetime(2020, 1, 3, tzinfo=bound_tz)),
+            [datetime(2020, 1, 2, tzinfo=start_tz)])
+
     def testBetweenDailyDistantStartPopulatesCache(self):
         start = datetime(2000, 1, 1)
         rr = rrule(DAILY,

--- a/tests/test_rrule.py
+++ b/tests/test_rrule.py
@@ -2593,67 +2593,88 @@ class RRuleTest(unittest.TestCase):
                           datetime(1997, 9, 6, 9, 0)])
 
     def testBetweenDailyDistantStart(self):
-        rr = rrule(DAILY,
-                   dtstart=datetime(2000, 1, 1),
-                   until=datetime(2030, 1, 1))
+        rr = rrule(
+            DAILY, dtstart=datetime(2000, 1, 1), until=datetime(2030, 1, 1)
+        )
 
         self.assertEqual(
             rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1)),
-            [datetime(2020, 1, day) for day in range(2, 32)])
+            [datetime(2020, 1, day) for day in range(2, 32)],
+        )
 
     def testBetweenDailyDistantStartInterval(self):
-        rr = rrule(DAILY,
-                   interval=3,
-                   dtstart=datetime(2000, 1, 2, 9),
-                   until=datetime(2030, 1, 1))
+        rr = rrule(
+            DAILY,
+            interval=3,
+            dtstart=datetime(2000, 1, 2, 9),
+            until=datetime(2030, 1, 1),
+        )
 
         self.assertEqual(
             rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1)),
-            [datetime(2020, 1, day, 9) for day in range(2, 30, 3)])
+            [datetime(2020, 1, day, 9) for day in range(2, 30, 3)],
+        )
 
     def testBetweenDailyDistantStartEarlierByHour(self):
-        rr = rrule(DAILY,
-                   byhour=(8, 20),
-                   dtstart=datetime(2000, 1, 1, 9),
-                   until=datetime(2030, 1, 1))
+        rr = rrule(
+            DAILY,
+            byhour=(8, 20),
+            dtstart=datetime(2000, 1, 1, 9),
+            until=datetime(2030, 1, 1),
+        )
 
         self.assertEqual(
-            rr.between(datetime(2020, 1, 1, 7),
-                       datetime(2020, 1, 1, 21)),
-            [datetime(2020, 1, 1, 8), datetime(2020, 1, 1, 20)])
+            rr.between(datetime(2020, 1, 1, 7), datetime(2020, 1, 1, 21)),
+            [datetime(2020, 1, 1, 8), datetime(2020, 1, 1, 20)],
+        )
 
     def testBetweenDailyDistantStartDifferentTimezone(self):
-        nyc = tz.gettz('America/New_York')
-        rr = rrule(DAILY,
-                   dtstart=datetime(2000, 1, 1, 23, 30, tzinfo=nyc),
-                   until=datetime(2030, 1, 1, 23, 30, tzinfo=nyc))
+        nyc = tz.gettz("America/New_York")
+        rr = rrule(
+            DAILY,
+            dtstart=datetime(2000, 1, 1, 23, 30, tzinfo=nyc),
+            until=datetime(2030, 1, 1, 23, 30, tzinfo=nyc),
+        )
 
         self.assertEqual(
-            rr.between(datetime(2020, 7, 2, 2, tzinfo=tz.UTC),
-                       datetime(2020, 7, 2, 5, tzinfo=tz.UTC)),
-            [datetime(2020, 7, 1, 23, 30, tzinfo=nyc)])
+            rr.between(
+                datetime(2020, 7, 2, 2, tzinfo=tz.UTC),
+                datetime(2020, 7, 2, 5, tzinfo=tz.UTC),
+            ),
+            [datetime(2020, 7, 1, 23, 30, tzinfo=nyc)],
+        )
 
     def testBetweenDailyDifferentTimezoneAtDatetimeMin(self):
-        west = tz.tzoffset('west-14', -14 * 60 * 60)
-        rr = rrule(DAILY,
-                   dtstart=datetime(1, 1, 1, tzinfo=west),
-                   until=datetime(1, 1, 10, tzinfo=west))
+        west = tz.tzoffset("west-14", -14 * 60 * 60)
+        rr = rrule(
+            DAILY,
+            dtstart=datetime(1, 1, 1, tzinfo=west),
+            until=datetime(1, 1, 10, tzinfo=west),
+        )
 
         self.assertEqual(
-            rr.between(datetime.min.replace(tzinfo=tz.UTC),
-                       datetime(1, 1, 3, tzinfo=tz.UTC)),
-            [datetime(1, 1, day, tzinfo=west) for day in (1, 2)])
+            rr.between(
+                datetime.min.replace(tzinfo=tz.UTC),
+                datetime(1, 1, 3, tzinfo=tz.UTC),
+            ),
+            [datetime(1, 1, day, tzinfo=west) for day in (1, 2)],
+        )
 
     def testBetweenDailyDifferentTimezoneAtDatetimeMax(self):
-        east = tz.tzoffset('east-14', 14 * 60 * 60)
-        rr = rrule(DAILY,
-                   dtstart=datetime(9999, 12, 20, tzinfo=east),
-                   until=datetime.max.replace(tzinfo=east))
+        east = tz.tzoffset("east-14", 14 * 60 * 60)
+        rr = rrule(
+            DAILY,
+            dtstart=datetime(9999, 12, 20, tzinfo=east),
+            until=datetime.max.replace(tzinfo=east),
+        )
 
         self.assertEqual(
-            rr.between(datetime.max.replace(tzinfo=tz.UTC),
-                       datetime.max.replace(tzinfo=tz.UTC)),
-            [])
+            rr.between(
+                datetime.max.replace(tzinfo=tz.UTC),
+                datetime.max.replace(tzinfo=tz.UTC),
+            ),
+            [],
+        )
 
     def testBetweenDailyDifferentFloatingTimezones(self):
         from datetime import tzinfo
@@ -2667,21 +2688,23 @@ class RRuleTest(unittest.TestCase):
 
         start_tz = FloatingTZ()
         bound_tz = FloatingTZ()
-        rr = rrule(DAILY,
-                   dtstart=datetime(2000, 1, 1, tzinfo=start_tz),
-                   until=datetime(2030, 1, 1, tzinfo=start_tz))
+        rr = rrule(
+            DAILY,
+            dtstart=datetime(2000, 1, 1, tzinfo=start_tz),
+            until=datetime(2030, 1, 1, tzinfo=start_tz),
+        )
 
         self.assertEqual(
-            rr.between(datetime(2020, 1, 1, tzinfo=bound_tz),
-                       datetime(2020, 1, 3, tzinfo=bound_tz)),
-            [datetime(2020, 1, 2, tzinfo=start_tz)])
+            rr.between(
+                datetime(2020, 1, 1, tzinfo=bound_tz),
+                datetime(2020, 1, 3, tzinfo=bound_tz),
+            ),
+            [datetime(2020, 1, 2, tzinfo=start_tz)],
+        )
 
     def testBetweenDailyDistantStartPopulatesCache(self):
         start = datetime(2000, 1, 1)
-        rr = rrule(DAILY,
-                   dtstart=start,
-                   until=datetime(2030, 1, 1),
-                   cache=True)
+        rr = rrule(DAILY, dtstart=start, until=datetime(2030, 1, 1), cache=True)
 
         rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1))
 
@@ -2698,8 +2721,8 @@ class RRuleTest(unittest.TestCase):
         rr = CustomRRule(DAILY, dtstart=datetime(2000, 1, 1))
 
         self.assertEqual(
-            rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1)),
-            [expected])
+            rr.between(datetime(2020, 1, 1), datetime(2020, 2, 1)), [expected]
+        )
 
     def testCachePre(self):
         rr = rrule(DAILY, count=15, cache=True,


### PR DESCRIPTION
Fixes #654

## Summary

- let uncached `between()` queries ask an rrule for an iterator positioned near the lower bound
- seek DAILY rules without `COUNT` to the preceding aligned interval instead of replaying every occurrence from `DTSTART`
- retain the existing path for cached rules, subclasses, incompatible timezones, and unsupported recurrence shapes
- cover distant starts, multi-day intervals, explicit earlier `BYHOUR` values, timezone conversion, cache population, and subclass behavior

## Performance

For the issue's 20-year DAILY recurrence, measured with 100 loops and the best of 7 runs:

| Version | Time per `between()` call |
| --- | ---: |
| Current `master` | 7.49 ms |
| This change | 42.3 us |

This is approximately a 177x speedup on the test machine.

## Validation

- `tests/test_rrule.py`: 567 passed, 1 expected failure
- full non-timezone test/docs run: 1658 passed, 3 skipped, 16 expected failures
- differential check: all 384 generated DAILY rule cases matched the existing cached-reference behavior

## Disclosure

This change was developed with Codex assistance; the commit records that assistance with an `Assisted-by` trailer.
