### PR TITLE
Fix timezone property test semantics

### DIFF
--- a/tests/property/test_tz_prop.py
+++ b/tests/property/test_tz_prop.py
@@ -7,8 +7,9 @@ from hypothesis import strategies as st
 
 from dateutil import tz
 
-EPOCHALYPSE = datetime.fromtimestamp(2147483647)
-NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
+EPOCH = datetime(1970, 1, 1)
+EPOCHALYPSE = EPOCH + timedelta(seconds=2147483647)
+NEGATIVE_EPOCHALYPSE = EPOCH - timedelta(seconds=2147483648)
 
 
 @pytest.mark.gettz
@@ -24,8 +25,11 @@ NEGATIVE_EPOCHALYPSE = datetime.fromtimestamp(0) - timedelta(seconds=2147483648)
         timezones=st.just(tz.UTC),
     )
 )
-@example(dt=datetime(2005, 10, 30, 1, 15))  # Ambiguous in US time zones
-@example(dt=datetime(1901, 12, 13, 18, 19, 3))  # Very old
+@example(
+    dt=datetime(2005, 10, 30, 5, 15, tzinfo=tz.UTC)
+)  # Ambiguous in US time zones
+@example(dt=datetime(1975, 10, 26, 5, tzinfo=tz.UTC))  # Aware ambiguous time
+@example(dt=NEGATIVE_EPOCHALYPSE.replace(tzinfo=tz.UTC))  # Very old
 def test_gettz_returns_local(gettz_arg, dt):
     act_tz = tz.gettz(gettz_arg)
     if isinstance(act_tz, tz.tzlocal):
@@ -48,8 +52,4 @@ def test_gettz_returns_local(gettz_arg, dt):
     ):
         assert dt_act == dt_exp
     else:
-        assert (
-            tz.enfold(dt, fold=0).astimezone().utcoffset()
-            != tz.enfold(dt, fold=1).astimezone().utcoffset()
-        )
         assert dt_act != dt_exp

--- a/tests/test_isoparser.py
+++ b/tests/test_isoparser.py
@@ -118,12 +118,15 @@ def test_ymd_hms(dt, date_fmt, time_fmt, tzoffset):
     _isoparse_date_and_time(dt, date_fmt, time_fmt, tzoffset)
 
 DATETIMES = [datetime(2017, 11, 27, 6, 14, 30, 123456)]
-@pytest.mark.parametrize('dt', tuple(DATETIMES))
-@pytest.mark.parametrize('date_fmt', YMD_FMTS)
-@pytest.mark.parametrize('time_fmt', (x + sep + '%f' for x in HMS_FMTS
-                                      for sep in '.,'))
-@pytest.mark.parametrize('tzoffset', TZOFFSETS)
-@pytest.mark.parametrize('precision', list(range(3, 7)))
+
+
+@pytest.mark.parametrize("dt", tuple(DATETIMES))
+@pytest.mark.parametrize("date_fmt", YMD_FMTS)
+@pytest.mark.parametrize(
+    "time_fmt", tuple(x + sep + "%f" for x in HMS_FMTS for sep in ".,")
+)
+@pytest.mark.parametrize("tzoffset", TZOFFSETS)
+@pytest.mark.parametrize("precision", list(range(3, 7)))
 def test_ymd_hms_micro(dt, date_fmt, time_fmt, tzoffset, precision):
     # Truncate the microseconds to the desired precision for the representation
     dt = dt.replace(microsecond=int(round(dt.microsecond, precision-6)))


### PR DESCRIPTION
## Summary

- Construct epoch boundary cases with timezone-independent datetime arithmetic.
- Keep explicit property-test examples inside the UTC-aware input domain.
- Remove a fold assertion that changed fold on a UTC datetime and therefore could not change its offset.
- Materialize the isoparser parameter iterable for pytest 9.1 compatibility.

## Rationale

The timezone property test mixed UTC-aware generated inputs with naive explicit examples. Those examples were interpreted through the host timezone, making the result platform-dependent. The fold assertion also operated on the UTC source datetime rather than the ambiguous local result, so it did not test the intended PEP 495 behavior.

## Local validation

- Full suites passed on CPython 2.7, 3.7, 3.8, 3.10, 3.12, 3.13, and 3.14.
- Python 3.13 tox run: 2032 passed, 47 skipped, 17 xfailed.
- pytest 9.1 collection and full suite passed.
- docs, linkcheck, tz master, pre-commit, Darker, coverage, wheel, and sdist checks passed.
