### PR TITLE
tests: use a list instead of a generator for test_ymd_hms_micro parametrize

### DIFF
--- a/changelog.d/1558.misc.rst
+++ b/changelog.d/1558.misc.rst
@@ -1,0 +1,1 @@
+Fixed test collection aborting under pytest 8.4 by passing a list, rather than a generator expression, to the ``test_ymd_hms_micro`` parametrize. Fixed by @Osamaali313 (gh pr #1558).

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -120,8 +120,8 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
 @pytest.mark.parametrize('dt', tuple(DATETIMES))
 @pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
+@pytest.mark.parametrize('time_fmt', [x + sep + '%f' for x in HMS_FMTS
+                                      for sep in '.,'])
 @pytest.mark.parametrize('tzoffset', TZOFFSETS)
 @pytest.mark.parametrize('precision', list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):


### PR DESCRIPTION
CI is currently red on `master` (and therefore on every open PR) at test **collection**:

```
ERROR tests/test_isoparser.py - PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
Test: tests/test_isoparser.py::test_ymd_hms_micro, argvalues type: generator
!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!
```

`test_ymd_hms_micro` passes a **generator expression** as its `time_fmt` values:

```python
@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
                                      for sep in '.,'))
```

pytest 8.4 turned "passing a non-Collection iterable to parametrize" into a `PytestRemovedIn10Warning`, and the suite runs under `filterwarnings = error` (setup.cfg), so that warning aborts collection of the **entire** `tests/` tree — which is why the whole matrix (all Python versions × all OSes) fails.

Fix: make it a list comprehension so the values are a real collection. No behavioural change — same parametrization.

Verified in a clean venv: before, `pytest tests/test_isoparser.py --co` aborts with 0 collected; after, it collects 568 tests. This is the only generator-expression parametrize in the suite (`grep` across `tests/`), so it fully unblocks collection.
