### PR TITLE
Make _common.weekday picklable at protocols 0 and 1

### DIFF
--- a/changelog.d/1553.bugfix.rst
+++ b/changelog.d/1553.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed `_common.weekday` being unpicklable with pickle protocols 0 and 1, which are still the default on Python 2: the class uses `__slots__` without a `__dict__` and did not define `__getstate__`. This also made the `MO`..`SU` constants, and any `relativedelta` carrying a weekday, unpicklable at those protocols. Reported and fixed by @<submitter> (gh pr #<PR>)

--- a/src/dateutil/_common.py
+++ b/src/dateutil/_common.py
@@ -40,4 +40,17 @@ class weekday(object):
         else:
             return "%s(%+d)" % (s, self.n)
 
+    # A class using `__slots__` without a `__dict__` cannot be pickled with
+    # protocol 0 or 1 unless it spells out its state, and protocol 0 is still
+    # the default on Python 2.  Without this, neither the `MO`..`SU`
+    # constants nor any `relativedelta` carrying a weekday could be pickled
+    # at those protocols.
+    def __getstate__(self):
+        return {name: getattr(self, name, None) for name in self.__slots__}
+
+    def __setstate__(self, state):
+        for name in self.__slots__:
+            if name in state:
+                setattr(self, name, state[name])
+
 # vim:ts=4:sw=4:et


### PR DESCRIPTION
`weekday` uses __slots__ and so has no __dict__. A class in that shape cannot be pickled with protocol 0 or 1 unless it spells out its own state, and protocol 0 is still the default on Python 2:

    >>> pickle.dumps(dateutil.relativedelta.MO, 0)
    TypeError: cannot pickle 'weekday' object: a class that defines
    __slots__ without defining __getstate__ cannot be pickled with
    protocol 0

That took the MO..SU constants and every relativedelta carrying a weekday with it. Add __getstate__/__setstate__, as tz._ttinfo already does.

<!-- First time contributors: Take a moment to review CONTRIBUTING.md! -->
<!-- Remove sections if not applicable -->
## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] Authors have been added to [AUTHORS.md](https://github.com/dateutil/dateutil/blob/master/AUTHORS.md)
- [ ] News fragment added in changelog.d. See [CONTRIBUTING.md](https://github.com/dateutil/dateutil/blob/master/CONTRIBUTING.md#changelog) for details
